### PR TITLE
Propagate bundled-backend include paths to Camada consumers

### DIFF
--- a/.github/workflows/release-consumer.yml
+++ b/.github/workflows/release-consumer.yml
@@ -1,0 +1,82 @@
+name: Release Consumer
+
+# Drive scripts/release.py and build a tiny downstream consumer
+# (scripts/release-consumer) against the staged `./release` directory.
+# Exercises the install path the official release tarballs use, so changes
+# to install rules, exported include paths, or camadaTargets.cmake stop
+# breaking downstream builds silently.
+on:
+  push:
+    branches:
+    - master
+    - release/*
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  linux:
+    name: Linux release consumer
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Dependencies
+      run: sudo apt-get update && sudo apt-get install -y cmake linux-libc-dev ninja-build gperf doxygen pkg-config libgmp-dev libmpfr-dev python3
+
+    - name: Cache release deps
+      uses: actions/cache@v4
+      with:
+        path: |
+          .build-release/deps
+          .build-release/_deps
+        key: ${{ runner.os }}-release-deps-v1
+
+    - name: Generate release
+      run: python3 ./scripts/release.py
+
+    - name: Configure consumer
+      run: cmake -S scripts/release-consumer -B scripts/release-consumer/build -GNinja -DCMAKE_PREFIX_PATH=$PWD/release
+
+    - name: Build consumer
+      run: cmake --build scripts/release-consumer/build
+
+    - name: Run consumer
+      run: ctest --test-dir scripts/release-consumer/build --output-on-failure
+
+  macos:
+    name: macOS release consumer
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Dependencies
+      # mpfr is needed because Bitwuzla's FP backend calls mpfr_* directly
+      # and scripts/release.py adds -lmpfr to the install's link interface.
+      run: brew install gmp mpfr cmake ninja automake boost zlib bison flex doxygen libtool pkg-config gettext texinfo python3
+
+    - name: Configure Homebrew Environment
+      run: |
+        echo "CPPFLAGS=-I$(brew --prefix gmp)/include" >> $GITHUB_ENV
+        echo "LDFLAGS=-L$(brew --prefix gmp)/lib" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=$(brew --prefix gmp)/lib/pkgconfig:$(brew --prefix zlib)/lib/pkgconfig" >> $GITHUB_ENV
+
+    - name: Cache release deps
+      uses: actions/cache@v4
+      with:
+        path: |
+          .build-release/deps
+          .build-release/_deps
+        key: ${{ runner.os }}-release-deps-v1
+
+    - name: Generate release
+      run: python3 ./scripts/release.py
+
+    - name: Configure consumer
+      # `-L$(brew --prefix)/lib` makes -lgmp / -lmpfr resolvable: Homebrew
+      # libs are not on the linker's default search path on macOS.
+      run: cmake -S scripts/release-consumer -B scripts/release-consumer/build -GNinja -DCMAKE_PREFIX_PATH=$PWD/release -DCMAKE_EXE_LINKER_FLAGS="-L$(brew --prefix)/lib"
+
+    - name: Build consumer
+      run: cmake --build scripts/release-consumer/build
+
+    - name: Run consumer
+      run: ctest --test-dir scripts/release-consumer/build --output-on-failure

--- a/scripts/release-consumer/CMakeLists.txt
+++ b/scripts/release-consumer/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Smoke test for a Camada release tarball: configure with
+# CMAKE_PREFIX_PATH pointing at the staged ./release directory and build a
+# tiny program that links against camada::camada and exercises one or more
+# enabled backends. CI uses this to catch packaging regressions in
+# scripts/release.py and the install rules — the regular regression suite
+# only validates the in-tree library, not the installed package config.
+
+cmake_minimum_required(VERSION 3.15)
+project(camada-release-consumer LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(camada CONFIG REQUIRED)
+
+add_executable(release_consumer main.cpp)
+target_link_libraries(release_consumer PRIVATE camada::camada)
+
+enable_testing()
+add_test(NAME release_consumer COMMAND release_consumer)

--- a/scripts/release-consumer/CMakeLists.txt
+++ b/scripts/release-consumer/CMakeLists.txt
@@ -1,9 +1,9 @@
-# Smoke test for a Camada release tarball: configure with
-# CMAKE_PREFIX_PATH pointing at the staged ./release directory and build a
-# tiny program that links against camada::camada and exercises one or more
-# enabled backends. CI uses this to catch packaging regressions in
-# scripts/release.py and the install rules — the regular regression suite
-# only validates the in-tree library, not the installed package config.
+# Smoke test for a Camada release tarball: configure with CMAKE_PREFIX_PATH
+# pointing at the staged ./release directory and build a tiny program that links
+# against camada::camada and exercises one or more enabled backends. CI uses
+# this to catch packaging regressions in scripts/release.py and the install
+# rules — the regular regression suite only validates the in-tree library, not
+# the installed package config.
 
 cmake_minimum_required(VERSION 3.15)
 project(camada-release-consumer LANGUAGES CXX)

--- a/scripts/release-consumer/main.cpp
+++ b/scripts/release-consumer/main.cpp
@@ -1,0 +1,63 @@
+// Smoke test for a Camada release: instantiate every backend the release
+// shipped with, run a one-line SAT problem, and check that the model agrees.
+// Built and run against the installed `camada::camada` package config in CI.
+
+#include <camada/camada.h>
+#include <camada/camadafeatures.h>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+namespace {
+
+int run(const camada::SMTSolverRef &solver, const std::string &name) {
+  auto bv32 = solver->mkBVSort(32);
+  auto x = solver->mkSymbol("x", bv32);
+  auto seven = solver->mkBVFromDec(7, 32);
+  solver->addConstraint(solver->mkEqual(x, seven));
+
+  if (solver->check() != camada::checkResult::SAT) {
+    std::cerr << name << ": expected SAT\n";
+    return 1;
+  }
+
+  auto value = solver->getBV(x);
+  if (!value) {
+    std::cerr << name << ": failed to read model: " << value.error().Message
+              << "\n";
+    return 1;
+  }
+  if (value.value() != static_cast<int64_t>(7)) {
+    std::cerr << name << ": expected x = 7, got " << value.value() << "\n";
+    return 1;
+  }
+
+  std::cout << name << ": ok\n";
+  return 0;
+}
+
+} // namespace
+
+int main() {
+  int backends_exercised = 0;
+
+#if CAMADA_HAVE_Z3
+  if (run(camada::createZ3Solver(), "Z3") != 0)
+    return 1;
+  ++backends_exercised;
+#endif
+
+#if CAMADA_HAVE_BITWUZLA
+  if (run(camada::createBitwuzlaSolver(), "Bitwuzla") != 0)
+    return 1;
+  ++backends_exercised;
+#endif
+
+  if (backends_exercised == 0) {
+    std::cerr << "release shipped with no backends the consumer test knows "
+                 "how to drive\n";
+    return 1;
+  }
+  return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,11 +73,23 @@ add_library(${PROJECT_NAME}::${LIBRARY_TARGET_NAME} ALIAS
             ${LIBRARY_TARGET_NAME})
 
 # Solvers
+#
+# The installed <backend>solver.h headers `#include` the backend's own
+# headers (z3++.h, bitwuzla/c/bitwuzla.h, etc.), so consumers compiling
+# against Camada must see the same headers Camada itself was built with.
+# Propagate the bundled-backend include path PUBLIC and wrap it in
+# BUILD_INTERFACE because the bundled solvers are not staged into Camada's
+# install prefix — installed consumers must supply their own backend
+# headers. If a consumer also has a system copy of the same backend
+# (/opt/homebrew/include, /usr/local/include) on its own -I list, they
+# must arrange for Camada's propagated -I to come first; this CMake side
+# only ensures the path reaches the consumer at all.
 if(${CAMADA_SOLVER_BITWUZLA_ENABLE})
   target_link_libraries(${LIBRARY_TARGET_NAME}
                         PUBLIC ${Bitwuzla_LINK_LIBRARIES})
-  target_include_directories(${LIBRARY_TARGET_NAME}
-                             PRIVATE ${Bitwuzla_INCLUDE_DIRS})
+  target_include_directories(
+    ${LIBRARY_TARGET_NAME}
+    PUBLIC "$<BUILD_INTERFACE:${Bitwuzla_INCLUDE_DIRS}>")
   target_compile_definitions(${LIBRARY_TARGET_NAME}
                              PRIVATE SOLVER_BITWUZLA_ENABLED)
 endif()
@@ -96,30 +108,35 @@ endif()
 
 if(${CAMADA_SOLVER_MATHSAT_ENABLE})
   target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC ${CAMADA_MATHSAT_LIB})
-  target_include_directories(${LIBRARY_TARGET_NAME}
-                             PRIVATE ${CAMADA_MATHSAT_INCLUDE_DIR})
+  target_include_directories(
+    ${LIBRARY_TARGET_NAME}
+    PUBLIC "$<BUILD_INTERFACE:${CAMADA_MATHSAT_INCLUDE_DIR}>")
   target_compile_definitions(${LIBRARY_TARGET_NAME}
                              PRIVATE SOLVER_MATHSAT_ENABLED)
 endif()
 
 if(${CAMADA_SOLVER_STP_ENABLE})
   target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC stp)
-  target_include_directories(${LIBRARY_TARGET_NAME} PRIVATE ${STP_INCLUDE_DIRS})
+  target_include_directories(
+    ${LIBRARY_TARGET_NAME}
+    PUBLIC "$<BUILD_INTERFACE:${STP_INCLUDE_DIRS}>")
   target_compile_definitions(${LIBRARY_TARGET_NAME} PRIVATE SOLVER_STP_ENABLED)
 endif()
 
 if(${CAMADA_SOLVER_YICES_ENABLE})
   target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC ${CAMADA_YICES_LIB})
-  target_include_directories(${LIBRARY_TARGET_NAME}
-                             PRIVATE ${CAMADA_YICES_INCLUDE_DIR})
+  target_include_directories(
+    ${LIBRARY_TARGET_NAME}
+    PUBLIC "$<BUILD_INTERFACE:${CAMADA_YICES_INCLUDE_DIR}>")
   target_compile_definitions(${LIBRARY_TARGET_NAME}
                              PRIVATE SOLVER_YICES_ENABLED)
 endif()
 
 if(${CAMADA_SOLVER_Z3_ENABLE})
   target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC ${CAMADA_Z3_LIB})
-  target_include_directories(${LIBRARY_TARGET_NAME}
-                             PRIVATE ${CAMADA_Z3_INCLUDE_DIR})
+  target_include_directories(
+    ${LIBRARY_TARGET_NAME}
+    PUBLIC "$<BUILD_INTERFACE:${CAMADA_Z3_INCLUDE_DIR}>")
   get_filename_component(CAMADA_Z3_LIB_DIR "${CAMADA_Z3_LIB}" DIRECTORY)
   if(BUILD_SHARED_LIBS AND EXISTS "${CAMADA_Z3_LIB_DIR}")
     target_link_directories(${LIBRARY_TARGET_NAME} PRIVATE ${CAMADA_Z3_LIB_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,22 +74,20 @@ add_library(${PROJECT_NAME}::${LIBRARY_TARGET_NAME} ALIAS
 
 # Solvers
 #
-# The installed <backend>solver.h headers `#include` the backend's own
-# headers (z3++.h, bitwuzla/c/bitwuzla.h, etc.), so consumers compiling
-# against Camada must see the same headers Camada itself was built with.
-# Propagate the bundled-backend include path PUBLIC and wrap it in
-# BUILD_INTERFACE because the bundled solvers are not staged into Camada's
-# install prefix — installed consumers must supply their own backend
-# headers. If a consumer also has a system copy of the same backend
-# (/opt/homebrew/include, /usr/local/include) on its own -I list, they
-# must arrange for Camada's propagated -I to come first; this CMake side
-# only ensures the path reaches the consumer at all.
+# The installed <backend>solver.h headers `#include` the backend's own headers
+# (z3++.h, bitwuzla/c/bitwuzla.h, etc.), so consumers compiling against Camada
+# must see the same headers Camada itself was built with. Propagate the
+# bundled-backend include path PUBLIC and wrap it in BUILD_INTERFACE because the
+# bundled solvers are not staged into Camada's install prefix — installed
+# consumers must supply their own backend headers. If a consumer also has a
+# system copy of the same backend (/opt/homebrew/include, /usr/local/include) on
+# its own -I list, they must arrange for Camada's propagated -I to come first;
+# this CMake side only ensures the path reaches the consumer at all.
 if(${CAMADA_SOLVER_BITWUZLA_ENABLE})
   target_link_libraries(${LIBRARY_TARGET_NAME}
                         PUBLIC ${Bitwuzla_LINK_LIBRARIES})
   target_include_directories(
-    ${LIBRARY_TARGET_NAME}
-    PUBLIC "$<BUILD_INTERFACE:${Bitwuzla_INCLUDE_DIRS}>")
+    ${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${Bitwuzla_INCLUDE_DIRS}>")
   target_compile_definitions(${LIBRARY_TARGET_NAME}
                              PRIVATE SOLVER_BITWUZLA_ENABLED)
 endif()
@@ -117,9 +115,8 @@ endif()
 
 if(${CAMADA_SOLVER_STP_ENABLE})
   target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC stp)
-  target_include_directories(
-    ${LIBRARY_TARGET_NAME}
-    PUBLIC "$<BUILD_INTERFACE:${STP_INCLUDE_DIRS}>")
+  target_include_directories(${LIBRARY_TARGET_NAME}
+                             PUBLIC "$<BUILD_INTERFACE:${STP_INCLUDE_DIRS}>")
   target_compile_definitions(${LIBRARY_TARGET_NAME} PRIVATE SOLVER_STP_ENABLED)
 endif()
 
@@ -135,8 +132,7 @@ endif()
 if(${CAMADA_SOLVER_Z3_ENABLE})
   target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC ${CAMADA_Z3_LIB})
   target_include_directories(
-    ${LIBRARY_TARGET_NAME}
-    PUBLIC "$<BUILD_INTERFACE:${CAMADA_Z3_INCLUDE_DIR}>")
+    ${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CAMADA_Z3_INCLUDE_DIR}>")
   get_filename_component(CAMADA_Z3_LIB_DIR "${CAMADA_Z3_LIB}" DIRECTORY)
   if(BUILD_SHARED_LIBS AND EXISTS "${CAMADA_Z3_LIB_DIR}")
     target_link_directories(${LIBRARY_TARGET_NAME} PRIVATE ${CAMADA_Z3_LIB_DIR})


### PR DESCRIPTION
The installed <backend>solver.h headers each #include the matching backend's headers (z3++.h, bitwuzla/c/bitwuzla.h, ...). Until now the backend include path was added PRIVATE, so consumers had to find those headers themselves. On a Homebrew Mac that meant /opt/homebrew/include shadowed the bundled z3++.h, and ESBMC's build broke with deleted-ctor errors because the two z3 releases had drifted.

Switch the five backends with a manual include path (Bitwuzla, MathSAT, STP, Yices, Z3) to PUBLIC and wrap the path in a BUILD_INTERFACE generator expression so installed consumers (where the bundled solvers are not staged) are unaffected. CVC5 already exposes its includes via the cvc5::cvc5 imported target.

Quote the generator expressions: Bitwuzla_INCLUDE_DIRS is a ;-separated list, and an unquoted ${list} inside $<BUILD_INTERFACE:...> splits into separate arguments. CMake then prepends CMAKE_CURRENT_SOURCE_DIR to the mangled fragment, which trips the "path prefixed in the source directory" validation.