### PR TITLE
Add tuple encoding for backends without native datatype support (#16)

### DIFF
--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -63,78 +63,60 @@ CAMADA_BITWUZLA_SMTLIB_PIPELINE_TEST("dual emitter logs to file too",
 
 #undef CAMADA_BITWUZLA_SMTLIB_PIPELINE_TEST
 
-#define CAMADA_BITWUZLA_SMTLIB_SHARED_TEST(NameStr, FixtureCall)               \
+// `MakeFn` is the camada_smtlib_pipeline factory used to construct the
+// SMTLIBSolver — pass `makeSMTLIBSolver` for the default native-tuple
+// configuration, or `makeSMTLIBSolverCamadaTuples` to lower tuples into
+// per-field BV/Bool symbols on the wire (required against children that
+// reject `(declare-datatypes ...)`).
+#define CAMADA_BITWUZLA_SMTLIB_SHARED_TEST(NameStr, FixtureCall, MakeFn)       \
   TEST_CASE("SMTLIB pipeline: " NameStr " [bitwuzla]",                         \
             "[Bitwuzla][SMTLIB][pipeline]") {                                  \
     CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::bitwuzlaCommand(),    \
                                  "bitwuzla");                                  \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolver(Cmd);                         \
+    camada::SMTSolverRef solver = camada_smtlib_pipeline::MakeFn(Cmd);         \
     FixtureCall;                                                               \
   }
 
-CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver))
+CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver),
+                                   makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("implies_semantics",
-                                   implies_semantics(solver))
+                                   implies_semantics(solver), makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("implies_true_implies_false",
-                                   implies_true_implies_false(solver))
+                                   implies_true_implies_false(solver),
+                                   makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("bv_lshr_semantics",
-                                   bv_lshr_semantics(solver))
+                                   bv_lshr_semantics(solver), makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("incremental_push_pop",
-                                   incremental_push_pop(solver))
+                                   incremental_push_pop(solver),
+                                   makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("symbol_cache_survives_push_pop",
-                                   symbol_cache_survives_push_pop(solver))
-CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("array", array(solver))
+                                   symbol_cache_survives_push_pop(solver),
+                                   makeSMTLIBSolver)
+CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("array", array(solver), makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("array_const_store_semantics",
-                                   array_const_store_semantics(solver))
+                                   array_const_store_semantics(solver),
+                                   makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("bool_array_const_store_semantics",
-                                   bool_array_const_store_semantics(solver))
-CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver))
+                                   bool_array_const_store_semantics(solver),
+                                   makeSMTLIBSolver)
+CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver),
+                                   makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("quantifier_semantics",
-                                   quantifier_semantics(solver))
+                                   quantifier_semantics(solver),
+                                   makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("fp_equal NativeFP",
-                                   fp_equal(solver, camada::FPEncoding::Native))
+                                   fp_equal(solver, camada::FPEncoding::Native),
+                                   makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("fp_equal BVFP",
-                                   fp_equal(solver, camada::FPEncoding::BV))
+                                   fp_equal(solver, camada::FPEncoding::BV),
+                                   makeSMTLIBSolver)
+// bitwuzla rejects (declare-datatypes ...), so tuples here must use the
+// Camada lowering (per-field BV/Bool symbols).
+CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("tuple_semantics [Camada]",
+                                   tuple_semantics(solver),
+                                   makeSMTLIBSolverCamadaTuples)
+CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
+                                   empty_tuple_semantics(solver),
+                                   makeSMTLIBSolverCamadaTuples)
 
 #undef CAMADA_BITWUZLA_SMTLIB_SHARED_TEST
-
-// Tuples against the bitwuzla binary use TupleEncoding::Camada — bitwuzla
-// rejects (declare-datatypes ...), but it parses BV/Bool fine, so the
-// Camada lowering produces a script bitwuzla can solve.
-#define CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)         \
-  TEST_CASE("SMTLIB pipeline: " NameStr " [bitwuzla]",                         \
-            "[Bitwuzla][SMTLIB][pipeline]") {                                  \
-    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::bitwuzlaCommand(),    \
-                                 "bitwuzla");                                  \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
-    FixtureCall;                                                               \
-  }
-
-CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
-                                         tuple_semantics(solver))
-CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
-                                         empty_tuple_semantics(solver))
-
-#undef CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST
-
-// Tuples against the bitwuzla binary use TupleEncoding::Camada — bitwuzla
-// rejects (declare-datatypes ...), but it parses BV/Bool fine, so the
-// Camada lowering produces a script bitwuzla can solve.
-#define CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)         \
-  TEST_CASE("SMTLIB pipeline: " NameStr " [bitwuzla][Camada tuples]",          \
-            "[Bitwuzla][SMTLIB][pipeline]") {                                  \
-    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::bitwuzlaCommand(),    \
-                                 "bitwuzla");                                  \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
-    FixtureCall;                                                               \
-  }
-
-CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics",
-                                         tuple_semantics(solver))
-CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics",
-                                         empty_tuple_semantics(solver))
-
-#undef CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -98,3 +98,43 @@ CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("fp_equal BVFP",
                                    fp_equal(solver, camada::FPEncoding::BV))
 
 #undef CAMADA_BITWUZLA_SMTLIB_SHARED_TEST
+
+// Tuples against the bitwuzla binary use TupleEncoding::Camada — bitwuzla
+// rejects (declare-datatypes ...), but it parses BV/Bool fine, so the
+// Camada lowering produces a script bitwuzla can solve.
+#define CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)         \
+  TEST_CASE("SMTLIB pipeline: " NameStr " [bitwuzla]",                         \
+            "[Bitwuzla][SMTLIB][pipeline]") {                                  \
+    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::bitwuzlaCommand(),    \
+                                 "bitwuzla");                                  \
+    camada::SMTSolverRef solver =                                              \
+        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
+    FixtureCall;                                                               \
+  }
+
+CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
+                                         tuple_semantics(solver))
+CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
+                                         empty_tuple_semantics(solver))
+
+#undef CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST
+
+// Tuples against the bitwuzla binary use TupleEncoding::Camada — bitwuzla
+// rejects (declare-datatypes ...), but it parses BV/Bool fine, so the
+// Camada lowering produces a script bitwuzla can solve.
+#define CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)         \
+  TEST_CASE("SMTLIB pipeline: " NameStr " [bitwuzla][Camada tuples]",          \
+            "[Bitwuzla][SMTLIB][pipeline]") {                                  \
+    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::bitwuzlaCommand(),    \
+                                 "bitwuzla");                                  \
+    camada::SMTSolverRef solver =                                              \
+        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
+    FixtureCall;                                                               \
+  }
+
+CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics",
+                                         tuple_semantics(solver))
+CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics",
+                                         empty_tuple_semantics(solver))
+
+#undef CAMADA_BITWUZLA_SMTLIB_CAMADA_TUPLE_TEST

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -115,6 +115,9 @@ CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("fp_equal BVFP",
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("tuple_semantics [Camada]",
                                    tuple_semantics(solver),
                                    makeSMTLIBSolverCamadaTuples)
+CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("tuple_with_array_field [Camada]",
+                                   tuple_with_array_field(solver),
+                                   makeSMTLIBSolverCamadaTuples)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
                                    empty_tuple_semantics(solver),
                                    makeSMTLIBSolverCamadaTuples)

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -59,65 +59,71 @@ CAMADA_CVC5_SMTLIB_PIPELINE_TEST("dual emitter logs to file too",
 
 #undef CAMADA_CVC5_SMTLIB_PIPELINE_TEST
 
-#define CAMADA_CVC5_SMTLIB_SHARED_TEST(NameStr, FixtureCall)                   \
+// `MakeFn` is the camada_smtlib_pipeline factory used to construct the
+// SMTLIBSolver — pass `makeSMTLIBSolver` for the default native-tuple
+// configuration, or `makeSMTLIBSolverCamadaTuples` to lower tuples into
+// per-field BV/Bool symbols on the wire.
+#define CAMADA_CVC5_SMTLIB_SHARED_TEST(NameStr, FixtureCall, MakeFn)           \
   TEST_CASE("SMTLIB pipeline: " NameStr " [cvc5]",                             \
             "[CVC5][SMTLIB][pipeline]") {                                      \
     CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::cvc5Command(),        \
                                  "cvc5");                                      \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolver(Cmd);                         \
+    camada::SMTSolverRef solver = camada_smtlib_pipeline::MakeFn(Cmd);         \
     FixtureCall;                                                               \
   }
 
-CAMADA_CVC5_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver))
-CAMADA_CVC5_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver))
+CAMADA_CVC5_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver), makeSMTLIBSolver)
+CAMADA_CVC5_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("implies_true_implies_false",
-                               implies_true_implies_false(solver))
-CAMADA_CVC5_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver))
+                               implies_true_implies_false(solver),
+                               makeSMTLIBSolver)
+CAMADA_CVC5_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("incremental_push_pop",
-                               incremental_push_pop(solver))
+                               incremental_push_pop(solver), makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("symbol_cache_survives_push_pop",
-                               symbol_cache_survives_push_pop(solver))
-CAMADA_CVC5_SMTLIB_SHARED_TEST("array", array(solver))
+                               symbol_cache_survives_push_pop(solver),
+                               makeSMTLIBSolver)
+CAMADA_CVC5_SMTLIB_SHARED_TEST("array", array(solver), makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("array_const_store_semantics",
-                               array_const_store_semantics(solver))
+                               array_const_store_semantics(solver),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("bool_array_const_store_semantics",
-                               bool_array_const_store_semantics(solver))
-CAMADA_CVC5_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver))
+                               bool_array_const_store_semantics(solver),
+                               makeSMTLIBSolver)
+CAMADA_CVC5_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("arith_model_queries",
-                               arith_model_queries(solver))
+                               arith_model_queries(solver), makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("quantifier_semantics",
-                               quantifier_semantics(solver))
+                               quantifier_semantics(solver), makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("int_arithmetic_semantics",
-                               int_arithmetic_semantics(solver))
+                               int_arithmetic_semantics(solver),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("real_arithmetic_semantics",
-                               real_arithmetic_semantics(solver))
+                               real_arithmetic_semantics(solver),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("arith_conversion_semantics",
-                               arith_conversion_semantics(solver))
+                               arith_conversion_semantics(solver),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("tuple_semantics [native]",
-                               tuple_semantics(solver))
+                               tuple_semantics(solver), makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("empty_tuple_semantics [native]",
-                               empty_tuple_semantics(solver))
+                               empty_tuple_semantics(solver), makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("fp_equal NativeFP",
-                               fp_equal(solver, camada::FPEncoding::Native))
+                               fp_equal(solver, camada::FPEncoding::Native),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("fp_equal BVFP",
-                               fp_equal(solver, camada::FPEncoding::BV))
+                               fp_equal(solver, camada::FPEncoding::BV),
+                               makeSMTLIBSolver)
+// Camada tuple lowering verified against cvc5 too — confirms the emitted
+// script is solvable, not just well-formed.
+CAMADA_CVC5_SMTLIB_SHARED_TEST("tuple_semantics [Camada]",
+                               tuple_semantics(solver),
+                               makeSMTLIBSolverCamadaTuples)
+CAMADA_CVC5_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
+                               empty_tuple_semantics(solver),
+                               makeSMTLIBSolverCamadaTuples)
 
 #undef CAMADA_CVC5_SMTLIB_SHARED_TEST
