### PR TITLE
Update MathSAT prebuilt archive to 5.6.16

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,13 +19,13 @@ jobs:
 
       # Setup/cache dependencies
     - name: Cache deps
-      id: cache-deps-v7
+      id: cache-deps-v8
       uses: actions/cache@v4
       with:
         path: |
           build/deps
           build/_deps
-        key: ${{ runner.os }}-deps-v7
+        key: ${{ runner.os }}-deps-v8
 
     - name: Configure Camada
       run: cmake -S . -B build -GNinja -DCAMADA_ENABLE_REGRESSION=ON -DBUILD_SHARED_LIBS=OFF -DCAMADA_DOWNLOAD_DEPENDENCIES=ALL -DCAMADA_SOLVER_BITWUZLA_ENABLE=ON -DCAMADA_SOLVER_CVC5_ENABLE=ON -DCAMADA_SOLVER_MATHSAT_ENABLE=ON -DCAMADA_SOLVER_STP_ENABLE=ON -DCAMADA_SOLVER_YICES_ENABLE=ON -DCAMADA_SOLVER_Z3_ENABLE=ON -DENABLE_WARNINGS=ON -DENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/release -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,13 +25,13 @@ jobs:
 
       # Setup/cache dependencies
     - name: Cache deps
-      id: cache-deps-v7
+      id: cache-deps-v8
       uses: actions/cache@v4
       with:
         path: |
           build/deps
           build/_deps
-        key: ${{ runner.os }}-deps-v7
+        key: ${{ runner.os }}-deps-v8
 
     - name: Configure Camada
       run: cmake -S . -B build -GNinja -DCAMADA_ENABLE_REGRESSION=ON -DBUILD_SHARED_LIBS=OFF -DCAMADA_DOWNLOAD_DEPENDENCIES=ALL -DCAMADA_SOLVER_BITWUZLA_ENABLE=ON -DCAMADA_SOLVER_CVC5_ENABLE=ON -DCAMADA_SOLVER_MATHSAT_ENABLE=ON -DCAMADA_SOLVER_STP_ENABLE=ON -DCAMADA_SOLVER_YICES_ENABLE=ON -DCAMADA_SOLVER_Z3_ENABLE=ON -DENABLE_WARNINGS=ON -DENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/release -DCMAKE_BUILD_TYPE=Debug

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ When CMake downloads dependencies itself:
 - `Yices` uses a source build.
 - `GMP` uses a source build when it is needed by downloaded dependencies and no
   suitable staged copy is already available.
-- `MathSAT` uses the vendor-provided prebuilt archive from `5.6.15`.
+- `MathSAT` uses the vendor-provided prebuilt archive from `5.6.16`.
 - `STP` still falls back to a source build. The `2.3.4_cadical` GitHub release
   only ships a standalone `stp` executable, not the headers and libraries that
   Camada needs to link against the STP C++ API.

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -70,19 +70,19 @@ set(CAMADA_BITWUZLA_MACOS_ARM64_URL
     CACHE STRING
           "URL used to download the prebuilt Bitwuzla archive for macOS arm64")
 set(CAMADA_MATHSAT_VERSION
-    "5.6.15"
+    "5.6.16"
     CACHE STRING "MathSAT release version used for prebuilt downloads")
 set(CAMADA_MATHSAT_LINUX_X86_64_URL
-    "https://mathsat.fbk.eu/release/mathsat-5.6.15-linux-x86_64.tar.gz"
+    "https://mathsat.fbk.eu/release/mathsat-5.6.16-linux-x86_64.tar.gz"
     CACHE STRING "URL used to download MathSAT for Linux x86_64")
 set(CAMADA_MATHSAT_LINUX_AARCH64_URL
-    "https://mathsat.fbk.eu/release/mathsat-5.6.15-linux-aarch64.tar.gz"
+    "https://mathsat.fbk.eu/release/mathsat-5.6.16-linux-aarch64.tar.gz"
     CACHE STRING "URL used to download MathSAT for Linux aarch64")
 set(CAMADA_MATHSAT_MACOS_X86_64_URL
-    "https://mathsat.fbk.eu/download.php?file=mathsat-5.6.15-osx.tar.gz"
+    "https://mathsat.fbk.eu/release/mathsat-5.6.16-macos.tar.gz"
     CACHE STRING "URL used to download MathSAT for macOS x86_64")
 set(CAMADA_MATHSAT_MACOS_ARM64_URL
-    "https://mathsat.fbk.eu/release/mathsat-5.6.15-macos.tar.gz"
+    "https://mathsat.fbk.eu/release/mathsat-5.6.16-macos.tar.gz"
     CACHE STRING "URL used to download MathSAT for macOS arm64")
 
 function(camada_ensure_deps_dirs)
@@ -435,10 +435,10 @@ function(camada_select_mathsat_prebuilt_info output_url_var output_archive_var
           "${CAMADA_MATHSAT_MACOS_X86_64_URL}"
           PARENT_SCOPE)
       set(${output_archive_var}
-          "${CAMADA_DEPS_SRC_DIR}/mathsat-${CAMADA_MATHSAT_VERSION}-osx.tar.gz"
+          "${CAMADA_DEPS_SRC_DIR}/mathsat-${CAMADA_MATHSAT_VERSION}-macos.tar.gz"
           PARENT_SCOPE)
       set(${output_source_dir_var}
-          "${CAMADA_DEPS_SRC_DIR}/mathsat-${CAMADA_MATHSAT_VERSION}-osx"
+          "${CAMADA_DEPS_SRC_DIR}/mathsat-${CAMADA_MATHSAT_VERSION}-macos"
           PARENT_SCOPE)
       return()
     endif()


### PR DESCRIPTION
## Summary
- Bump `CAMADA_MATHSAT_VERSION` from `5.6.15` to `5.6.16` and update all four prebuilt download URLs.
- The vendor dropped the legacy `download.php?file=mathsat-*-osx.tar.gz` form for macOS x86_64; both macOS variants now share the unified `release/mathsat-5.6.16-macos.tar.gz` tarball, so the macOS x86_64 cache/source-dir naming is updated to `-macos` accordingly.

## Test plan
- [x] Configure with `CAMADA_DOWNLOAD_DEPENDENCIES=ALL` — fetches `mathsat-5.6.16-linux-x86_64.tar.gz`.
- [x] Build `camada` and `camada-regression` with `-j32`.
- [x] `ctest -R MathSAT` — all 7 MathSAT regression tests pass.
- [ ] CI to confirm the macOS x86_64 / aarch64 download paths on their respective runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)