### PR TITLE
Document FlipSignBit limitation on native FP backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Camada is based on the backend written for [ESBMC](https://github.com/esbmc/esbm
 - `mkFPNeg` now accepts `FPNegBehavior`.
 - The default, `FPNegBehavior::FlipSignBit`, preserves the full IEEE payload and only toggles the sign bit, including on `NaN`s.
 - `FPNegBehavior::PreserveNaNPayload` follows the SMT floating-point standard and leaves `NaN`s unchanged.
+- `FlipSignBit` is fully honored under BV encoding and via the SMTLIB pipeline. On native FP backends (Bitwuzla, CVC5, Z3) it is best-effort: these solvers treat all `NaN`s as a single equivalence class, so when the operand is a `NaN` the resulting `NaN`'s bit pattern is not guaranteed to match a literal sign-bit flip of the input bits.
 
 ## Usage Example
 

--- a/src/camada.h
+++ b/src/camada.h
@@ -365,6 +365,12 @@ public:
   /// `FlipSignBit` preserves the full IEEE encoding and only toggles the sign
   /// bit. `PreserveNaNPayload` follows the SMT floating-point standard and
   /// leaves NaNs unchanged.
+  ///
+  /// `FlipSignBit` is fully honored under BV encoding and via the SMTLIB
+  /// pipeline. On native FP backends (Bitwuzla, CVC5, Z3) it is best-effort:
+  /// these solvers treat all NaNs as a single equivalence class, so when the
+  /// operand is a NaN the resulting NaN's bit pattern is not guaranteed to
+  /// match a literal sign-bit flip of the input bits.
   virtual SMTExprRef
   mkFPNeg(const SMTExprRef &Exp,
           FPNegBehavior Behavior = FPNegBehavior::FlipSignBit) = 0;


### PR DESCRIPTION
## Summary

- `FPNegBehavior::FlipSignBit` cannot be reliably enforced on Bitwuzla, CVC5, or Z3's native FP support: all NaNs are a single equivalence class, so the resulting NaN's bit pattern is not guaranteed to match a literal sign-bit flip of the input bits.
- A `mkBVToIEEEFP` / `mkIEEEFPToBV` round-trip does not preserve NaN payloads either (verified with a probe — bitwuzla, z3, and cvc5 each return SAT for the disequality between input and round-tripped NaN bits), so it cannot rescue the behavior.
- Documentation-only change: docstring on `SMTSolver::mkFPNeg` in `src/camada.h` and the corresponding bullet in `README.md`. No behavioral change.

## Test plan

- [x] Rebuild with the configured solvers (`bitwuzla`, `cvc5`, `z3`) — clean.
- [x] Run `Simple Bitwuzla test`, `Simple Z3 test`, `Simple CVC5 test` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)