-
-#define CAMADA_CVC5_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)             \
-  TEST_CASE("SMTLIB pipeline: " NameStr " [cvc5]",                             \
-            "[CVC5][SMTLIB][pipeline]") {                                      \
-    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::cvc5Command(),        \
-                                 "cvc5");                                      \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
-    FixtureCall;                                                               \
-  }
-
-CAMADA_CVC5_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
-                                     tuple_semantics(solver))
-CAMADA_CVC5_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
-                                     empty_tuple_semantics(solver))
-
-#undef CAMADA_CVC5_SMTLIB_CAMADA_TUPLE_TEST

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -109,6 +109,8 @@ CAMADA_CVC5_SMTLIB_SHARED_TEST("arith_conversion_semantics",
                                makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("tuple_semantics [native]",
                                tuple_semantics(solver), makeSMTLIBSolver)
+CAMADA_CVC5_SMTLIB_SHARED_TEST("tuple_with_array_field [native]",
+                               tuple_with_array_field(solver), makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("empty_tuple_semantics [native]",
                                empty_tuple_semantics(solver), makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("fp_equal NativeFP",
@@ -121,6 +123,9 @@ CAMADA_CVC5_SMTLIB_SHARED_TEST("fp_equal BVFP",
 // script is solvable, not just well-formed.
 CAMADA_CVC5_SMTLIB_SHARED_TEST("tuple_semantics [Camada]",
                                tuple_semantics(solver),
+                               makeSMTLIBSolverCamadaTuples)
+CAMADA_CVC5_SMTLIB_SHARED_TEST("tuple_with_array_field [Camada]",
+                               tuple_with_array_field(solver),
                                makeSMTLIBSolverCamadaTuples)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
                                empty_tuple_semantics(solver),

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -34,14 +34,9 @@ TEST_CASE("Arith CVC5 test", "[CVC5]") {
   arith_symbolic_shift_semantics(cvc5);
 }
 
-TEST_CASE("Tuple CVC5 test", "[CVC5]") {
+TEST_CASE("Tuple-with-Int CVC5 test", "[CVC5]") {
   auto cvc5 = camada::createCVC5Solver();
-  tuple_semantics(cvc5);
-}
-
-TEST_CASE("Empty tuple CVC5 test", "[CVC5]") {
-  auto cvc5 = camada::createCVC5Solver();
-  empty_tuple_semantics(cvc5);
+  tuple_semantics_with_int(cvc5);
 }
 
 // ---------------------------------------------------------------------------
@@ -99,8 +94,9 @@ CAMADA_CVC5_SMTLIB_SHARED_TEST("real_arithmetic_semantics",
                                real_arithmetic_semantics(solver))
 CAMADA_CVC5_SMTLIB_SHARED_TEST("arith_conversion_semantics",
                                arith_conversion_semantics(solver))
-CAMADA_CVC5_SMTLIB_SHARED_TEST("tuple_semantics", tuple_semantics(solver))
-CAMADA_CVC5_SMTLIB_SHARED_TEST("empty_tuple_semantics",
+CAMADA_CVC5_SMTLIB_SHARED_TEST("tuple_semantics [native]",
+                               tuple_semantics(solver))
+CAMADA_CVC5_SMTLIB_SHARED_TEST("empty_tuple_semantics [native]",
                                empty_tuple_semantics(solver))
 CAMADA_CVC5_SMTLIB_SHARED_TEST("fp_equal NativeFP",
                                fp_equal(solver, camada::FPEncoding::Native))
@@ -108,3 +104,20 @@ CAMADA_CVC5_SMTLIB_SHARED_TEST("fp_equal BVFP",
                                fp_equal(solver, camada::FPEncoding::BV))
 
 #undef CAMADA_CVC5_SMTLIB_SHARED_TEST
+
+#define CAMADA_CVC5_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)             \
+  TEST_CASE("SMTLIB pipeline: " NameStr " [cvc5]",                             \
+            "[CVC5][SMTLIB][pipeline]") {                                      \
+    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::cvc5Command(),        \
+                                 "cvc5");                                      \
+    camada::SMTSolverRef solver =                                              \
+        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
+    FixtureCall;                                                               \
+  }
+
+CAMADA_CVC5_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
+                                     tuple_semantics(solver))
+CAMADA_CVC5_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
+                                     empty_tuple_semantics(solver))
+
+#undef CAMADA_CVC5_SMTLIB_CAMADA_TUPLE_TEST

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -143,64 +143,67 @@ CAMADA_MATHSAT_SMTLIB_PIPELINE_TEST("dual emitter logs to file too",
 
 #undef CAMADA_MATHSAT_SMTLIB_PIPELINE_TEST
 
-#define CAMADA_MATHSAT_SMTLIB_SHARED_TEST(NameStr, FixtureCall)                \
+// `MakeFn` is the camada_smtlib_pipeline factory used to construct the
+// SMTLIBSolver — pass `makeSMTLIBSolver` for the default native-tuple
+// configuration, or `makeSMTLIBSolverCamadaTuples` to lower tuples into
+// per-field BV/Bool symbols on the wire (required against children that
+// reject `(declare-datatypes ...)`).
+#define CAMADA_MATHSAT_SMTLIB_SHARED_TEST(NameStr, FixtureCall, MakeFn)        \
   TEST_CASE("SMTLIB pipeline: " NameStr " [mathsat]",                          \
             "[MathSAT][SMTLIB][pipeline]") {                                   \
     CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::mathsatCommand(),     \
                                  "mathsat");                                   \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolver(Cmd);                         \
+    camada::SMTSolverRef solver = camada_smtlib_pipeline::MakeFn(Cmd);         \
     FixtureCall;                                                               \
   }
 
-CAMADA_MATHSAT_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver))
+CAMADA_MATHSAT_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver),
+                                  makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("implies_semantics",
-                                  implies_semantics(solver))
+                                  implies_semantics(solver), makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("implies_true_implies_false",
-                                  implies_true_implies_false(solver))
+                                  implies_true_implies_false(solver),
+                                  makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("bv_lshr_semantics",
-                                  bv_lshr_semantics(solver))
+                                  bv_lshr_semantics(solver), makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("incremental_push_pop",
-                                  incremental_push_pop(solver))
+                                  incremental_push_pop(solver),
+                                  makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("symbol_cache_survives_push_pop",
-                                  symbol_cache_survives_push_pop(solver))
-CAMADA_MATHSAT_SMTLIB_SHARED_TEST("array", array(solver))
+                                  symbol_cache_survives_push_pop(solver),
+                                  makeSMTLIBSolver)
+CAMADA_MATHSAT_SMTLIB_SHARED_TEST("array", array(solver), makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("array_const_store_semantics",
-                                  array_const_store_semantics(solver))
+                                  array_const_store_semantics(solver),
+                                  makeSMTLIBSolver)
 // bool_array_const_store_semantics is absent: mathsat rejects arrays whose
 // element sort is Bool ("Arrays with Bool as argument are not supported").
-CAMADA_MATHSAT_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver))
+CAMADA_MATHSAT_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver),
+                                  makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("int_arithmetic_semantics",
-                                  int_arithmetic_semantics(solver))
+                                  int_arithmetic_semantics(solver),
+                                  makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("real_arithmetic_semantics",
-                                  real_arithmetic_semantics(solver))
+                                  real_arithmetic_semantics(solver),
+                                  makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("arith_model_queries",
-                                  arith_model_queries(solver))
+                                  arith_model_queries(solver), makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("arith_conversion_semantics",
-                                  arith_conversion_semantics(solver))
+                                  arith_conversion_semantics(solver),
+                                  makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("fp_equal NativeFP",
-                                  fp_equal(solver, camada::FPEncoding::Native))
+                                  fp_equal(solver, camada::FPEncoding::Native),
+                                  makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("fp_equal BVFP",
-                                  fp_equal(solver, camada::FPEncoding::BV))
+                                  fp_equal(solver, camada::FPEncoding::BV),
+                                  makeSMTLIBSolver)
+// mathsat's SMT-LIB parser rejects (declare-datatypes ...), so tuples here
+// must use the Camada lowering (per-field BV/Bool symbols).
+CAMADA_MATHSAT_SMTLIB_SHARED_TEST("tuple_semantics [Camada]",
+                                  tuple_semantics(solver),
+                                  makeSMTLIBSolverCamadaTuples)
+CAMADA_MATHSAT_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
+                                  empty_tuple_semantics(solver),
+                                  makeSMTLIBSolverCamadaTuples)
 
 #undef CAMADA_MATHSAT_SMTLIB_SHARED_TEST
-
-// Tuples against the mathsat binary use TupleEncoding::Camada — mathsat's
-// SMT-LIB parser rejects (declare-datatypes ...), but the Camada lowering
-// emits only BV/Bool which mathsat solves natively.
-#define CAMADA_MATHSAT_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)          \
-  TEST_CASE("SMTLIB pipeline: " NameStr " [mathsat]",                          \
-            "[MathSAT][SMTLIB][pipeline]") {                                   \
-    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::mathsatCommand(),     \
-                                 "mathsat");                                   \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
-    FixtureCall;                                                               \
-  }
-
-CAMADA_MATHSAT_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
-                                        tuple_semantics(solver))
-CAMADA_MATHSAT_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
-                                        empty_tuple_semantics(solver))
-
-#undef CAMADA_MATHSAT_SMTLIB_CAMADA_TUPLE_TEST

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -202,6 +202,9 @@ CAMADA_MATHSAT_SMTLIB_SHARED_TEST("fp_equal BVFP",
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("tuple_semantics [Camada]",
                                   tuple_semantics(solver),
                                   makeSMTLIBSolverCamadaTuples)
+CAMADA_MATHSAT_SMTLIB_SHARED_TEST("tuple_with_array_field [Camada]",
+                                  tuple_with_array_field(solver),
+                                  makeSMTLIBSolverCamadaTuples)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
                                   empty_tuple_semantics(solver),
                                   makeSMTLIBSolverCamadaTuples)

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -184,3 +184,23 @@ CAMADA_MATHSAT_SMTLIB_SHARED_TEST("fp_equal BVFP",
                                   fp_equal(solver, camada::FPEncoding::BV))
 
 #undef CAMADA_MATHSAT_SMTLIB_SHARED_TEST
+
+// Tuples against the mathsat binary use TupleEncoding::Camada — mathsat's
+// SMT-LIB parser rejects (declare-datatypes ...), but the Camada lowering
+// emits only BV/Bool which mathsat solves natively.
+#define CAMADA_MATHSAT_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)          \
+  TEST_CASE("SMTLIB pipeline: " NameStr " [mathsat]",                          \
+            "[MathSAT][SMTLIB][pipeline]") {                                   \
+    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::mathsatCommand(),     \
+                                 "mathsat");                                   \
+    camada::SMTSolverRef solver =                                              \
+        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
+    FixtureCall;                                                               \
+  }
+
+CAMADA_MATHSAT_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
+                                        tuple_semantics(solver))
+CAMADA_MATHSAT_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
+                                        empty_tuple_semantics(solver))
+
+#undef CAMADA_MATHSAT_SMTLIB_CAMADA_TUPLE_TEST

--- a/regression/smtlib_pipeline.test.h
+++ b/regression/smtlib_pipeline.test.h
@@ -131,6 +131,15 @@ makeSMTLIBSolver(const std::vector<std::string> &Argv) {
   return camada::createSMTLIBSolver(Argv);
 }
 
+// Same, but the SMTLIBSolver lowers tuples in Camada (per-field BV/Bool
+// symbols) instead of emitting `(declare-datatypes ...)`. Use this for
+// tuple fixtures against child solvers that don't accept SMT-LIB
+// datatypes (bitwuzla, mathsat, yices-smt2).
+inline camada::SMTSolverRef
+makeSMTLIBSolverCamadaTuples(const std::vector<std::string> &Argv) {
+  return camada::createSMTLIBSolver(Argv, camada::TupleEncoding::Camada);
+}
+
 // Skip the test if the binary isn't reachable.
 #define CAMADA_SMTLIB_REQUIRE_BINARY(CmdExpr, Name)                            \
   std::vector<std::string> Cmd = (CmdExpr);                                    \

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -53,6 +53,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(array_const_store_semantics);
   RESETANDTEST(bool_array_const_store_semantics);
   RESETANDTEST(array_const_survives_push_pop);
+  RESETANDTEST(tuple_semantics);
+  RESETANDTEST(empty_tuple_semantics);
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);
   RESETANDTEST(fp_neg_nan_native_bv_parity);

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -54,6 +54,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(bool_array_const_store_semantics);
   RESETANDTEST(array_const_survives_push_pop);
   RESETANDTEST(tuple_semantics);
+  RESETANDTEST(tuple_with_array_field);
   RESETANDTEST(empty_tuple_semantics);
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -55,6 +55,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(array_const_survives_push_pop);
   RESETANDTEST(tuple_semantics);
   RESETANDTEST(tuple_with_array_field);
+  RESETANDTEST(tuple_structural_equality);
   RESETANDTEST(empty_tuple_semantics);
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -58,6 +58,46 @@ inline void tuple_semantics_with_int(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::checkResult::SAT);
 }
 
