### PR TITLE
Small cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ limitations still matter in day-to-day use.
 - Use explicit `FPEncoding` when creating floating-point and rounding-mode
   sorts/constants so the chosen native-vs-BV representation is obvious at the
   call site.
+- Treat each solver instance as thread-confined. Camada does not support
+  concurrent use of a single solver object from multiple threads.
 
 ## Design Notes
 

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -136,7 +136,7 @@ void BitwuzlaSolver::addConstraintImpl(const SMTExprRef &Exp) {
   bitwuzla_assert(Context, toSolverExpr<BitwExpr>(*Exp).Expr);
 }
 
-SMTExprRef BitwuzlaSolver::newExprRefImpl(const SMTExpr &Exp) const {
+SMTExprRef BitwuzlaSolver::newExprRefImpl(const SMTExpr &Exp) {
   const auto &Wrapped = toSolverExpr<BitwExpr>(Exp);
   return makeExprRef<BitwExpr>(Exp.getKind(), Wrapped.Context, Exp.Sort,
                                Wrapped.Expr);
@@ -144,7 +144,7 @@ SMTExprRef BitwuzlaSolver::newExprRefImpl(const SMTExpr &Exp) const {
 
 SMTExprRef BitwuzlaSolver::rewrapExprImpl(const SMTExpr &Exp,
                                           const SMTSortRef &Sort,
-                                          SMTExprKind Kind) const {
+                                          SMTExprKind Kind) {
   const auto &Wrapped = toSolverExpr<BitwExpr>(Exp);
   return makeExprRef<BitwExpr>(Kind, Wrapped.Context, Sort, Wrapped.Expr);
 }

--- a/src/bitwuzlasolver.h
+++ b/src/bitwuzlasolver.h
@@ -79,9 +79,9 @@ protected:
 
   void addConstraintImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef newExprRefImpl(const SMTExpr &Exp) const override;
+  SMTExprRef newExprRefImpl(const SMTExpr &Exp) override;
   SMTExprRef rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
-                            SMTExprKind Kind) const override;
+                            SMTExprKind Kind) override;
 
   SMTSortRef mkBoolSortImpl() override;
   SMTSortRef mkBVSortImpl(unsigned BitWidth) override;

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -469,13 +469,23 @@ SMTExprRef SMTSolverImpl::mkFPAbsImpl(const SMTExprRef &Exp) {
 
 SMTExprRef SMTSolverImpl::mkFPNegImpl(const SMTExprRef &Exp,
                                       FPNegBehavior Behavior) {
-  // Extract everything but the sign bit
-  SMTExprRef ew_sw = extractExpSig(*this, Exp);
-  SMTExprRef sgn = extractSgn(*this, Exp);
-  SMTExprRef flipped = mkBVToIEEEFP(mkBVConcat(mkBVNot(sgn), ew_sw), Exp->Sort);
-  SMTExprRef result = Behavior == FPNegBehavior::FlipSignBit
-                          ? flipped
-                          : mkIte(mkFPIsNaN(Exp), Exp, flipped);
+  SMTExprRef result;
+  if (Behavior == FPNegBehavior::FlipSignBit) {
+    SMTExprRef ew_sw = extractExpSig(*this, Exp);
+    SMTExprRef sgn = extractSgn(*this, Exp);
+    result = mkBVToIEEEFP(mkBVConcat(mkBVNot(sgn), ew_sw), Exp->Sort);
+  } else {
+    // Preserve NaNs, negate everything else.
+    SMTExprRef sgn = extractSgn(*this, Exp);
+    SMTExprRef exp = extractExp(*this, Exp);
+    SMTExprRef sig = extractSig(*this, Exp);
+    SMTExprRef x_is_nan = mkFPIsNaN(Exp);
+    SMTExprRef nsgn = mkBVNot(sgn);
+    SMTExprRef nx =
+        mkBVToIEEEFP(mkBVConcat(nsgn, mkBVConcat(exp, sig)), Exp->Sort);
+    result = mkIte(x_is_nan, Exp, nx);
+  }
+
   return rewrapExprImpl(*result, result->Sort, SMTExprKind::FPNeg);
 }
 

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -39,6 +39,14 @@ static bool usesBVFPEncoding(const SMTSortRef &Sort) {
   return Sort->isBVFPSort();
 }
 
+constexpr std::size_t fpEncodingIndex(FPEncoding Encoding) {
+  return Encoding == FPEncoding::BV ? 1u : 0u;
+}
+
+constexpr std::size_t cachedSmallBVExprIndex(int64_t Value) {
+  return static_cast<std::size_t>(Value + 1);
+}
+
 static bool usesBVFPEncoding(const SMTExprRef &Exp) {
   return usesBVFPEncoding(Exp->Sort);
 }
@@ -87,11 +95,10 @@ void SMTSolverImpl::clearSortCaches() {
   CachedBoolSort = {};
   CachedIntSort = {};
   CachedRealSort = {};
-  CachedNativeRMSort = {};
-  CachedEncodedRMSort = {};
+  CachedRMSorts.fill({});
   BVSortCache.clear();
-  NativeFPSortCache.clear();
-  EncodedFPSortCache.clear();
+  for (auto &Cache : FPSortCaches)
+    Cache.clear();
   ArraySortCache.clear();
   SmallFunctionSortCache.clear();
   FunctionSortCache.clear();
@@ -104,9 +111,8 @@ void SMTSolverImpl::clearExprCaches() {
   CachedBVOne1Expr = {};
   CachedSmallBVZeroExprs.fill({});
   CachedRMBVExprs.fill({});
-  CachedBVNegOneExprs.clear();
-  CachedBVZeroExprs.clear();
-  CachedBVOneExprs.clear();
+  for (auto &Cache : CachedSmallBVExprs)
+    Cache.clear();
   SymbolExprCache.clear();
   FPSpecialExprCache.clear();
   FPConstExprCache.clear();
@@ -120,6 +126,9 @@ void SMTSolverImpl::initializeCommonSingletons() {
   CachedSmallBVZeroExprs[2] = mkBVFromBin("00", 2);
   CachedSmallBVZeroExprs[3] = mkBVFromBin("000", 3);
   CachedSmallBVZeroExprs[4] = mkBVFromBin("0000", 4);
+  auto &CachedBVNegOneExprs = CachedSmallBVExprs[cachedSmallBVExprIndex(-1)];
+  auto &CachedBVZeroExprs = CachedSmallBVExprs[cachedSmallBVExprIndex(0)];
+  auto &CachedBVOneExprs = CachedSmallBVExprs[cachedSmallBVExprIndex(1)];
   CachedBVZeroExprs.resize(5);
   CachedBVZeroExprs[1] = CachedSmallBVZeroExprs[1];
   CachedBVZeroExprs[2] = CachedSmallBVZeroExprs[2];
@@ -186,8 +195,7 @@ SMTSortRef SMTSolverImpl::mkBVSort(const unsigned BitWidth) {
 }
 
 SMTSortRef SMTSolverImpl::mkRMSort(FPEncoding Encoding) {
-  SMTSortRef &CachedSort =
-      Encoding == FPEncoding::BV ? CachedEncodedRMSort : CachedNativeRMSort;
+  SMTSortRef &CachedSort = CachedRMSorts[fpEncodingIndex(Encoding)];
   if (CachedSort)
     return CachedSort;
 
@@ -203,8 +211,7 @@ SMTSortRef SMTSolverImpl::mkFPSort(const unsigned ExpWidth,
                                    const unsigned SigWidth,
                                    FPEncoding Encoding) {
   assert(ExpWidth && SigWidth);
-  auto &Cache =
-      Encoding == FPEncoding::BV ? EncodedFPSortCache : NativeFPSortCache;
+  auto &Cache = FPSortCaches[fpEncodingIndex(Encoding)];
   FPSortCacheKey Key{ExpWidth, SigWidth};
   auto It = Cache.find(Key);
   if (It != Cache.end())
@@ -1135,26 +1142,11 @@ SMTExprRef SMTSolverImpl::mkBVFromDec(const int64_t Int,
   }
 
   if (Sort->getSortKind() == SMTSortKind::BV && Int >= -1 && Int <= 1) {
-    std::vector<SMTExprRef> *Cache = nullptr;
-    switch (Int) {
-    case -1:
-      Cache = &CachedBVNegOneExprs;
-      break;
-    case 0:
-      Cache = &CachedBVZeroExprs;
-      break;
-    case 1:
-      Cache = &CachedBVOneExprs;
-      break;
-    default:
-      break;
-    }
+    auto &Cache = CachedSmallBVExprs[cachedSmallBVExprIndex(Int)];
+    if (Cache.size() <= Sort->getWidth())
+      Cache.resize(Sort->getWidth() + 1);
 
-    assert(Cache);
-    if (Cache->size() <= Sort->getWidth())
-      Cache->resize(Sort->getWidth() + 1);
-
-    SMTExprRef &CachedExpr = (*Cache)[Sort->getWidth()];
+    SMTExprRef &CachedExpr = Cache[Sort->getWidth()];
     if (CachedExpr)
       return CachedExpr;
 

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -76,14 +76,11 @@ protected:
   SMTExprRef CachedBVOne1Expr;
   std::array<SMTExprRef, 5> CachedSmallBVZeroExprs;
   std::array<SMTExprRef, 5> CachedRMBVExprs;
-  std::vector<SMTExprRef> CachedBVNegOneExprs;
-  std::vector<SMTExprRef> CachedBVZeroExprs;
-  std::vector<SMTExprRef> CachedBVOneExprs;
+  std::array<std::vector<SMTExprRef>, 3> CachedSmallBVExprs;
   SMTSortRef CachedBoolSort;
   SMTSortRef CachedIntSort;
   SMTSortRef CachedRealSort;
-  SMTSortRef CachedNativeRMSort;
-  SMTSortRef CachedEncodedRMSort;
+  std::array<SMTSortRef, 2> CachedRMSorts;
   std::unordered_map<SymbolExprCacheKey, SMTExprRef, SymbolExprCacheKeyHash>
       SymbolExprCache;
   std::unordered_map<FPSpecialExprCacheKey, SMTExprRef,
@@ -92,10 +89,9 @@ protected:
   std::unordered_map<FPConstExprCacheKey, SMTExprRef, FPConstExprCacheKeyHash>
       FPConstExprCache;
   std::unordered_map<unsigned, SMTSortRef> BVSortCache;
-  std::unordered_map<FPSortCacheKey, SMTSortRef, FPSortCacheKeyHash>
-      NativeFPSortCache;
-  std::unordered_map<FPSortCacheKey, SMTSortRef, FPSortCacheKeyHash>
-      EncodedFPSortCache;
+  std::array<std::unordered_map<FPSortCacheKey, SMTSortRef, FPSortCacheKeyHash>,
+             2>
+      FPSortCaches;
   std::unordered_map<ArraySortCacheKey, SMTSortRef, ArraySortCacheKeyHash>
       ArraySortCache;
   std::unordered_map<SmallFunctionSortCacheKey, SMTSortRef,

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -49,14 +49,14 @@ public:
 
 protected:
   template <typename SolverExpr, typename... Args>
-  SMTExprRef makeExprRef(SMTExprKind Kind, Args &&...ArgsV) const {
+  SMTExprRef makeExprRef(SMTExprKind Kind, Args &&...ArgsV) {
     auto *Exp =
         ExprArena.create<SolverExpr>(Kind, std::forward<Args>(ArgsV)...);
     assert(Exp->Sort->isWidthValidated());
     return SMTExprRef(Exp, HandleState, HandleState->Generation);
   }
 
-  template <typename SolverSort> SMTSortRef makeSortRef(SolverSort Sort) const {
+  template <typename SolverSort> SMTSortRef makeSortRef(SolverSort Sort) {
     auto *OwnedSort = SortArena.create<SolverSort>(std::move(Sort));
     assert(OwnedSort->validateSortWidth());
 #ifndef NDEBUG
@@ -70,48 +70,43 @@ protected:
   void clearExprCaches();
   void initializeCommonSingletons();
 
-  mutable ObjectArena SortArena;
-  mutable ObjectArena ExprArena;
-  mutable std::array<SMTExprRef, 2> CachedBoolExprs;
-  mutable SMTExprRef CachedBVOne1Expr;
-  mutable std::array<SMTExprRef, 5> CachedSmallBVZeroExprs;
-  mutable std::array<SMTExprRef, 5> CachedRMBVExprs;
-  mutable std::vector<SMTExprRef> CachedBVNegOneExprs;
-  mutable std::vector<SMTExprRef> CachedBVZeroExprs;
-  mutable std::vector<SMTExprRef> CachedBVOneExprs;
-  mutable SMTSortRef CachedBoolSort;
-  mutable SMTSortRef CachedIntSort;
-  mutable SMTSortRef CachedRealSort;
-  mutable SMTSortRef CachedNativeRMSort;
-  mutable SMTSortRef CachedEncodedRMSort;
-  mutable std::unordered_map<SymbolExprCacheKey, SMTExprRef,
-                             SymbolExprCacheKeyHash>
+  ObjectArena SortArena;
+  ObjectArena ExprArena;
+  std::array<SMTExprRef, 2> CachedBoolExprs;
+  SMTExprRef CachedBVOne1Expr;
+  std::array<SMTExprRef, 5> CachedSmallBVZeroExprs;
+  std::array<SMTExprRef, 5> CachedRMBVExprs;
+  std::vector<SMTExprRef> CachedBVNegOneExprs;
+  std::vector<SMTExprRef> CachedBVZeroExprs;
+  std::vector<SMTExprRef> CachedBVOneExprs;
+  SMTSortRef CachedBoolSort;
+  SMTSortRef CachedIntSort;
+  SMTSortRef CachedRealSort;
+  SMTSortRef CachedNativeRMSort;
+  SMTSortRef CachedEncodedRMSort;
+  std::unordered_map<SymbolExprCacheKey, SMTExprRef, SymbolExprCacheKeyHash>
       SymbolExprCache;
-  mutable std::unordered_map<FPSpecialExprCacheKey, SMTExprRef,
-                             FPSpecialExprCacheKeyHash>
+  std::unordered_map<FPSpecialExprCacheKey, SMTExprRef,
+                     FPSpecialExprCacheKeyHash>
       FPSpecialExprCache;
-  mutable std::unordered_map<FPConstExprCacheKey, SMTExprRef,
-                             FPConstExprCacheKeyHash>
+  std::unordered_map<FPConstExprCacheKey, SMTExprRef, FPConstExprCacheKeyHash>
       FPConstExprCache;
-  mutable std::unordered_map<unsigned, SMTSortRef> BVSortCache;
-  mutable std::unordered_map<FPSortCacheKey, SMTSortRef, FPSortCacheKeyHash>
+  std::unordered_map<unsigned, SMTSortRef> BVSortCache;
+  std::unordered_map<FPSortCacheKey, SMTSortRef, FPSortCacheKeyHash>
       NativeFPSortCache;
-  mutable std::unordered_map<FPSortCacheKey, SMTSortRef, FPSortCacheKeyHash>
+  std::unordered_map<FPSortCacheKey, SMTSortRef, FPSortCacheKeyHash>
       EncodedFPSortCache;
-  mutable std::unordered_map<ArraySortCacheKey, SMTSortRef,
-                             ArraySortCacheKeyHash>
+  std::unordered_map<ArraySortCacheKey, SMTSortRef, ArraySortCacheKeyHash>
       ArraySortCache;
-  mutable std::unordered_map<SmallFunctionSortCacheKey, SMTSortRef,
-                             SmallFunctionSortCacheKeyHash>
+  std::unordered_map<SmallFunctionSortCacheKey, SMTSortRef,
+                     SmallFunctionSortCacheKeyHash>
       SmallFunctionSortCache;
-  mutable std::unordered_map<FunctionSortCacheKey, SMTSortRef,
-                             FunctionSortCacheKeyHash>
+  std::unordered_map<FunctionSortCacheKey, SMTSortRef, FunctionSortCacheKeyHash>
       FunctionSortCache;
-  mutable std::unordered_map<SmallTupleSortCacheKey, SMTSortRef,
-                             SmallTupleSortCacheKeyHash>
+  std::unordered_map<SmallTupleSortCacheKey, SMTSortRef,
+                     SmallTupleSortCacheKeyHash>
       SmallTupleSortCache;
-  mutable std::unordered_map<TupleSortCacheKey, SMTSortRef,
-                             TupleSortCacheKeyHash>
+  std::unordered_map<TupleSortCacheKey, SMTSortRef, TupleSortCacheKeyHash>
       TupleSortCache;
   std::shared_ptr<SMTHandleState> HandleState =
       std::make_shared<SMTHandleState>();
@@ -351,7 +346,7 @@ public:
   void dumpModel(std::string &Out) override final;
 
 protected:
-  virtual SMTExprRef newExprRefImpl(const SMTExpr &Exp) const = 0;
+  virtual SMTExprRef newExprRefImpl(const SMTExpr &Exp) = 0;
 
   // Rewrap an existing backend payload with a different Camada-facing
   // sort/kind. This is still needed for lowered/common-layer operations where
@@ -359,7 +354,7 @@ protected:
   // though backend-native operations should construct expressions with the
   // final kind directly.
   virtual SMTExprRef rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
-                                    SMTExprKind Kind) const = 0;
+                                    SMTExprKind Kind) = 0;
 
   virtual SMTSortRef mkBoolSortImpl() = 0;
 

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -118,7 +118,7 @@ void CVC5Solver::addConstraintImpl(const SMTExprRef &Exp) {
   Context.assertFormula(toSolverExpr<CVC5Expr>(*Exp).Expr);
 }
 
-SMTExprRef CVC5Solver::newExprRefImpl(const SMTExpr &Exp) const {
+SMTExprRef CVC5Solver::newExprRefImpl(const SMTExpr &Exp) {
   const auto &Wrapped = toSolverExpr<CVC5Expr>(Exp);
   return makeExprRef<CVC5Expr>(Exp.getKind(), Wrapped.Context, Exp.Sort,
                                Wrapped.Expr);
@@ -126,7 +126,7 @@ SMTExprRef CVC5Solver::newExprRefImpl(const SMTExpr &Exp) const {
 
 SMTExprRef CVC5Solver::rewrapExprImpl(const SMTExpr &Exp,
                                       const SMTSortRef &Sort,
-                                      SMTExprKind Kind) const {
+                                      SMTExprKind Kind) {
   const auto &Wrapped = toSolverExpr<CVC5Expr>(Exp);
   return makeExprRef<CVC5Expr>(Kind, Wrapped.Context, Sort, Wrapped.Expr);
 }

--- a/src/cvc5solver.h
+++ b/src/cvc5solver.h
@@ -77,9 +77,9 @@ protected:
 
   void addConstraintImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef newExprRefImpl(const SMTExpr &Exp) const override;
+  SMTExprRef newExprRefImpl(const SMTExpr &Exp) override;
   SMTExprRef rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
-                            SMTExprKind Kind) const override;
+                            SMTExprKind Kind) override;
 
   SMTSortRef mkBoolSortImpl() override;
   SMTSortRef mkIntSortImpl() override;

--- a/src/mathsatsolver.cpp
+++ b/src/mathsatsolver.cpp
@@ -184,7 +184,7 @@ static inline bool checkExprError(const SMTExpr &Exp) {
                       : checkExprError(*exp.Context, exp.getTerm());
 }
 
-SMTExprRef MathSATSolver::newExprRefImpl(const SMTExpr &Exp) const {
+SMTExprRef MathSATSolver::newExprRefImpl(const SMTExpr &Exp) {
   assert(!checkExprError(Exp) && "Error when creating MathSAT expr.");
   const auto &Wrapped = toSolverExpr<MathSATExpr>(Exp);
   if (Wrapped.isDecl())
@@ -196,7 +196,7 @@ SMTExprRef MathSATSolver::newExprRefImpl(const SMTExpr &Exp) const {
 
 SMTExprRef MathSATSolver::rewrapExprImpl(const SMTExpr &Exp,
                                          const SMTSortRef &Sort,
-                                         SMTExprKind Kind) const {
+                                         SMTExprKind Kind) {
   assert(!checkExprError(Exp) && "Error when creating MathSAT expr.");
   const auto &Wrapped = toSolverExpr<MathSATExpr>(Exp);
   if (Wrapped.isDecl())

--- a/src/mathsatsolver.h
+++ b/src/mathsatsolver.h
@@ -100,9 +100,9 @@ protected:
 
   void addConstraintImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef newExprRefImpl(const SMTExpr &Exp) const override;
+  SMTExprRef newExprRefImpl(const SMTExpr &Exp) override;
   SMTExprRef rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
-                            SMTExprKind Kind) const override;
+                            SMTExprKind Kind) override;
 
   SMTSortRef mkBoolSortImpl() override;
   SMTSortRef mkIntSortImpl() override;

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -105,7 +105,7 @@ void STPSolver::addConstraintImpl(const SMTExprRef &Exp) {
   STP::vc_assertFormula(Context, toSolverExpr<STPExpr>(*Exp).Expr);
 }
 
-SMTExprRef STPSolver::newExprRefImpl(const SMTExpr &Exp) const {
+SMTExprRef STPSolver::newExprRefImpl(const SMTExpr &Exp) {
   // Store a fresh wrapper that owns the underlying STP term. STP leaks
   // ordinary constructed terms unless the final arena-held wrapper deletes
   // them via `vc_DeleteExpr`.
@@ -115,7 +115,7 @@ SMTExprRef STPSolver::newExprRefImpl(const SMTExpr &Exp) const {
 }
 
 SMTExprRef STPSolver::rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
-                                     SMTExprKind Kind) const {
+                                     SMTExprKind Kind) {
   const auto &Wrapped = toSolverExpr<STPExpr>(Exp);
   return makeExprRef<STPExpr>(Kind, Wrapped.Context, Sort, Wrapped.Expr, false);
 }

--- a/src/stpsolver.h
+++ b/src/stpsolver.h
@@ -89,9 +89,9 @@ protected:
 
   void addConstraintImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef newExprRefImpl(const SMTExpr &Exp) const override;
+  SMTExprRef newExprRefImpl(const SMTExpr &Exp) override;
   SMTExprRef rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
-                            SMTExprKind Kind) const override;
+                            SMTExprKind Kind) override;
 
   SMTSortRef mkBoolSortImpl() override;
   SMTSortRef mkBVSortImpl(unsigned BitWidth) override;

--- a/src/yicessolver.cpp
+++ b/src/yicessolver.cpp
@@ -187,7 +187,7 @@ void YicesSolver::addConstraintImpl(const SMTExprRef &Exp) {
   yices_assert_formula(Context, toSolverExpr<YicesExpr>(*Exp).Expr);
 }
 
-SMTExprRef YicesSolver::newExprRefImpl(const SMTExpr &Exp) const {
+SMTExprRef YicesSolver::newExprRefImpl(const SMTExpr &Exp) {
   const auto &Wrapped = toSolverExpr<YicesExpr>(Exp);
   yicesCheckTerm(Wrapped.Expr, "Error when creating Yices expr");
   return makeExprRef<YicesExpr>(Exp.getKind(), Wrapped.Context, Exp.Sort,
@@ -196,7 +196,7 @@ SMTExprRef YicesSolver::newExprRefImpl(const SMTExpr &Exp) const {
 
 SMTExprRef YicesSolver::rewrapExprImpl(const SMTExpr &Exp,
                                        const SMTSortRef &Sort,
-                                       SMTExprKind Kind) const {
+                                       SMTExprKind Kind) {
   const auto &Wrapped = toSolverExpr<YicesExpr>(Exp);
   yicesCheckTerm(Wrapped.Expr, "Error when creating Yices expr");
   return makeExprRef<YicesExpr>(Kind, Wrapped.Context, Sort, Wrapped.Expr);

--- a/src/yicessolver.h
+++ b/src/yicessolver.h
@@ -83,9 +83,9 @@ protected:
 
   void addConstraintImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef newExprRefImpl(const SMTExpr &Exp) const override;
+  SMTExprRef newExprRefImpl(const SMTExpr &Exp) override;
   SMTExprRef rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
-                            SMTExprKind Kind) const override;
+                            SMTExprKind Kind) override;
 
   SMTSortRef mkBoolSortImpl() override;
   SMTSortRef mkIntSortImpl() override;

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -141,14 +141,14 @@ void Z3Solver::addConstraintImpl(const SMTExprRef &Exp) {
   Solver.add(toZ3Expr(Exp));
 }
 
-SMTExprRef Z3Solver::newExprRefImpl(const SMTExpr &Exp) const {
+SMTExprRef Z3Solver::newExprRefImpl(const SMTExpr &Exp) {
   const auto &Wrapped = toSolverExpr<Z3Expr>(Exp);
   return makeExprRef<Z3Expr>(Exp.getKind(), Wrapped.Context, Exp.Sort,
                              Wrapped.Expr);
 }
 
 SMTExprRef Z3Solver::rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
-                                    SMTExprKind Kind) const {
+                                    SMTExprKind Kind) {
   const auto &Wrapped = toSolverExpr<Z3Expr>(Exp);
   return makeExprRef<Z3Expr>(Kind, Wrapped.Context, Sort, Wrapped.Expr);
 }

--- a/src/z3solver.h
+++ b/src/z3solver.h
@@ -81,9 +81,9 @@ protected:
 
   void addConstraintImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef newExprRefImpl(const SMTExpr &Exp) const override;
+  SMTExprRef newExprRefImpl(const SMTExpr &Exp) override;
   SMTExprRef rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
-                            SMTExprKind Kind) const override;
+                            SMTExprKind Kind) override;
 
   SMTSortRef mkBoolSortImpl() override;
   SMTSortRef mkIntSortImpl() override;


### PR DESCRIPTION
This PR:
- documents in README.md that solver instances are thread-confined and must not be used concurrently from multiple threads
- removes mutable from the common solver caches/arenas and updates the common/backend helper signatures so object construction no longer relies on “const-but-mutating” internals
- cleans up a few internal caches in src/camadaimpl.h / src/camadaimpl.cpp, and 
- makes the fp.neg behavior split in src/camadafp.cpp more explicit