+// Tuple whose second field is an array. Exercises the encoded path's
+// per-field decomposition for non-scalar field sorts: on backends
+// without native datatype support, the array field becomes a regular
+// array-typed symbol named __CAMADA_tup_<base>_1 minted on demand.
+//
+// Skipped on yices-smt2 SMT-LIB pipeline (which rejects mkArrayConst —
+// this fixture intentionally avoids it). Works on every native backend
+// and on the SMT-LIB pipeline against z3/cvc5/bitwuzla/mathsat.
+inline void tuple_with_array_field(const camada::SMTSolverRef &solver) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idxSort = solver->mkBVSort(3);
+  auto arrSort = solver->mkArraySort(idxSort, bv8);
+  auto tupleSort = solver->mkTupleSort({bv8, arrSort});
+
+  REQUIRE(tupleSort->isTupleSort());
+  REQUIRE(tupleSort->getTupleElementSorts().size() == 2);
+  REQUIRE(tupleSort->getTupleElementSorts()[1] == arrSort);
+
+  auto t = solver->mkSymbol("t_arr", tupleSort);
+  auto bvField = solver->mkTupleSelect(t, 0);
+  auto arrField = solver->mkTupleSelect(t, 1);
+  REQUIRE(bvField->Sort == bv8);
+  REQUIRE(arrField->Sort == arrSort);
+
+  // Constrain the BV field to 7 and require arrField[3] == 42.
+  solver->addConstraint(solver->mkEqual(bvField, solver->mkBVFromDec(7, 8)));
+  auto idx = solver->mkBVFromDec(3, idxSort);
+  auto fortyTwo = solver->mkBVFromDec(42, 8);
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(arrField, idx), fortyTwo));
+
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  auto bv_res = solver->getBV(bvField);
+  REQUIRE(bv_res);
+  REQUIRE(bv_res.value() == 7);
+  auto sel_res = solver->getBV(solver->mkArraySelect(arrField, idx));
+  REQUIRE(sel_res);
+  REQUIRE(sel_res.value() == 42);
+}
+
 inline void empty_tuple_semantics(const camada::SMTSolverRef &solver) {
   auto tupleSort = solver->mkTupleSort({});
   auto tupleValue = solver->mkTuple({});

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -1,39 +1,33 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+// Bool + BV only — works on every backend, including those without Int
+// support (bitwuzla, stp, yices). Backends that lack native datatype
+// support exercise the Camada-managed encoding here.
 inline void tuple_semantics(const camada::SMTSolverRef &solver) {
   auto boolSort = solver->mkBoolSort();
   auto bv8Sort = solver->mkBVSort(8);
-  auto intSort = solver->mkIntSort();
-  auto tupleSort = solver->mkTupleSort({boolSort, bv8Sort, intSort});
+  auto tupleSort = solver->mkTupleSort({boolSort, bv8Sort});
 
   REQUIRE(tupleSort->isTupleSort());
-  REQUIRE(tupleSort->getTupleElementSorts().size() == 3);
+  REQUIRE(tupleSort->getTupleElementSorts().size() == 2);
   REQUIRE(tupleSort->getTupleElementSorts()[0] == boolSort);
   REQUIRE(tupleSort->getTupleElementSorts()[1] == bv8Sort);
-  REQUIRE(tupleSort->getTupleElementSorts()[2] == intSort);
 
-  auto tupleValue = solver->mkTuple(
-      {solver->mkBool(true), solver->mkBVFromDec(42, 8), solver->mkInt(7)});
-  REQUIRE(tupleValue->getKind() == camada::SMTExprKind::TupleConst);
+  auto tupleValue =
+      solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(42, 8)});
 
   auto tupleSymbol = solver->mkSymbol("t", tupleSort);
   solver->addConstraint(solver->mkEqual(tupleSymbol, tupleValue));
 
   auto b = solver->mkTupleSelect(tupleSymbol, 0);
   auto bv = solver->mkTupleSelect(tupleSymbol, 1);
-  auto i = solver->mkTupleSelect(tupleSymbol, 2);
 
-  REQUIRE(b->getKind() == camada::SMTExprKind::TupleSelect);
-  REQUIRE(bv->getKind() == camada::SMTExprKind::TupleSelect);
-  REQUIRE(i->getKind() == camada::SMTExprKind::TupleSelect);
   REQUIRE(b->Sort == boolSort);
   REQUIRE(bv->Sort == bv8Sort);
-  REQUIRE(i->Sort == intSort);
 
   solver->addConstraint(solver->mkEqual(b, solver->mkBool(true)));
   solver->addConstraint(solver->mkEqual(bv, solver->mkBVFromDec(42, 8)));
-  solver->addConstraint(solver->mkEqual(i, solver->mkInt(7)));
   REQUIRE(solver->check() == camada::checkResult::SAT);
   auto b_res = solver->getBool(b);
   auto bv_res = solver->getBV(bv);
@@ -43,13 +37,33 @@ inline void tuple_semantics(const camada::SMTSolverRef &solver) {
   REQUIRE(bv_res.value() == 42);
 }
 
+// Bool + BV + Int — only run against backends with Int support
+// (z3, cvc5). Kept separate so the Int-free fixture above can run on
+// every backend via the shared tests(solver) runner.
+inline void tuple_semantics_with_int(const camada::SMTSolverRef &solver) {
+  auto boolSort = solver->mkBoolSort();
+  auto bv8Sort = solver->mkBVSort(8);
+  auto intSort = solver->mkIntSort();
+  auto tupleSort = solver->mkTupleSort({boolSort, bv8Sort, intSort});
+
+  auto tupleValue = solver->mkTuple(
+      {solver->mkBool(true), solver->mkBVFromDec(42, 8), solver->mkInt(7)});
+
+  auto tupleSymbol = solver->mkSymbol("t_int", tupleSort);
+  solver->addConstraint(solver->mkEqual(tupleSymbol, tupleValue));
+
+  auto i = solver->mkTupleSelect(tupleSymbol, 2);
+  REQUIRE(i->Sort == intSort);
+  solver->addConstraint(solver->mkEqual(i, solver->mkInt(7)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
 inline void empty_tuple_semantics(const camada::SMTSolverRef &solver) {
   auto tupleSort = solver->mkTupleSort({});
   auto tupleValue = solver->mkTuple({});
 
   REQUIRE(tupleSort->isTupleSort());
   REQUIRE(tupleSort->getTupleElementSorts().empty());
-  REQUIRE(tupleValue->getKind() == camada::SMTExprKind::TupleConst);
   REQUIRE(tupleValue->Sort == tupleSort);
 
   auto tupleSymbol = solver->mkSymbol("empty_tuple", tupleSort);

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -98,6 +98,38 @@ inline void tuple_with_array_field(const camada::SMTSolverRef &solver) {
   REQUIRE(sel_res.value() == 42);
 }
 
+// Pin host-side AST equality for tuple expressions: two freshly built
+// CamadaTupleExpr nodes that describe the same shape with structurally
+// equal components compare equal via SMTExpr::operator==. Distinct
+// components (different bool, different bv, different symbol name)
+// compare unequal. Native-tuple backends already get this for free via
+// their backend term; the encoded path needs to implement it on
+// CamadaTupleExpr explicitly.
+inline void tuple_structural_equality(const camada::SMTSolverRef &solver) {
+  auto boolSort = solver->mkBoolSort();
+  auto bv8Sort = solver->mkBVSort(8);
+  auto tupleSort = solver->mkTupleSort({boolSort, bv8Sort});
+
+  auto t1 = solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(42, 8)});
+  auto t1_alias =
+      solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(42, 8)});
+  auto t2 =
+      solver->mkTuple({solver->mkBool(false), solver->mkBVFromDec(42, 8)});
+
+  REQUIRE(*t1 == *t1);
+  REQUIRE(*t1 == *t1_alias);
+  REQUIRE_FALSE(*t1 == *t2);
+
+  // Symbols: same (name, sort) → equal; different name → not.
+  auto sym_a = solver->mkSymbol("tup_a", tupleSort);
+  auto sym_b = solver->mkSymbol("tup_b", tupleSort);
+  // mkSymbol caches by (name, sort), so the same name returns the same
+  // handle. Use the underlying expr equality to verify the path works
+  // even when handle identity coincides with structural identity.
+  REQUIRE(*sym_a == *sym_a);
+  REQUIRE_FALSE(*sym_a == *sym_b);
+}
+
 inline void empty_tuple_semantics(const camada::SMTSolverRef &solver) {
   auto tupleSort = solver->mkTupleSort({});
   auto tupleValue = solver->mkTuple({});

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -91,16 +91,16 @@ TEST_CASE("Override Yices Solver", "[YICES]") {
     }
 
   private:
-    static void configureQfBv(ctx_config_t *config) {
+    static void configureQfAbv(ctx_config_t *config) {
       yices_set_config(config, "mode", "push-pop");
       yices_set_config(config, "solver-type", "dpllt");
       yices_set_config(config, "uf-solver", "none");
       yices_set_config(config, "bv-solver", "default");
-      yices_set_config(config, "array-solver", "none");
+      yices_set_config(config, "array-solver", "default");
       yices_set_config(config, "arith-solver", "none");
     }
 
-    void create() { recreateContextWithConfig("QF_BV", configureQfBv); }
+    void create() { recreateContextWithConfig("QF_ABV", configureQfAbv); }
   };
 
   // Create Yices Solver

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -148,59 +148,61 @@ CAMADA_YICES_SMTLIB_PIPELINE_TEST("dual emitter logs to file too",
 
 #undef CAMADA_YICES_SMTLIB_PIPELINE_TEST
 
-#define CAMADA_YICES_SMTLIB_SHARED_TEST(NameStr, FixtureCall)                  \
+// `MakeFn` is the camada_smtlib_pipeline factory used to construct the
+// SMTLIBSolver — pass `makeSMTLIBSolver` for the default native-tuple
+// configuration, or `makeSMTLIBSolverCamadaTuples` to lower tuples into
+// per-field BV/Bool symbols on the wire (required against children that
+// reject `(declare-datatypes ...)`).
+#define CAMADA_YICES_SMTLIB_SHARED_TEST(NameStr, FixtureCall, MakeFn)          \
   TEST_CASE("SMTLIB pipeline: " NameStr " [yices-smt2]",                       \
             "[YICES][SMTLIB][pipeline]") {                                     \
     CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::yicesSmt2Command(),   \
                                  "yices-smt2");                                \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolver(Cmd);                         \
+    camada::SMTSolverRef solver = camada_smtlib_pipeline::MakeFn(Cmd);         \
     FixtureCall;                                                               \
   }
 
-CAMADA_YICES_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver))
-CAMADA_YICES_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver))
+CAMADA_YICES_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver),
+                                makeSMTLIBSolver)
+CAMADA_YICES_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver),
+                                makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("implies_true_implies_false",
-                                implies_true_implies_false(solver))
-CAMADA_YICES_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver))
+                                implies_true_implies_false(solver),
+                                makeSMTLIBSolver)
+CAMADA_YICES_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver),
+                                makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("incremental_push_pop",
-                                incremental_push_pop(solver))
+                                incremental_push_pop(solver), makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("symbol_cache_survives_push_pop",
-                                symbol_cache_survives_push_pop(solver))
+                                symbol_cache_survives_push_pop(solver),
+                                makeSMTLIBSolver)
 // Array fixtures absent for yices: they all use `mkArrayConst`, which Camada
 // emits as `((as const ...) ...)`. yices-smt2 rejects this syntax outright
 // ("undefined term: const"); native yices supports const-arrays via a
 // different C-API path, but there's no SMT-LIB-wire equivalent.
-CAMADA_YICES_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver))
+CAMADA_YICES_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver),
+                                makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("int_arithmetic_semantics",
-                                int_arithmetic_semantics(solver))
+                                int_arithmetic_semantics(solver),
+                                makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("real_arithmetic_semantics",
-                                real_arithmetic_semantics(solver))
+                                real_arithmetic_semantics(solver),
+                                makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("arith_model_queries",
-                                arith_model_queries(solver))
+                                arith_model_queries(solver), makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("arith_conversion_semantics",
-                                arith_conversion_semantics(solver))
+                                arith_conversion_semantics(solver),
+                                makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("fp_equal BVFP",
-                                fp_equal(solver, camada::FPEncoding::BV))
+                                fp_equal(solver, camada::FPEncoding::BV),
+                                makeSMTLIBSolver)
+// yices rejects (declare-datatypes ...), so tuples here must use the
+// Camada lowering (per-field BV/Bool symbols).
+CAMADA_YICES_SMTLIB_SHARED_TEST("tuple_semantics [Camada]",
+                                tuple_semantics(solver),
+                                makeSMTLIBSolverCamadaTuples)
+CAMADA_YICES_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
+                                empty_tuple_semantics(solver),
+                                makeSMTLIBSolverCamadaTuples)
 
 #undef CAMADA_YICES_SMTLIB_SHARED_TEST
-
-// Tuples against the yices-smt2 binary use TupleEncoding::Camada — yices
-// rejects (declare-datatypes ...), but the Camada lowering produces a
-// pure BV/Bool script which yices solves natively.
-#define CAMADA_YICES_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)            \
-  TEST_CASE("SMTLIB pipeline: " NameStr " [yices]",                            \
-            "[Yices][SMTLIB][pipeline]") {                                     \
-    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::yicesSmt2Command(),   \
-                                 "yices-smt2");                                \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
-    FixtureCall;                                                               \
-  }
-
-CAMADA_YICES_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
-                                      tuple_semantics(solver))
-CAMADA_YICES_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
-                                      empty_tuple_semantics(solver))
-
-#undef CAMADA_YICES_SMTLIB_CAMADA_TUPLE_TEST

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -184,3 +184,23 @@ CAMADA_YICES_SMTLIB_SHARED_TEST("fp_equal BVFP",
                                 fp_equal(solver, camada::FPEncoding::BV))
 
 #undef CAMADA_YICES_SMTLIB_SHARED_TEST
+
+// Tuples against the yices-smt2 binary use TupleEncoding::Camada — yices
+// rejects (declare-datatypes ...), but the Camada lowering produces a
+// pure BV/Bool script which yices solves natively.
+#define CAMADA_YICES_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)            \
+  TEST_CASE("SMTLIB pipeline: " NameStr " [yices]",                            \
+            "[Yices][SMTLIB][pipeline]") {                                     \
+    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::yicesSmt2Command(),   \
+                                 "yices-smt2");                                \
+    camada::SMTSolverRef solver =                                              \
+        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
+    FixtureCall;                                                               \
+  }
+
+CAMADA_YICES_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
+                                      tuple_semantics(solver))
+CAMADA_YICES_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
+                                      empty_tuple_semantics(solver))
+
+#undef CAMADA_YICES_SMTLIB_CAMADA_TUPLE_TEST

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -93,63 +93,68 @@ CAMADA_Z3_SMTLIB_PIPELINE_TEST("dual emitter logs to file too",
 // SMTLIBSolver wrapping the z3 binary and hands it to a fixture from the
 // existing native suite. z3 supports the full Camada surface, so we wire up
 // one TEST_CASE per fixture that's relevant to a pipe-driven session.
-#define CAMADA_Z3_SMTLIB_SHARED_TEST(NameStr, FixtureCall)                     \
+// `MakeFn` is the camada_smtlib_pipeline factory used to construct the
+// SMTLIBSolver — pass `makeSMTLIBSolver` for the default native-tuple
+// configuration, or `makeSMTLIBSolverCamadaTuples` to lower tuples into
+// per-field BV/Bool symbols on the wire.
+#define CAMADA_Z3_SMTLIB_SHARED_TEST(NameStr, FixtureCall, MakeFn)             \
   TEST_CASE("SMTLIB pipeline: " NameStr " [z3]", "[Z3][SMTLIB][pipeline]") {   \
     CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::z3Command(), "z3");   \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolver(Cmd);                         \
+    camada::SMTSolverRef solver = camada_smtlib_pipeline::MakeFn(Cmd);         \
     FixtureCall;                                                               \
   }
 
-CAMADA_Z3_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver))
-CAMADA_Z3_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver))
+CAMADA_Z3_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver), makeSMTLIBSolver)
+CAMADA_Z3_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver),
+                             makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("implies_true_implies_false",
-                             implies_true_implies_false(solver))
-CAMADA_Z3_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver))
+                             implies_true_implies_false(solver),
+                             makeSMTLIBSolver)
+CAMADA_Z3_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver),
+                             makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("incremental_push_pop",
-                             incremental_push_pop(solver))
+                             incremental_push_pop(solver), makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("symbol_cache_survives_push_pop",
-                             symbol_cache_survives_push_pop(solver))
-CAMADA_Z3_SMTLIB_SHARED_TEST("array", array(solver))
+                             symbol_cache_survives_push_pop(solver),
+                             makeSMTLIBSolver)
+CAMADA_Z3_SMTLIB_SHARED_TEST("array", array(solver), makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("array_const_store_semantics",
-                             array_const_store_semantics(solver))
+                             array_const_store_semantics(solver),
+                             makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("bool_array_const_store_semantics",
-                             bool_array_const_store_semantics(solver))
-CAMADA_Z3_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver))
+                             bool_array_const_store_semantics(solver),
+                             makeSMTLIBSolver)
+CAMADA_Z3_SMTLIB_SHARED_TEST("uf_semantics", uf_semantics(solver),
+                             makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("quantifier_semantics",
-                             quantifier_semantics(solver))
+                             quantifier_semantics(solver), makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("int_arithmetic_semantics",
-                             int_arithmetic_semantics(solver))
+                             int_arithmetic_semantics(solver), makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("real_arithmetic_semantics",
-                             real_arithmetic_semantics(solver))
-CAMADA_Z3_SMTLIB_SHARED_TEST("arith_model_queries", arith_model_queries(solver))
+                             real_arithmetic_semantics(solver),
+                             makeSMTLIBSolver)
+CAMADA_Z3_SMTLIB_SHARED_TEST("arith_model_queries", arith_model_queries(solver),
+                             makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("arith_conversion_semantics",
-                             arith_conversion_semantics(solver))
+                             arith_conversion_semantics(solver),
+                             makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("tuple_semantics [native]",
-                             tuple_semantics(solver))
+                             tuple_semantics(solver), makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("empty_tuple_semantics [native]",
-                             empty_tuple_semantics(solver))
+                             empty_tuple_semantics(solver), makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("fp_equal NativeFP",
-                             fp_equal(solver, camada::FPEncoding::Native))
+                             fp_equal(solver, camada::FPEncoding::Native),
+                             makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("fp_equal BVFP",
-                             fp_equal(solver, camada::FPEncoding::BV))
+                             fp_equal(solver, camada::FPEncoding::BV),
+                             makeSMTLIBSolver)
+// Camada tuple lowering verified against z3 too — confirms the emitted
+// script is actually solvable, not just well-formed.
+CAMADA_Z3_SMTLIB_SHARED_TEST("tuple_semantics [Camada]",
+                             tuple_semantics(solver),
+                             makeSMTLIBSolverCamadaTuples)
+CAMADA_Z3_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
+                             empty_tuple_semantics(solver),
+                             makeSMTLIBSolverCamadaTuples)
 
 #undef CAMADA_Z3_SMTLIB_SHARED_TEST
-
-// Camada tuple lowering (per-field BV/Bool symbols). Works against any
-// SMT-LIB v2 solver — verified here against z3 too so we know the
-// emitted script is actually solvable, not just well-formed.
-#define CAMADA_Z3_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)               \
-  TEST_CASE("SMTLIB pipeline: " NameStr " [z3]", "[Z3][SMTLIB][pipeline]") {   \
-    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::z3Command(), "z3");   \
-    camada::SMTSolverRef solver =                                              \
-        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
-    FixtureCall;                                                               \
-  }
-
-CAMADA_Z3_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
-                                   tuple_semantics(solver))
-CAMADA_Z3_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
-                                   empty_tuple_semantics(solver))
-
-#undef CAMADA_Z3_SMTLIB_CAMADA_TUPLE_TEST

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -140,6 +140,8 @@ CAMADA_Z3_SMTLIB_SHARED_TEST("arith_conversion_semantics",
                              makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("tuple_semantics [native]",
                              tuple_semantics(solver), makeSMTLIBSolver)
+CAMADA_Z3_SMTLIB_SHARED_TEST("tuple_with_array_field [native]",
+                             tuple_with_array_field(solver), makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("empty_tuple_semantics [native]",
                              empty_tuple_semantics(solver), makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("fp_equal NativeFP",
@@ -152,6 +154,9 @@ CAMADA_Z3_SMTLIB_SHARED_TEST("fp_equal BVFP",
 // script is actually solvable, not just well-formed.
 CAMADA_Z3_SMTLIB_SHARED_TEST("tuple_semantics [Camada]",
                              tuple_semantics(solver),
+                             makeSMTLIBSolverCamadaTuples)
+CAMADA_Z3_SMTLIB_SHARED_TEST("tuple_with_array_field [Camada]",
+                             tuple_with_array_field(solver),
                              makeSMTLIBSolverCamadaTuples)
 CAMADA_Z3_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
                              empty_tuple_semantics(solver),

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -34,14 +34,9 @@ TEST_CASE("Arith Z3 test", "[Z3]") {
   arith_symbolic_shift_semantics(z3);
 }
 
-TEST_CASE("Tuple Z3 test", "[Z3]") {
+TEST_CASE("Tuple-with-Int Z3 test", "[Z3]") {
   auto z3 = camada::createZ3Solver();
-  tuple_semantics(z3);
-}
-
-TEST_CASE("Empty tuple Z3 test", "[Z3]") {
-  auto z3 = camada::createZ3Solver();
-  empty_tuple_semantics(z3);
+  tuple_semantics_with_int(z3);
 }
 
 TEST_CASE("Override Z3 Solver", "[Z3]") {
@@ -130,8 +125,9 @@ CAMADA_Z3_SMTLIB_SHARED_TEST("real_arithmetic_semantics",
 CAMADA_Z3_SMTLIB_SHARED_TEST("arith_model_queries", arith_model_queries(solver))
 CAMADA_Z3_SMTLIB_SHARED_TEST("arith_conversion_semantics",
                              arith_conversion_semantics(solver))
-CAMADA_Z3_SMTLIB_SHARED_TEST("tuple_semantics", tuple_semantics(solver))
-CAMADA_Z3_SMTLIB_SHARED_TEST("empty_tuple_semantics",
+CAMADA_Z3_SMTLIB_SHARED_TEST("tuple_semantics [native]",
+                             tuple_semantics(solver))
+CAMADA_Z3_SMTLIB_SHARED_TEST("empty_tuple_semantics [native]",
                              empty_tuple_semantics(solver))
 CAMADA_Z3_SMTLIB_SHARED_TEST("fp_equal NativeFP",
                              fp_equal(solver, camada::FPEncoding::Native))
@@ -139,3 +135,21 @@ CAMADA_Z3_SMTLIB_SHARED_TEST("fp_equal BVFP",
                              fp_equal(solver, camada::FPEncoding::BV))
 
 #undef CAMADA_Z3_SMTLIB_SHARED_TEST
+
+// Camada tuple lowering (per-field BV/Bool symbols). Works against any
+// SMT-LIB v2 solver — verified here against z3 too so we know the
+// emitted script is actually solvable, not just well-formed.
+#define CAMADA_Z3_SMTLIB_CAMADA_TUPLE_TEST(NameStr, FixtureCall)               \
+  TEST_CASE("SMTLIB pipeline: " NameStr " [z3]", "[Z3][SMTLIB][pipeline]") {   \
+    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::z3Command(), "z3");   \
+    camada::SMTSolverRef solver =                                              \
+        camada_smtlib_pipeline::makeSMTLIBSolverCamadaTuples(Cmd);             \
+    FixtureCall;                                                               \
+  }
+
+CAMADA_Z3_SMTLIB_CAMADA_TUPLE_TEST("tuple_semantics [Camada]",
+                                   tuple_semantics(solver))
+CAMADA_Z3_SMTLIB_CAMADA_TUPLE_TEST("empty_tuple_semantics [Camada]",
+                                   empty_tuple_semantics(solver))
+
+#undef CAMADA_Z3_SMTLIB_CAMADA_TUPLE_TEST

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(${LIBRARY_TARGET_NAME}_SRC
     camadafp.cpp
     camadaimpl.cpp
     camadasort.cpp
+    camadatuple.cpp
     bitwuzlasolver.cpp
     cvc5solver.cpp
     mathsatsolver.cpp

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -910,7 +910,7 @@ SMTExprRef BitwuzlaSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
   const SMTSortRef &to =
       mkFPSort(Exp->Sort->getFPExponentWidth(),
                Exp->Sort->getFPSignificandWidth(), FPEncoding::BV);
-  const SMTExprRef &newSymbol = mkSymbol(name, to);
+  const SMTExprRef &newSymbol = mkSymbolUnchecked(name, to);
   addConstraint(mkEqual(Exp, mkBVToIEEEFP(newSymbol, Exp->Sort)));
   return newSymbol;
 }

--- a/src/camada.cpp
+++ b/src/camada.cpp
@@ -108,13 +108,16 @@ SMTSolverRef createSTPSolver() {
 #endif
 }
 
-SMTSolverRef createSMTLIBSolver(const std::vector<std::string> &Argv) {
-  return std::make_unique<SMTLIBSolver>(SMTLIBProcessTag{}, Argv);
+SMTSolverRef createSMTLIBSolver(const std::vector<std::string> &Argv,
+                                TupleEncoding TupleMode) {
+  return std::make_unique<SMTLIBSolver>(SMTLIBProcessTag{}, Argv, TupleMode);
 }
 
 SMTSolverRef createSMTLIBSolver(const std::vector<std::string> &Argv,
-                                const std::string &OutputPath) {
-  return std::make_unique<SMTLIBSolver>(SMTLIBProcessTag{}, Argv, OutputPath);
+                                const std::string &OutputPath,
+                                TupleEncoding TupleMode) {
+  return std::make_unique<SMTLIBSolver>(SMTLIBProcessTag{}, Argv, OutputPath,
+                                        TupleMode);
 }
 
 } // namespace camada

--- a/src/camada.h
+++ b/src/camada.h
@@ -42,6 +42,18 @@ enum class FPNegBehavior {
   PreserveNaNPayload,
 };
 
+/// Selects how the SMT-LIB backend lowers tuples on the wire.
+///
+/// - Native: emit `(declare-datatypes ...)` and rely on the downstream
+///   solver to support SMT-LIB datatypes. Works against z3 and cvc5; not
+///   accepted by bitwuzla, mathsat, yices-smt2.
+/// - Camada: lower tuples in Camada to per-field BV/Bool symbols before
+///   anything reaches the wire. The emitted script contains no
+///   datatype declarations, so any standard SMT-LIB v2 solver can parse
+///   it. Same encoding the non-native backends (bitwuzla/mathsat/stp/
+///   yices) already use.
+enum class TupleEncoding { Native, Camada };
+
 enum class RM {
   ROUND_TO_EVEN = 0,
   ROUND_TO_AWAY = 1,
@@ -698,13 +710,17 @@ SMTSolverRef createSTPSolver();
 /// The child must speak standard SMT-LIB on stdin/stdout. Camada sends
 /// `(set-option :print-success true)` to it at startup, so any solver that
 /// honors that contract works.
-SMTSolverRef createSMTLIBSolver(const std::vector<std::string> &Argv);
+SMTSolverRef
+createSMTLIBSolver(const std::vector<std::string> &Argv,
+                   TupleEncoding TupleMode = TupleEncoding::Native);
 
 /// Same as `createSMTLIBSolver(Argv)` but also tees the emitted SMT-LIB
 /// script to OutputPath (or stdout if OutputPath is "-") for offline
 /// reproduction.
-SMTSolverRef createSMTLIBSolver(const std::vector<std::string> &Argv,
-                                const std::string &OutputPath);
+SMTSolverRef
+createSMTLIBSolver(const std::vector<std::string> &Argv,
+                   const std::string &OutputPath,
+                   TupleEncoding TupleMode = TupleEncoding::Native);
 
 } // namespace camada
 

--- a/src/camada.h
+++ b/src/camada.h
@@ -34,11 +34,43 @@
 
 namespace camada {
 
+/// Selects how Camada represents floating-point values when constructing
+/// FP/RM sorts and FP constants. The encoding is per-sort, not solver-
+/// wide — a single solver instance can hold both Native and BV-encoded
+/// FP values at the same time, and they interoperate through the
+/// common-layer encoders.
+///
+/// - Native: use the backend's native floating-point sort (`Float32Sort`
+///   in z3, `mkFloatingPoint` in cvc5, etc.). Requires native FP
+///   support in the backend; fastest path on solvers that have it.
+/// - BV: bit-blast every FP value into a fixed-width bit-vector and
+///   emulate the IEEE-754 operations through Camada's common-layer
+///   encoder. The only path available on backends without native FP
+///   (STP, Yices-SMT2) and on SMT-LIB scripts intended for solvers that
+///   reject native FP. Substantially slower than Native on backends
+///   that have both.
+///
+/// The two encodings round-trip cleanly across all five FP arithmetic
+/// ops, predicates, and conversions (the `fp_native_bv_predicate_parity`
+/// regression pins this), but model values are reported in the encoded
+/// representation — `getFP32` decodes BV back to `float`, `getBV`
+/// returns the raw bits when the sort was Native.
 enum class FPEncoding { Native, BV };
 
+/// Selects how Camada lowers `mkFPNeg` for backends whose native FP
+/// implementation diverges from the IEEE-754 sign-bit-flip semantics
+/// some users expect.
+///
+/// - FlipSignBit: always flip the IEEE-754 sign bit, including on NaN
+///   inputs. Matches the behavior of CPU FP units and most language
+///   runtimes. Backed by an explicit bit-blast on solvers whose native
+///   `fp.neg` preserves the NaN payload — see PR #59 for the per-
+///   backend status.
+/// - PreserveNaNPayload: follow the SMT-LIB `fp.neg` definition, which
+///   leaves NaN payloads (including the sign bit) unchanged. Cheaper to
+///   emit on backends that natively implement this semantics.
 enum class FPNegBehavior {
   FlipSignBit,
-  // Follows SMT-LIB FP semantics: fp.neg leaves NaNs unchanged.
   PreserveNaNPayload,
 };
 

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -345,6 +345,18 @@ SMTSortRef SMTSolverImpl::mkFP64Sort(FPEncoding Encoding) {
 
 SMTSortRef SMTSolverImpl::mkArraySort(const SMTSortRef &IndexSort,
                                       const SMTSortRef &ElemSort) {
+  // Tuple-typed array components on backends without native datatype
+  // support would route the encoded tuple's CamadaTupleSort (which has
+  // no backend sort handle) through mkArraySortImpl, where the backend
+  // would static_cast it as one of its own sorts. Reject up front. The
+  // per-field array decomposition is tracked in issue #17.
+  fatalErrorIf(IndexSort->isTupleSort() && !nativeTupleSupport(),
+               "Arrays whose index sort is a tuple are not yet supported "
+               "on this backend; see issue #17");
+  fatalErrorIf(ElemSort->isTupleSort() && !nativeTupleSupport(),
+               "Arrays whose element sort is a tuple are not yet supported "
+               "on this backend; see issue #17");
+
   ArraySortCacheKey Key{IndexSort.get(), ElemSort.get()};
   auto It = ArraySortCache.find(Key);
   if (It != ArraySortCache.end())
@@ -363,6 +375,18 @@ SMTSolverImpl::mkFunctionSort(const std::vector<SMTSortRef> &DomainSorts,
                               const SMTSortRef &CodomainSort) {
   fatalErrorIf(DomainSorts.empty(),
                "Function sort must have at least one domain sort");
+  // Tuple-typed function components on backends without native datatype
+  // support would static_cast a CamadaTupleSort as a backend sort.
+  // Reject up front; structural lowering is part of the issue #17 work.
+  if (!nativeTupleSupport()) {
+    fatalErrorIf(CodomainSort->isTupleSort(),
+                 "Functions returning tuples are not yet supported on this "
+                 "backend; see issue #17");
+    for (const auto &D : DomainSorts)
+      fatalErrorIf(D->isTupleSort(),
+                   "Functions taking tuple arguments are not yet supported "
+                   "on this backend; see issue #17");
+  }
   if (DomainSorts.size() <= 4) {
     SmallFunctionSortCacheKey SmallKey{};
     SmallKey.CodomainSort = CodomainSort.get();
@@ -1091,6 +1115,14 @@ SMTExprRef SMTSolverImpl::mkApplyImpl(const SMTExprRef &,
 SMTExprRef SMTSolverImpl::mkForall(const std::vector<SMTExprRef> &Vars,
                                    const SMTExprRef &Body) {
   requireBoolSort(Body, "Expected boolean quantifier body");
+  // Encoded tuple variables would reach the backend's mkForallImpl as a
+  // CamadaTupleExpr without a backend term, which the backend would
+  // then static_cast as one of its own expressions. Reject up front.
+  if (!nativeTupleSupport())
+    for (const auto &V : Vars)
+      fatalErrorIf(V->Sort->isTupleSort(),
+                   "Quantifiers over tuple-typed variables are not yet "
+                   "supported on this backend; see issue #17");
   SMTExprRef theExp = mkForallImpl(Vars, Body);
   assert(theExp->isBoolSort());
   return theExp;
@@ -1104,6 +1136,11 @@ SMTExprRef SMTSolverImpl::mkForallImpl(const std::vector<SMTExprRef> &,
 SMTExprRef SMTSolverImpl::mkExists(const std::vector<SMTExprRef> &Vars,
                                    const SMTExprRef &Body) {
   requireBoolSort(Body, "Expected boolean quantifier body");
+  if (!nativeTupleSupport())
+    for (const auto &V : Vars)
+      fatalErrorIf(V->Sort->isTupleSort(),
+                   "Quantifiers over tuple-typed variables are not yet "
+                   "supported on this backend; see issue #17");
   SMTExprRef theExp = mkExistsImpl(Vars, Body);
   assert(theExp->isBoolSort());
   return theExp;

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -21,6 +21,7 @@
 
 #include "camadaimpl.h"
 #include "camadacommon.h"
+#include "camadatuple.h"
 
 #include <cstdio>
 #include <limits>
@@ -400,6 +401,14 @@ SMTSolverImpl::mkFunctionSort(const std::vector<SMTSortRef> &DomainSorts,
 
 SMTSortRef
 SMTSolverImpl::mkTupleSort(const std::vector<SMTSortRef> &ElementSorts) {
+  // Route to the Camada-managed lowering for backends without native
+  // datatype support; the caches still serve identity for these (the
+  // CamadaTupleSort sits in the same SortArena as backend sorts).
+  auto Construct = [this, &ElementSorts]() {
+    return nativeTupleSupport() ? mkTupleSortImpl(ElementSorts)
+                                : mkCamadaTupleSort(*this, ElementSorts);
+  };
+
   if (ElementSorts.size() <= 4) {
     SmallTupleSortCacheKey SmallKey{};
     SmallKey.Size = static_cast<uint8_t>(ElementSorts.size());
@@ -410,7 +419,7 @@ SMTSolverImpl::mkTupleSort(const std::vector<SMTSortRef> &ElementSorts) {
     if (It != SmallTupleSortCache.end())
       return It->second;
 
-    SMTSortRef theSort = mkTupleSortImpl(ElementSorts);
+    SMTSortRef theSort = Construct();
     assert(theSort->isTupleSort());
     assert(theSort->getTupleElementSorts() == ElementSorts);
     SmallTupleSortCache.emplace(SmallKey, theSort);
@@ -425,7 +434,7 @@ SMTSolverImpl::mkTupleSort(const std::vector<SMTSortRef> &ElementSorts) {
   if (It != TupleSortCache.end())
     return It->second;
 
-  SMTSortRef theSort = mkTupleSortImpl(ElementSorts);
+  SMTSortRef theSort = Construct();
   assert(theSort->isTupleSort());
   assert(theSort->getTupleElementSorts() == ElementSorts);
   TupleSortCache.emplace(std::move(Key), theSort);
@@ -548,10 +557,18 @@ CAMADA_DEFINE_SIMPLE_BINARY_WRAPPER(SMTExprRef, mkBVSge,
                                     requireBVSameSort(LHS, RHS),
                                     mkBVSgeImpl(LHS, RHS),
                                     assert(theExp->Sort->isBoolSort()))
-CAMADA_DEFINE_SIMPLE_BINARY_WRAPPER(
-    SMTExprRef, mkEqual,
-    requireSameSort(LHS, RHS, "Expected expressions with same sort"),
-    mkEqualImpl(LHS, RHS), assert(theExp->isBoolSort()))
+SMTExprRef SMTSolverImpl::mkEqual(const SMTExprRef &LHS,
+                                  const SMTExprRef &RHS) {
+  requireSameSort(LHS, RHS, "Expected expressions with same sort");
+  // Tuple-sorted operands on backends without native datatype support
+  // route through the Camada lowering, which fans out to per-field
+  // equalities.
+  if (LHS->Sort->isTupleSort() && !nativeTupleSupport())
+    return mkCamadaTupleEqual(*this, LHS, RHS);
+  SMTExprRef theExp = mkEqualImpl(LHS, RHS);
+  assert(theExp->isBoolSort());
+  return theExp;
+}
 CAMADA_DEFINE_SIMPLE_BINARY_WRAPPER(SMTExprRef, mkImplies,
                                     requireBoolSameSort(LHS, RHS),
                                     mkImpliesImpl(LHS, RHS),
@@ -726,6 +743,11 @@ SMTExprRef SMTSolverImpl::mkIte(const SMTExprRef &Cond, const SMTExprRef &T,
                                 const SMTExprRef &F) {
   requireBoolSort(Cond, "Expected boolean condition");
   requireSameSort(T, F, "Expected ITE branches with same sort");
+  // Tuple-sorted branches on backends without native datatype support
+  // route through the Camada lowering, which builds an Ite-kind tuple
+  // node that distributes selection over its fields lazily.
+  if (T->Sort->isTupleSort() && !nativeTupleSupport())
+    return mkCamadaTupleIte(*this, Cond, T, F);
   SMTExprRef theExp = mkIteImpl(Cond, T, F);
   assert(theExp->Sort == F->Sort);
   return theExp;
@@ -1023,6 +1045,9 @@ SMTExprRef SMTSolverImpl::mkArrayStore(const SMTExprRef &Array,
 }
 
 SMTExprRef SMTSolverImpl::mkTuple(const std::vector<SMTExprRef> &Elements) {
+  if (!nativeTupleSupport())
+    return mkCamadaTuple(*this, Elements);
+
   std::vector<SMTSortRef> ElementSorts;
   ElementSorts.reserve(Elements.size());
   for (const auto &Element : Elements)
@@ -1038,6 +1063,8 @@ SMTExprRef SMTSolverImpl::mkTupleSelect(const SMTExprRef &Tuple,
   fatalErrorIf(!Tuple->Sort->isTupleSort(), "Expected tuple expression");
   fatalErrorIf(Index >= Tuple->Sort->getTupleElementSorts().size(),
                "Tuple element index is out of bounds");
+  if (!nativeTupleSupport())
+    return mkCamadaTupleSelect(*this, Tuple, Index);
   SMTExprRef theExp = mkTupleSelectImpl(Tuple, Index);
   assert(theExp->Sort == Tuple->Sort->getTupleElementSorts()[Index]);
   return theExp;
@@ -1279,10 +1306,30 @@ SMTExprRef SMTSolverImpl::mkBVFromBin(const std::string &Int) {
 
 SMTExprRef SMTSolverImpl::mkSymbol(const std::string &Name,
                                    const SMTSortRef &Sort) {
+  // The `__CAMADA_` prefix is reserved for Camada-internal symbol names
+  // (currently tuple field decompositions and FP-to-BV shadowing). User
+  // names with that prefix would alias internal symbols and silently
+  // corrupt encoded-tuple semantics; reject up front.
+  fatalErrorIf(Name.compare(0, 9, "__CAMADA_") == 0,
+               "Symbol names with the reserved __CAMADA_ prefix are not "
+               "permitted; rename the symbol");
+  return mkSymbolUnchecked(Name, Sort);
+}
+
+SMTExprRef SMTSolverImpl::mkSymbolUnchecked(const std::string &Name,
+                                            const SMTSortRef &Sort) {
   SymbolExprCacheKey Key{Sort.get(), Name};
   auto Cached = SymbolExprCache.find(Key);
   if (Cached != SymbolExprCache.end())
     return Cached->second;
+
+  // Route tuple-typed symbols to the Camada-managed lowering on backends
+  // without native datatype support.
+  if (Sort->isTupleSort() && !nativeTupleSupport()) {
+    SMTExprRef theExp = mkCamadaTupleSymbol(*this, Name, Sort);
+    SymbolExprCache.emplace(Key, theExp);
+    return theExp;
+  }
 
   SMTExprRef theExp = mkSymbolImpl(Name, Sort);
   assert(theExp->Sort == Sort);

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -58,7 +58,12 @@ public:
     HandleState->bumpGeneration();
   }
 
-protected:
+public:
+  /// Allocates an SMTExpr-derived object in the per-solver arena. Used by
+  /// every backend's *Impl methods and by camadatuple.cpp to construct
+  /// CamadaTupleExpr nodes. The first ctor argument of `SolverExpr` (and
+  /// of CamadaTupleExpr) is `SMTExprKind` so it is forwarded explicitly
+  /// rather than tucked inside ArgsV.
   template <typename SolverExpr, typename... Args>
   SMTExprRef makeExprRef(SMTExprKind Kind, Args &&...ArgsV) {
     auto *Exp =
@@ -67,36 +72,12 @@ protected:
     return SMTExprRef(Exp, HandleState, HandleState->Generation);
   }
 
+  /// Allocates an SMTSort-derived object in the per-solver arena. Same
+  /// shape as makeExprRef but takes the sort by value (each backend's
+  /// SolverSort is cheap to construct in place at the call site).
   template <typename SolverSort> SMTSortRef makeSortRef(SolverSort Sort) {
     auto *OwnedSort = SortArena.create<SolverSort>(std::move(Sort));
     assert(OwnedSort->validateSortWidth());
-#ifndef NDEBUG
-    OwnedSort->markWidthValidated();
-#endif
-    return SMTSortRef(OwnedSort, HandleState, HandleState->Generation);
-  }
-
-public:
-  /// Allocates a Camada-managed (non-SolverExpr) expression in the arena.
-  /// Used by camadatuple.cpp to construct CamadaTupleExpr nodes that have
-  /// no backend term. Public so the free functions in camadatuple.cpp can
-  /// reach it; not part of the SMTSolver public surface.
-  template <typename ExprT, typename... Args>
-  SMTExprRef makeCamadaExprRef(Args &&...ArgsV) {
-    auto *Exp = ExprArena.create<ExprT>(std::forward<Args>(ArgsV)...);
-#ifndef NDEBUG
-    // Camada-managed exprs (currently only CamadaTupleExpr) live above
-    // the backend's width contract — width validation does not apply.
-    if (!Exp->Sort->isTupleSort())
-      assert(Exp->Sort->isWidthValidated());
-#endif
-    return SMTExprRef(Exp, HandleState, HandleState->Generation);
-  }
-
-  /// Counterpart to makeCamadaExprRef for sorts.
-  template <typename SortT, typename... Args>
-  SMTSortRef makeCamadaSortRef(Args &&...ArgsV) {
-    auto *OwnedSort = SortArena.create<SortT>(std::forward<Args>(ArgsV)...);
 #ifndef NDEBUG
     OwnedSort->markWidthValidated();
 #endif

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -76,6 +76,40 @@ protected:
     return SMTSortRef(OwnedSort, HandleState, HandleState->Generation);
   }
 
+public:
+  /// Allocates a Camada-managed (non-SolverExpr) expression in the arena.
+  /// Used by camadatuple.cpp to construct CamadaTupleExpr nodes that have
+  /// no backend term. Public so the free functions in camadatuple.cpp can
+  /// reach it; not part of the SMTSolver public surface.
+  template <typename ExprT, typename... Args>
+  SMTExprRef makeCamadaExprRef(Args &&...ArgsV) {
+    auto *Exp = ExprArena.create<ExprT>(std::forward<Args>(ArgsV)...);
+#ifndef NDEBUG
+    // Camada-managed exprs (currently only CamadaTupleExpr) live above
+    // the backend's width contract — width validation does not apply.
+    if (!Exp->Sort->isTupleSort())
+      assert(Exp->Sort->isWidthValidated());
+#endif
+    return SMTExprRef(Exp, HandleState, HandleState->Generation);
+  }
+
+  /// Counterpart to makeCamadaExprRef for sorts.
+  template <typename SortT, typename... Args>
+  SMTSortRef makeCamadaSortRef(Args &&...ArgsV) {
+    auto *OwnedSort = SortArena.create<SortT>(std::forward<Args>(ArgsV)...);
+#ifndef NDEBUG
+    OwnedSort->markWidthValidated();
+#endif
+    return SMTSortRef(OwnedSort, HandleState, HandleState->Generation);
+  }
+
+  /// mkSymbol variant that bypasses the user-name validation. Used by
+  /// internal lowerings (Camada tuple field decomposition, STP array
+  /// extensionality, FP-to-BV shadowing) that mint symbols with the
+  /// reserved __CAMADA_ prefix.
+  SMTExprRef mkSymbolUnchecked(const std::string &Name, const SMTSortRef &Sort);
+
+protected:
   void invalidateGeneratedObjects();
   void clearSortCaches();
   void clearExprCaches();
@@ -383,6 +417,12 @@ protected:
                                         const SMTSortRef &);
 
   virtual SMTSortRef mkTupleSortImpl(const std::vector<SMTSortRef> &);
+
+  /// Backends that natively support SMT-LIB datatypes (z3, cvc5, smtlib)
+  /// override this to true. Other backends (bitwuzla, mathsat, stp,
+  /// yices) inherit the default false and route tuple operations through
+  /// the Camada-managed lowering in camadatuple.cpp.
+  virtual bool nativeTupleSupport() const { return false; }
 
   virtual void addConstraintImpl(const SMTExprRef &Exp) = 0;
 

--- a/src/camadatuple.cpp
+++ b/src/camadatuple.cpp
@@ -62,41 +62,42 @@ private:
   SMTBackendKind BackendKind;
 };
 
-/// Tuple expression owned by the Camada layer. One of three node kinds:
-///   - Symbol: lazy — per-field symbols are minted on demand by mkTupleSelect
-///   - Value: eager — components are stored verbatim
-///   - Ite: lazy — distributes over fields when selected
+/// Tuple expression owned by the Camada layer. The SMTExpr::Kind
+/// discriminates between three shapes (Symbol / TupleConst / Ite) — no
+/// separate NodeKind is needed:
+///   - SMTExprKind::Symbol: lazy — per-field symbols minted on demand by
+///     mkTupleSelect
+///   - SMTExprKind::TupleConst: eager — components stored verbatim
+///   - SMTExprKind::Ite: lazy — distributes over fields when selected
 class CamadaTupleExpr : public SMTExpr {
 public:
-  enum class NodeKind { Symbol, Value, Ite };
+  // Symbol form (SMTExprKind::Symbol)
+  CamadaTupleExpr(SMTExprKind ExprKind, SMTBackendKind BackendKind,
+                  const SMTSortRef &Sort, std::string SymbolName)
+      : SMTExpr(ExprKind, Sort), SymbolName(std::move(SymbolName)),
+        BackendKind(BackendKind) {}
 
-  // Symbol form
-  CamadaTupleExpr(SMTBackendKind BackendKind, const SMTSortRef &Sort,
-                  std::string SymbolName)
-      : SMTExpr(SMTExprKind::Symbol, Sort), Kind(NodeKind::Symbol),
-        SymbolName(std::move(SymbolName)), BackendKind(BackendKind) {}
+  // Value form (SMTExprKind::TupleConst)
+  CamadaTupleExpr(SMTExprKind ExprKind, SMTBackendKind BackendKind,
+                  const SMTSortRef &Sort, std::vector<SMTExprRef> Elements)
+      : SMTExpr(ExprKind, Sort), Elements(std::move(Elements)),
+        BackendKind(BackendKind) {}
 
-  // Value form
-  CamadaTupleExpr(SMTBackendKind BackendKind, const SMTSortRef &Sort,
-                  std::vector<SMTExprRef> Elements)
-      : SMTExpr(SMTExprKind::TupleConst, Sort), Kind(NodeKind::Value),
-        Elements(std::move(Elements)), BackendKind(BackendKind) {}
-
-  // Ite form
-  CamadaTupleExpr(SMTBackendKind BackendKind, const SMTSortRef &Sort,
-                  SMTExprRef Cond, SMTExprRef T, SMTExprRef F)
-      : SMTExpr(SMTExprKind::Ite, Sort), Kind(NodeKind::Ite),
-        Cond(std::move(Cond)), TrueTuple(std::move(T)),
+  // Ite form (SMTExprKind::Ite)
+  CamadaTupleExpr(SMTExprKind ExprKind, SMTBackendKind BackendKind,
+                  const SMTSortRef &Sort, SMTExprRef Cond, SMTExprRef T,
+                  SMTExprRef F)
+      : SMTExpr(ExprKind, Sort), Cond(std::move(Cond)), TrueTuple(std::move(T)),
         FalseTuple(std::move(F)), BackendKind(BackendKind) {}
 
   SMTBackendKind getBackendKind() const override { return BackendKind; }
 
   void dump(std::string &Out) const override {
-    switch (Kind) {
-    case NodeKind::Symbol:
+    switch (getKind()) {
+    case SMTExprKind::Symbol:
       Out = "(CamadaTupleSymbol " + SymbolName + ")\n";
       return;
-    case NodeKind::Value: {
+    case SMTExprKind::TupleConst: {
       Out = "(CamadaTupleValue";
       for (const auto &E : Elements) {
         Out += " ";
@@ -109,14 +110,14 @@ public:
       Out += ")\n";
       return;
     }
-    case NodeKind::Ite:
+    case SMTExprKind::Ite:
       Out = "(CamadaTupleIte ...)\n";
       return;
+    default:
+      fatalError("Invalid CamadaTupleExpr SMTExprKind");
     }
-    fatalError("Invalid CamadaTupleExpr NodeKind");
   }
 
-  NodeKind Kind;
   std::string SymbolName;
   std::vector<SMTExprRef> Elements;
   SMTExprRef Cond;
@@ -149,15 +150,15 @@ SMTSortRef mkCamadaTupleSort(SMTSolverImpl &Solver,
   SMTBackendKind BackendKind = ElementSorts.empty()
                                    ? Solver.mkBoolSort()->getBackendKind()
                                    : ElementSorts.front()->getBackendKind();
-  return Solver.makeCamadaSortRef<CamadaTupleSort>(BackendKind, ElementSorts);
+  return Solver.makeSortRef(CamadaTupleSort(BackendKind, ElementSorts));
 }
 
 SMTExprRef mkCamadaTupleSymbol(SMTSolverImpl &Solver, const std::string &Name,
                                const SMTSortRef &Sort) {
   fatalErrorIf(!Sort->isTupleSort(),
                "mkCamadaTupleSymbol called on non-tuple sort");
-  return Solver.makeCamadaExprRef<CamadaTupleExpr>(Sort->getBackendKind(), Sort,
-                                                   Name);
+  return Solver.makeExprRef<CamadaTupleExpr>(
+      SMTExprKind::Symbol, Sort->getBackendKind(), Sort, Name);
 }
 
 SMTExprRef mkCamadaTuple(SMTSolverImpl &Solver,
@@ -167,8 +168,8 @@ SMTExprRef mkCamadaTuple(SMTSolverImpl &Solver,
   for (const auto &E : Elements)
     ElementSorts.push_back(E->Sort);
   SMTSortRef Sort = Solver.mkTupleSort(ElementSorts);
-  return Solver.makeCamadaExprRef<CamadaTupleExpr>(Sort->getBackendKind(), Sort,
-                                                   Elements);
+  return Solver.makeExprRef<CamadaTupleExpr>(
+      SMTExprKind::TupleConst, Sort->getBackendKind(), Sort, Elements);
 }
 
 SMTExprRef mkCamadaTupleSelect(SMTSolverImpl &Solver, const SMTExprRef &Tuple,
@@ -180,22 +181,23 @@ SMTExprRef mkCamadaTupleSelect(SMTSolverImpl &Solver, const SMTExprRef &Tuple,
                "Tuple field index out of bounds");
 
   const SMTSortRef &FieldSort = Tuple->Sort->getTupleElementSorts()[Index];
-  switch (TE->Kind) {
-  case CamadaTupleExpr::NodeKind::Symbol: {
+  switch (TE->getKind()) {
+  case SMTExprKind::Symbol: {
     // Synthesize a per-field symbol on demand. The reserved __CAMADA_tup_
     // name space prevents collisions with user-supplied symbol names.
     std::string FieldName =
         "__CAMADA_tup_" + TE->SymbolName + "_" + std::to_string(Index);
     return Solver.mkSymbolUnchecked(FieldName, FieldSort);
   }
-  case CamadaTupleExpr::NodeKind::Value:
+  case SMTExprKind::TupleConst:
     return TE->Elements[Index];
-  case CamadaTupleExpr::NodeKind::Ite:
+  case SMTExprKind::Ite:
     return Solver.mkIte(TE->Cond,
                         mkCamadaTupleSelect(Solver, TE->TrueTuple, Index),
                         mkCamadaTupleSelect(Solver, TE->FalseTuple, Index));
+  default:
+    fatalError("Invalid CamadaTupleExpr SMTExprKind");
   }
-  fatalError("Invalid CamadaTupleExpr NodeKind");
 }
 
 SMTExprRef mkCamadaTupleEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
@@ -220,8 +222,8 @@ SMTExprRef mkCamadaTupleIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
                             const SMTExprRef &T, const SMTExprRef &F) {
   fatalErrorIf(!T->Sort->isTupleSort() || !F->Sort->isTupleSort(),
                "mkCamadaTupleIte on non-tuple branches");
-  return Solver.makeCamadaExprRef<CamadaTupleExpr>(T->getBackendKind(), T->Sort,
-                                                   Cond, T, F);
+  return Solver.makeExprRef<CamadaTupleExpr>(
+      SMTExprKind::Ite, T->getBackendKind(), T->Sort, Cond, T, F);
 }
 
 } // namespace camada

--- a/src/camadatuple.cpp
+++ b/src/camadatuple.cpp
@@ -125,10 +125,37 @@ public:
   SMTExprRef FalseTuple;
 
 protected:
-  // Camada-managed tuple expressions have no shared backend identity; two
-  // freshly built nodes are equal iff they are the same object. Semantic
-  // equality must go through mkCamadaTupleEqual.
-  bool equal_to(SMTExpr const &Other) const override { return this == &Other; }
+  // Structural host-side equality. Two freshly built nodes compare equal
+  // when they describe the same tuple shape with components that
+  // themselves compare equal via SMTExpr::operator== — symbol vs symbol
+  // matches on name; value vs value recursively compares the field
+  // vector; ite vs ite recursively compares cond + branches. This is
+  // host-side AST equality only; SMT-level satisfaction equality goes
+  // through mkCamadaTupleEqual, which decomposes into per-field
+  // mkEqual + mkAnd.
+  bool equal_to(SMTExpr const &Other) const override {
+    if (Sort != Other.Sort || Other.getBackendKind() != getBackendKind() ||
+        getKind() != Other.getKind())
+      return false;
+    auto const &Rhs = static_cast<const CamadaTupleExpr &>(Other);
+    switch (getKind()) {
+    case SMTExprKind::Symbol:
+      return SymbolName == Rhs.SymbolName;
+    case SMTExprKind::TupleConst: {
+      if (Elements.size() != Rhs.Elements.size())
+        return false;
+      for (std::size_t I = 0; I < Elements.size(); ++I)
+        if (!(*Elements[I] == *Rhs.Elements[I]))
+          return false;
+      return true;
+    }
+    case SMTExprKind::Ite:
+      return *Cond == *Rhs.Cond && *TrueTuple == *Rhs.TrueTuple &&
+             *FalseTuple == *Rhs.FalseTuple;
+    default:
+      return false;
+    }
+  }
 
 private:
   SMTBackendKind BackendKind;

--- a/src/camadatuple.cpp
+++ b/src/camadatuple.cpp
@@ -1,0 +1,227 @@
+/**************************************************************************
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ **************************************************************************/
+
+#include "camadatuple.h"
+
+#include "camadacommon.h"
+#include "camadaimpl.h"
+
+#include <utility>
+
+namespace camada {
+
+namespace {
+
+/// Tuple sort owned by the Camada layer rather than any backend. Used by
+/// the encoding for backends without native datatype support.
+class CamadaTupleSort : public SMTSort {
+public:
+  CamadaTupleSort(SMTBackendKind BackendKind,
+                  const std::vector<SMTSortRef> &ElementSorts)
+      : SMTSort(SMTSortKind::Tuple, TupleSortData{ElementSorts}),
+        BackendKind(BackendKind) {}
+
+  SMTBackendKind getBackendKind() const override { return BackendKind; }
+
+  unsigned getWidthFromSolver() const override {
+    fatalError("Width query on Camada-managed tuple sort");
+  }
+
+  void dump(std::string &Out) const override {
+    Out = "(CamadaTuple";
+    for (const auto &E : getTupleElementSorts()) {
+      Out += " ";
+      std::string ElemOut;
+      E->dump(ElemOut);
+      if (!ElemOut.empty() && ElemOut.back() == '\n')
+        ElemOut.pop_back();
+      Out += ElemOut;
+    }
+    Out += ")\n";
+  }
+
+private:
+  SMTBackendKind BackendKind;
+};
+
+/// Tuple expression owned by the Camada layer. One of three node kinds:
+///   - Symbol: lazy — per-field symbols are minted on demand by mkTupleSelect
+///   - Value: eager — components are stored verbatim
+///   - Ite: lazy — distributes over fields when selected
+class CamadaTupleExpr : public SMTExpr {
+public:
+  enum class NodeKind { Symbol, Value, Ite };
+
+  // Symbol form
+  CamadaTupleExpr(SMTBackendKind BackendKind, const SMTSortRef &Sort,
+                  std::string SymbolName)
+      : SMTExpr(SMTExprKind::Symbol, Sort), Kind(NodeKind::Symbol),
+        SymbolName(std::move(SymbolName)), BackendKind(BackendKind) {}
+
+  // Value form
+  CamadaTupleExpr(SMTBackendKind BackendKind, const SMTSortRef &Sort,
+                  std::vector<SMTExprRef> Elements)
+      : SMTExpr(SMTExprKind::TupleConst, Sort), Kind(NodeKind::Value),
+        Elements(std::move(Elements)), BackendKind(BackendKind) {}
+
+  // Ite form
+  CamadaTupleExpr(SMTBackendKind BackendKind, const SMTSortRef &Sort,
+                  SMTExprRef Cond, SMTExprRef T, SMTExprRef F)
+      : SMTExpr(SMTExprKind::Ite, Sort), Kind(NodeKind::Ite),
+        Cond(std::move(Cond)), TrueTuple(std::move(T)),
+        FalseTuple(std::move(F)), BackendKind(BackendKind) {}
+
+  SMTBackendKind getBackendKind() const override { return BackendKind; }
+
+  void dump(std::string &Out) const override {
+    switch (Kind) {
+    case NodeKind::Symbol:
+      Out = "(CamadaTupleSymbol " + SymbolName + ")\n";
+      return;
+    case NodeKind::Value: {
+      Out = "(CamadaTupleValue";
+      for (const auto &E : Elements) {
+        Out += " ";
+        std::string ElemOut;
+        E->dump(ElemOut);
+        if (!ElemOut.empty() && ElemOut.back() == '\n')
+          ElemOut.pop_back();
+        Out += ElemOut;
+      }
+      Out += ")\n";
+      return;
+    }
+    case NodeKind::Ite:
+      Out = "(CamadaTupleIte ...)\n";
+      return;
+    }
+    fatalError("Invalid CamadaTupleExpr NodeKind");
+  }
+
+  NodeKind Kind;
+  std::string SymbolName;
+  std::vector<SMTExprRef> Elements;
+  SMTExprRef Cond;
+  SMTExprRef TrueTuple;
+  SMTExprRef FalseTuple;
+
+protected:
+  // Camada-managed tuple expressions have no shared backend identity; two
+  // freshly built nodes are equal iff they are the same object. Semantic
+  // equality must go through mkCamadaTupleEqual.
+  bool equal_to(SMTExpr const &Other) const override { return this == &Other; }
+
+private:
+  SMTBackendKind BackendKind;
+};
+
+const CamadaTupleExpr *toCamadaTupleExpr(const SMTExprRef &Exp) {
+  if (!Exp || !Exp->Sort->isTupleSort())
+    return nullptr;
+  return dynamic_cast<const CamadaTupleExpr *>(Exp.get());
+}
+
+} // namespace
+
+SMTSortRef mkCamadaTupleSort(SMTSolverImpl &Solver,
+                             const std::vector<SMTSortRef> &ElementSorts) {
+  // Pick the backend kind from the first element when available; for
+  // empty tuples, the bool sort gives us the same backend kind without
+  // needing a dedicated solver-level accessor.
+  SMTBackendKind BackendKind = ElementSorts.empty()
+                                   ? Solver.mkBoolSort()->getBackendKind()
+                                   : ElementSorts.front()->getBackendKind();
+  return Solver.makeCamadaSortRef<CamadaTupleSort>(BackendKind, ElementSorts);
+}
+
+SMTExprRef mkCamadaTupleSymbol(SMTSolverImpl &Solver, const std::string &Name,
+                               const SMTSortRef &Sort) {
+  fatalErrorIf(!Sort->isTupleSort(),
+               "mkCamadaTupleSymbol called on non-tuple sort");
+  return Solver.makeCamadaExprRef<CamadaTupleExpr>(Sort->getBackendKind(), Sort,
+                                                   Name);
+}
+
+SMTExprRef mkCamadaTuple(SMTSolverImpl &Solver,
+                         const std::vector<SMTExprRef> &Elements) {
+  std::vector<SMTSortRef> ElementSorts;
+  ElementSorts.reserve(Elements.size());
+  for (const auto &E : Elements)
+    ElementSorts.push_back(E->Sort);
+  SMTSortRef Sort = Solver.mkTupleSort(ElementSorts);
+  return Solver.makeCamadaExprRef<CamadaTupleExpr>(Sort->getBackendKind(), Sort,
+                                                   Elements);
+}
+
+SMTExprRef mkCamadaTupleSelect(SMTSolverImpl &Solver, const SMTExprRef &Tuple,
+                               unsigned Index) {
+  const CamadaTupleExpr *TE = toCamadaTupleExpr(Tuple);
+  fatalErrorIf(TE == nullptr,
+               "mkCamadaTupleSelect on non-Camada-tuple expression");
+  fatalErrorIf(Index >= Tuple->Sort->getTupleElementSorts().size(),
+               "Tuple field index out of bounds");
+
+  const SMTSortRef &FieldSort = Tuple->Sort->getTupleElementSorts()[Index];
+  switch (TE->Kind) {
+  case CamadaTupleExpr::NodeKind::Symbol: {
+    // Synthesize a per-field symbol on demand. The reserved __CAMADA_tup_
+    // name space prevents collisions with user-supplied symbol names.
+    std::string FieldName =
+        "__CAMADA_tup_" + TE->SymbolName + "_" + std::to_string(Index);
+    return Solver.mkSymbolUnchecked(FieldName, FieldSort);
+  }
+  case CamadaTupleExpr::NodeKind::Value:
+    return TE->Elements[Index];
+  case CamadaTupleExpr::NodeKind::Ite:
+    return Solver.mkIte(TE->Cond,
+                        mkCamadaTupleSelect(Solver, TE->TrueTuple, Index),
+                        mkCamadaTupleSelect(Solver, TE->FalseTuple, Index));
+  }
+  fatalError("Invalid CamadaTupleExpr NodeKind");
+}
+
+SMTExprRef mkCamadaTupleEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
+                              const SMTExprRef &RHS) {
+  fatalErrorIf(!LHS->Sort->isTupleSort() || !RHS->Sort->isTupleSort(),
+               "mkCamadaTupleEqual on non-tuple operands");
+  fatalErrorIf(LHS->Sort != RHS->Sort,
+               "mkCamadaTupleEqual on tuples of different sorts");
+  const auto &Fields = LHS->Sort->getTupleElementSorts();
+  if (Fields.empty())
+    return Solver.mkBool(true);
+  SMTExprRef Acc = Solver.mkEqual(mkCamadaTupleSelect(Solver, LHS, 0),
+                                  mkCamadaTupleSelect(Solver, RHS, 0));
+  for (unsigned I = 1; I < Fields.size(); ++I)
+    Acc =
+        Solver.mkAnd(Acc, Solver.mkEqual(mkCamadaTupleSelect(Solver, LHS, I),
+                                         mkCamadaTupleSelect(Solver, RHS, I)));
+  return Acc;
+}
+
+SMTExprRef mkCamadaTupleIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
+                            const SMTExprRef &T, const SMTExprRef &F) {
+  fatalErrorIf(!T->Sort->isTupleSort() || !F->Sort->isTupleSort(),
+               "mkCamadaTupleIte on non-tuple branches");
+  return Solver.makeCamadaExprRef<CamadaTupleExpr>(T->getBackendKind(), T->Sort,
+                                                   Cond, T, F);
+}
+
+} // namespace camada

--- a/src/camadatuple.h
+++ b/src/camadatuple.h
@@ -1,0 +1,63 @@
+/**************************************************************************
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ **************************************************************************/
+
+#ifndef CAMADATUPLE_H_
+#define CAMADATUPLE_H_
+
+#include "camada.h"
+
+#include <string>
+#include <vector>
+
+namespace camada {
+
+class SMTSolverImpl;
+
+/// Camada-managed tuple lowering for backends without native datatype
+/// support (bitwuzla, mathsat, stp, yices). Tuples are represented as
+/// dedicated SMTSort/SMTExpr classes (no backend term), and operations
+/// are decomposed into per-field operations against the backend's BV/
+/// Bool/array machinery.
+///
+/// Native-tuple backends (z3, cvc5, smtlib) are unaffected; SMTSolverImpl
+/// dispatches here only when nativeTupleSupport() is false.
+
+SMTSortRef mkCamadaTupleSort(SMTSolverImpl &Solver,
+                             const std::vector<SMTSortRef> &ElementSorts);
+
+SMTExprRef mkCamadaTupleSymbol(SMTSolverImpl &Solver, const std::string &Name,
+                               const SMTSortRef &Sort);
+
+SMTExprRef mkCamadaTuple(SMTSolverImpl &Solver,
+                         const std::vector<SMTExprRef> &Elements);
+
+SMTExprRef mkCamadaTupleSelect(SMTSolverImpl &Solver, const SMTExprRef &Tuple,
+                               unsigned Index);
+
+SMTExprRef mkCamadaTupleEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
+                              const SMTExprRef &RHS);
+
+SMTExprRef mkCamadaTupleIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
+                            const SMTExprRef &T, const SMTExprRef &F);
+
+} // namespace camada
+
+#endif

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -1102,7 +1102,7 @@ SMTExprRef CVC5Solver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
   const SMTSortRef &to =
       mkFPSort(Exp->Sort->getFPExponentWidth(),
                Exp->Sort->getFPSignificandWidth(), FPEncoding::BV);
-  const SMTExprRef &newSymbol = mkSymbol(name, to);
+  const SMTExprRef &newSymbol = mkSymbolUnchecked(name, to);
 
   // and constraint it to be the conversion of the fp, since
   // (fp_matches_bv f bv) <-> (= f ((_ to_fp E S) bv))

--- a/src/cvc5solver.h
+++ b/src/cvc5solver.h
@@ -106,6 +106,8 @@ protected:
   SMTSortRef
   mkTupleSortImpl(const std::vector<SMTSortRef> &ElementSorts) override;
 
+  bool nativeTupleSupport() const override { return true; }
+
   SMTExprRef mkBVNegImpl(const SMTExprRef &Exp) override;
 
   SMTExprRef mkBVNotImpl(const SMTExprRef &Exp) override;

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -548,24 +548,27 @@ const std::string &textOf(const SMTSortRef &S) {
 
 } // namespace
 
-SMTLIBSolver::SMTLIBSolver(const std::string &OutputPath)
-    : File(std::make_unique<FileEmitter>(OutputPath)) {
-  emitPreamble();
-  initializeCommonSingletons();
-}
-
-SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
-                           const std::vector<std::string> &Argv)
-    : Proc(std::make_unique<ProcessEmitter>(Argv)) {
+SMTLIBSolver::SMTLIBSolver(const std::string &OutputPath,
+                           TupleEncoding TupleMode)
+    : File(std::make_unique<FileEmitter>(OutputPath)), TupleMode(TupleMode) {
   emitPreamble();
   initializeCommonSingletons();
 }
 
 SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
                            const std::vector<std::string> &Argv,
-                           const std::string &OutputPath)
+                           TupleEncoding TupleMode)
+    : Proc(std::make_unique<ProcessEmitter>(Argv)), TupleMode(TupleMode) {
+  emitPreamble();
+  initializeCommonSingletons();
+}
+
+SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
+                           const std::vector<std::string> &Argv,
+                           const std::string &OutputPath,
+                           TupleEncoding TupleMode)
     : File(std::make_unique<FileEmitter>(OutputPath)),
-      Proc(std::make_unique<ProcessEmitter>(Argv)) {
+      Proc(std::make_unique<ProcessEmitter>(Argv)), TupleMode(TupleMode) {
   emitPreamble();
   initializeCommonSingletons();
 }
@@ -1205,7 +1208,7 @@ SMTExprRef SMTLIBSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
   const std::string Name = "__CAMADA_ieeebv" + std::to_string(NextIEEEBVId++);
   SMTSortRef BVSort = mkBVSort(Exp->Sort->getFPExponentWidth() +
                                Exp->Sort->getFPSignificandWidth() + 1);
-  SMTExprRef NewSymbol = mkSymbol(Name, BVSort);
+  SMTExprRef NewSymbol = mkSymbolUnchecked(Name, BVSort);
   addConstraint(mkEqual(Exp, mkBVToIEEEFP(NewSymbol, Exp->Sort)));
   return NewSymbol;
 }

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -161,7 +161,10 @@ class SMTLIBSolver : public SMTSolverImpl {
 public:
   /// Write-only constructor: write the emitted SMT-LIB script to OutputPath.
   /// Pass "-" for stdout. check() returns UNKNOWN; get* queries error.
-  explicit SMTLIBSolver(const std::string &OutputPath);
+  /// `TupleMode` selects how tuples are lowered on the wire — see the
+  /// docstring on TupleEncoding.
+  explicit SMTLIBSolver(const std::string &OutputPath,
+                        TupleEncoding TupleMode = TupleEncoding::Native);
 
   /// Interactive constructor: spawn a child solver via
   /// `execvp(Argv[0], Argv)`. The solver must speak standard SMT-LIB on
@@ -169,13 +172,15 @@ public:
   /// through the child. No shell is involved — argv entries are passed
   /// verbatim, so spaces, quotes, and other metacharacters in any entry
   /// carry no special meaning.
-  SMTLIBSolver(SMTLIBProcessTag, const std::vector<std::string> &Argv);
+  SMTLIBSolver(SMTLIBProcessTag, const std::vector<std::string> &Argv,
+               TupleEncoding TupleMode = TupleEncoding::Native);
 
   /// Combined constructor: spawn a child solver via execvp *and* log the
   /// script to a file. Useful when you want both an interactive answer
   /// and a reproducer to hand to another tool.
   SMTLIBSolver(SMTLIBProcessTag, const std::vector<std::string> &Argv,
-               const std::string &OutputPath);
+               const std::string &OutputPath,
+               TupleEncoding TupleMode = TupleEncoding::Native);
 
   ~SMTLIBSolver() override;
 
@@ -201,6 +206,10 @@ protected:
                                 const SMTSortRef &CodomainSort) override;
   SMTSortRef
   mkTupleSortImpl(const std::vector<SMTSortRef> &ElementSorts) override;
+
+  bool nativeTupleSupport() const override {
+    return TupleMode == TupleEncoding::Native;
+  }
 
   // --- expressions ---
   SMTExprRef mkBVNegImpl(const SMTExprRef &Exp) override;
@@ -386,6 +395,11 @@ private:
 
   std::unique_ptr<FileEmitter> File;
   std::unique_ptr<ProcessEmitter> Proc;
+
+  // Tuple lowering mode: Native emits (declare-datatypes ...) on the
+  // wire; Camada decomposes tuples into per-field BV/Bool symbols before
+  // anything reaches the wire. Default is Native.
+  TupleEncoding TupleMode = TupleEncoding::Native;
 
   // Counter for fresh symbols introduced by mkIEEEFPToBVImpl. SMT-LIB has no
   // portable fp→bv same-encoding op, so we materialize a fresh BV symbol

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -386,7 +386,8 @@ SMTExprRef STPSolver::mkEqualImpl(const SMTExprRef &LHS,
     // variable
     const std::string name =
         "__CAMADA_index" + std::to_string(ConstArrayCounter++);
-    const SMTExprRef &index = mkSymbol(name, LHS->Sort->getIndexSort());
+    const SMTExprRef &index =
+        mkSymbolUnchecked(name, LHS->Sort->getIndexSort());
 
     // and do select(A,i) == select(B,i)
     return mkEqual(mkArraySelect(LHS, index), mkArraySelect(RHS, index));
@@ -569,7 +570,8 @@ SMTExprRef STPSolver::mkSymbolImpl(const std::string &Name,
 SMTExprRef STPSolver::mkArrayConstImpl(const SMTSortRef &IndexSort,
                                        const SMTExprRef &InitValue) {
   const std::string name = "__CAMADA_arr" + std::to_string(ConstArrayCounter++);
-  SMTExprRef arr = mkSymbol(name, mkArraySort(IndexSort, InitValue->Sort));
+  SMTExprRef arr =
+      mkSymbolUnchecked(name, mkArraySort(IndexSort, InitValue->Sort));
 
   const unsigned width = IndexSort->getWidth();
   if (width >= 64)

--- a/src/z3solver.h
+++ b/src/z3solver.h
@@ -110,6 +110,8 @@ protected:
   SMTSortRef
   mkTupleSortImpl(const std::vector<SMTSortRef> &ElementSorts) override;
 
+  bool nativeTupleSupport() const override { return true; }
+
   SMTExprRef mkBVNegImpl(const SMTExprRef &Exp) override;
 
   SMTExprRef mkBVNotImpl(const SMTExprRef &Exp) override;


### PR DESCRIPTION
## Summary

Closes #16. Bitwuzla, MathSAT, STP, and Yices gain tuple support via a Camada-side encoding layer; the SMT-LIB backend gains a `TupleEncoding` knob so users can opt into the same lowering when their downstream solver doesn't accept `(declare-datatypes ...)`.

- New `src/camadatuple.{h,cpp}` (~290 lines): `CamadaTupleSort` and `CamadaTupleExpr` inherit directly from `SMTSort` / `SMTExpr`, no backend term, no placeholder. Three node kinds — Symbol (lazy field synthesis), Value (eager components), Ite (lazy distribution).
- `SMTSolverImpl::nativeTupleSupport()` virtual gates routing. Default `false`; z3/cvc5 override `true`. SMT-LIB returns the value of its `TupleEncoding` constructor knob.
- `mkSymbol` rejects user names with the reserved `__CAMADA_` prefix; internal callers (STP array extensionality, FP-to-BV shadowing, tuple field names) use the new `mkSymbolUnchecked`.

## SMT-LIB backend

```cpp
auto solver = camada::createSMTLIBSolver({"z3", "-in"}); // default: Native
auto solver2 = camada::createSMTLIBSolver(
    {"bitwuzla"}, camada::TupleEncoding::Camada); // BV/Bool only on the wire
```

## Test plan

- [x] `cmake --build build -j32` clean
- [x] `ctest -j16` reports 141/141 passing (up from 129; +12 SMT-LIB pipeline tuple tests)
- [x] Bool+BV `tuple_semantics` runs on every backend via `tests(solver)`
- [x] `tuple_semantics_with_int` runs only on z3/cvc5
- [x] SMT-LIB pipeline tuple tests cover both encodings on z3/cvc5; Camada-only on bitwuzla/mathsat/yices

🤖 Generated with [Claude Code](https://claude.com/claude-code)