### PR TITLE
Reformulate BV fp.rem with modular arithmetic, fixing a subnormal-divisor bug

### DIFF
--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -20,12 +20,13 @@ TEST_CASE("Simple Bitwuzla test", "[Bitwuzla]") {
 TEST_CASE("FP remainder randomized host oracle Bitwuzla", "[Bitwuzla]") {
   auto solver = camada::createBitwuzlaSolver();
 
-  std::mt19937 Rng(0xCA3ADAu);
-  std::uniform_int_distribution<uint32_t> Bits32;
-  std::uniform_int_distribution<uint64_t> Bits64;
+  // Raw mt19937 outputs are fully specified by the standard, so the sweep is
+  // bit-identical across standard libraries.
+  std::mt19937 Rng32(0xCA3ADAu);
+  std::mt19937_64 Rng64(0xCA3ADAu);
 
   for (int I = 0; I < 200; ++I) {
-    uint32_t XB = Bits32(Rng), YB = Bits32(Rng);
+    uint32_t XB = Rng32(), YB = Rng32();
     float X, Y;
     std::memcpy(&X, &XB, sizeof(X));
     std::memcpy(&Y, &YB, sizeof(Y));
@@ -33,7 +34,7 @@ TEST_CASE("FP remainder randomized host oracle Bitwuzla", "[Bitwuzla]") {
   }
 
   for (int I = 0; I < 25; ++I) {
-    uint64_t XB = Bits64(Rng), YB = Bits64(Rng);
+    uint64_t XB = Rng64(), YB = Rng64();
     double X, Y;
     std::memcpy(&X, &XB, sizeof(X));
     std::memcpy(&Y, &YB, sizeof(Y));

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -6,10 +6,39 @@
 
 #include <bitwuzlasolver.h>
 #include <catch2/catch_test_macros.hpp>
+#include <cstring>
+#include <random>
 
 TEST_CASE("Simple Bitwuzla test", "[Bitwuzla]") {
   auto bitwuzla = camada::createBitwuzlaSolver();
   tests(bitwuzla);
+}
+
+// Randomized cross-check of the BV-encoded fp.rem against the host CPU,
+// which computes IEEE-754 remainder exactly. Full-bit-pattern inputs cover
+// NaN/inf/subnormal operands; the seed is fixed for reproducibility.
+TEST_CASE("FP remainder randomized host oracle Bitwuzla", "[Bitwuzla]") {
+  auto solver = camada::createBitwuzlaSolver();
+
+  std::mt19937 Rng(0xCA3ADAu);
+  std::uniform_int_distribution<uint32_t> Bits32;
+  std::uniform_int_distribution<uint64_t> Bits64;
+
+  for (int I = 0; I < 200; ++I) {
+    uint32_t XB = Bits32(Rng), YB = Bits32(Rng);
+    float X, Y;
+    std::memcpy(&X, &XB, sizeof(X));
+    std::memcpy(&Y, &YB, sizeof(Y));
+    check_rem_pair_f32(solver, camada::FPEncoding::BV, X, Y);
+  }
+
+  for (int I = 0; I < 25; ++I) {
+    uint64_t XB = Bits64(Rng), YB = Bits64(Rng);
+    double X, Y;
+    std::memcpy(&X, &XB, sizeof(X));
+    std::memcpy(&Y, &YB, sizeof(Y));
+    check_rem_pair_f64(solver, camada::FPEncoding::BV, X, Y);
+  }
 }
 
 TEST_CASE("Quantifiers Bitwuzla test", "[Bitwuzla]") {

--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -4,6 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <limits>
+#include <utility>
 
 inline void fp_native_bv_predicate_parity(const camada::SMTSolverRef &solver) {
   const auto backend = solver->mkBool(true)->getBackendKind();
@@ -401,6 +402,92 @@ inline void fp_remainder_semantics(const camada::SMTSolverRef &solver,
   solver->addConstraint(solver->mkEqual(rem, expected));
 
   REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
+// Checks one concrete fp.rem result against the host CPU, which computes
+// IEEE-754 remainder exactly (std::remainder is correctly rounded). mkEqual
+// is object equality on FP, so signed zeros are distinguished; NaN results
+// are checked via fp.isNaN since payloads are unspecified.
+inline void check_rem_pair_f32(const camada::SMTSolverRef &solver,
+                               camada::FPEncoding Encoding, float X, float Y) {
+  const bool IsBVEncoding = Encoding == camada::FPEncoding::BV;
+  CAPTURE(X, Y, IsBVEncoding);
+  solver->reset();
+  auto rem =
+      solver->mkFPRem(solver->mkFP32(X, Encoding), solver->mkFP32(Y, Encoding));
+  float Expected = std::remainder(X, Y);
+  if (std::isnan(Expected))
+    solver->addConstraint(solver->mkFPIsNaN(rem));
+  else
+    solver->addConstraint(
+        solver->mkEqual(rem, solver->mkFP32(Expected, Encoding)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
+inline void check_rem_pair_f64(const camada::SMTSolverRef &solver,
+                               camada::FPEncoding Encoding, double X,
+                               double Y) {
+  const bool IsBVEncoding = Encoding == camada::FPEncoding::BV;
+  CAPTURE(X, Y, IsBVEncoding);
+  solver->reset();
+  auto rem =
+      solver->mkFPRem(solver->mkFP64(X, Encoding), solver->mkFP64(Y, Encoding));
+  double Expected = std::remainder(X, Y);
+  if (std::isnan(Expected))
+    solver->addConstraint(solver->mkFPIsNaN(rem));
+  else
+    solver->addConstraint(
+        solver->mkEqual(rem, solver->mkFP64(Expected, Encoding)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
+inline void fp_remainder_host_oracle(const camada::SMTSolverRef &solver,
+                                     camada::FPEncoding Encoding) {
+  const std::pair<float, float> Pairs[] = {
+      // Quotient rounding and ties-to-even.
+      {5.0f, 2.0f},  // q = 2.5 -> 2 (even), rem = 1
+      {7.0f, 2.0f},  // q = 3.5 -> 4 (even), rem = -1
+      {6.0f, 4.0f},  // q = 1.5 -> 2 (even), rem = -2
+      {10.0f, 4.0f}, // q = 2.5 -> 2 (even), rem = 2
+      {7.5f, 2.5f},  // exact q = 3, rem = 0
+      // Sign combinations; rem keeps the sign of x.
+      {-5.0f, 2.0f},
+      {5.0f, -2.0f},
+      {-5.0f, -2.0f},
+      {-7.0f, 2.0f},
+      // Signed zero results.
+      {4.0f, 2.0f},  // +0
+      {-4.0f, 2.0f}, // -0
+      {0.0f, 3.0f},
+      {-0.0f, 3.0f},
+      // Large exponent difference (the expensive encoding path).
+      {1.0e38f, 3.0f},
+      {1.0e30f, 1.1754944e-38f}, // y = min normal
+      // Subnormal operands.
+      {1.0e-45f, 1.0e-44f},         // x, y both subnormal
+      {1.0e-39f, 1.1754944e-38f},   // x subnormal, y min normal
+      {1.0f, 1.4012985e-45f},       // y = min subnormal, huge diff
+      {1.9999998f, 1.4012985e-45f}, // full mantissa over min subnormal
+      {1.4012985e-45f, 1.0e-38f},   // x min subnormal, y near min normal
+      {2.3509886e-38f, 2.3509887e-38f},
+      // y subnormal with x slightly above: exercises the negative
+      // exponent-difference path while the raw-exponent guard is disabled
+      // (raw exp(y) == 0).
+      {1.4012985e-45f, 1.1754942e-38f}, // |x| << |y|, y max subnormal
+      {5.8774718e-39f, 1.1754942e-38f}, // q = 0.5, tie with q even
+      {8.8162076e-39f, 1.1754942e-38f}, // q = 0.75 -> 1
+      // x < y/2 just below the raw-exponent guard boundary.
+      {0.49999997f, 2.0f},
+      {0.5f, 2.0f}, // tie: q = 0.25 -> 0, rem = x
+      // Specials.
+      {3.0f, std::numeric_limits<float>::infinity()},  // -> x
+      {-3.0f, std::numeric_limits<float>::infinity()}, // -> x
+      {std::numeric_limits<float>::infinity(), 3.0f},  // -> NaN
+      {3.0f, 0.0f},                                    // -> NaN
+      {0.0f, 0.0f},                                    // -> NaN
+  };
+  for (const auto &P : Pairs)
+    check_rem_pair_f32(solver, Encoding, P.first, P.second);
 }
 
 inline void fp_non_standard_widths(const camada::SMTSolverRef &solver,

--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -463,6 +463,12 @@ inline void fp_remainder_host_oracle(const camada::SMTSolverRef &solver,
       // Large exponent difference (the expensive encoding path).
       {1.0e38f, 3.0f},
       {1.0e30f, 1.1754944e-38f}, // y = min normal
+      // Exponent difference beyond 2^ebits - 3: y subnormal pushes the
+      // normalized difference up to (2^ebits - 3) + (sbits - 1). The
+      // classic Z3-style encoding under-allocates shift headroom here and
+      // returns wrong values; pins the modular encoding's fix.
+      {3.0e38f, 7.0e-39f},
+      {3.4028235e38f, 1.4012985e-45f}, // max finite over min subnormal
       // Subnormal operands.
       {1.0e-45f, 1.0e-44f},         // x, y both subnormal
       {1.0e-39f, 1.1754944e-38f},   // x subnormal, y min normal

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -80,6 +80,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDFPTEST(fp_div_overflow_to_inf, BVFP);
   RESETANDFPTEST(fp_remainder_semantics, NativeFP);
   RESETANDFPTEST(fp_remainder_semantics, BVFP);
+  RESETANDFPTEST(fp_remainder_host_oracle, NativeFP);
+  RESETANDFPTEST(fp_remainder_host_oracle, BVFP);
   RESETANDTEST(arena_stress_test);
   RESETANDFPTEST(fp_non_standard_widths, BVFP);
   RESETANDFPTEST(fp_cancellation_and_normalization, NativeFP);

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -834,6 +834,9 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
   SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
   SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
 
+  // ebits+2 bits hold the maximal normalized difference
+  // (2^ebits - 3) + (sbits - 1) only while sbits <= 2^ebits + 3; every IEEE
+  // format satisfies this, and the classic encoding had the same bound.
   SMTExprRef exp_diff =
       mkBVSub(mkBVSub(a_exp_ext, a_lz_ext), mkBVSub(b_exp_ext, b_lz_ext));
   SMTExprRef neg_exp_diff = mkBVNeg(exp_diff);
@@ -880,11 +883,12 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
   SMTExprRef m2_W =
       mkBVZeroExt(W - (sbits + 1), mkBVConcat(b_sig, mkBVZero1(*this)));
   // Processing MSB-first, after consuming the top `lead` bits the
-  // accumulator is 2^(d >> (ebits+1-lead)), which stays below 2M as long as
-  // 2^lead - 1 <= sbits. Those first rounds therefore collapse into a single
-  // shift of 1, skipping their multiply/remainder pairs.
+  // accumulator is 2^(d >> (ebits+1-lead)), which stays within [1, 2M] (and
+  // congruent mod 2M) as long as 2^lead - 1 <= sbits. Those first rounds
+  // therefore collapse into a single shift of 1, skipping their
+  // multiply/remainder pairs.
   unsigned lead = 0;
-  while (lead < ebits + 1 && ((1u << (lead + 1)) - 1) <= sbits)
+  while (lead < ebits + 1 && ((1ull << (lead + 1)) - 1) <= sbits)
     ++lead;
   SMTExprRef acc;
   if (lead > 0) {

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -22,11 +22,11 @@
 #include "camadacommon.h"
 #include "camadaimpl.h"
 
+#include <algorithm>
 #include <bitset>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
-#include <stdexcept>
 
 namespace camada {
 namespace {
@@ -368,21 +368,6 @@ mkRoundingDecision(SMTSolver &S, const SMTExprRef &R, const SMTExprRef &RMNeg,
   SMTExprRef inc_c3 = S.mkIte(rm_is_to_pos, inc_pos, inc_c4);
   SMTExprRef inc_c2 = S.mkIte(rm_is_away, inc_taway, inc_c3);
   return S.mkIte(rm_is_even, inc_teven, inc_c2);
-}
-
-// Zero-extend by TotalBits. Camada's extension APIs take fixed-size integer
-// parameters, so very large extensions are applied in chunks instead of
-// relying on a single oversized call.
-static inline SMTExprRef chunkedZeroExt(SMTSolver &S, SMTExprRef Exp,
-                                        uint64_t TotalBits) {
-  constexpr uint64_t max_chunk = static_cast<uint64_t>(INT32_MAX);
-  while (TotalBits > max_chunk) {
-    Exp = S.mkBVZeroExt(static_cast<unsigned>(max_chunk), Exp);
-    TotalBits -= max_chunk;
-  }
-  if (TotalBits != 0)
-    Exp = S.mkBVZeroExt(static_cast<unsigned>(TotalBits), Exp);
-  return Exp;
 }
 
 static inline void unpack(SMTSolver &S, const SMTExprRef &Src, SMTExprRef &Sgn,
@@ -844,11 +829,6 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
   unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, true);
   unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, true);
 
-  if (ebits >= std::numeric_limits<uint64_t>::digits)
-    throw std::runtime_error("Huge exponents in fp.rem are not supported.");
-
-  uint64_t max_exp_diff_u64 = (uint64_t{1} << ebits) - 3;
-
   SMTExprRef a_exp_ext = mkBVSignExt(2, a_exp);
   SMTExprRef b_exp_ext = mkBVSignExt(2, b_exp);
   SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
@@ -862,29 +842,82 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
   SMTExprRef two_ebits_p2 = mkBVFromDec(2, ebits + 2);
   SMTExprRef exp_diff_is_neg = mkBVSle(exp_diff, zero_ebits_p2);
 
-  // CMW: This creates huge bit-vectors, which is potentially sub-optimal, but
-  // the iterative remainder encodings are also very expensive. Lazy lowering
-  // would likely be the right long-term direction here too.
-  SMTExprRef a_sig_ext = mkBVConcat(
-      chunkedZeroExt(*this, a_sig, max_exp_diff_u64), mkBVZero3(*this));
-  SMTExprRef b_sig_ext = mkBVConcat(
-      chunkedZeroExt(*this, b_sig, max_exp_diff_u64), mkBVZero3(*this));
+  // The classic (Z3-style) encoding shifts the dividend significand left by
+  // up to 2^ebits bits and divides, creating enormous bit-vectors. Instead,
+  // compute the same remainder with modular arithmetic over ~2*sbits-bit
+  // values: with d = exp_diff, M = b_sig, the candidate remainder is
+  // (a_sig * 2^d) mod M, and 2^d mod 2M is computed by square-and-multiply
+  // over the bits of d. Reducing modulo 2M instead of M also yields the
+  // integer quotient's parity, needed for the ties-to-even adjustment below:
+  // (a_sig * 2^d) mod 2M == (q mod 2)*M + r.
+  //
+  // Both significands carry a factor of 8 (three low guard bits) so the
+  // negative-d path keeps fractional bits, mirroring the classic encoding.
 
-  uint64_t max_exp_diff_adj_u64 = max_exp_diff_u64 + sbits - ebits + 1;
-  SMTExprRef lshift = chunkedZeroExt(*this, exp_diff, max_exp_diff_adj_u64);
-  SMTExprRef rshift = chunkedZeroExt(*this, neg_exp_diff, max_exp_diff_adj_u64);
+  // d <= 0: |x| < 2|y| at these scales, so the integer quotient is 0 or 1
+  // and the remainder needs only a compare-and-subtract. The shift below is
+  // well-defined for any d: bvlshr yields 0 once the amount reaches the
+  // width. This path's value is discarded by the ite when d > 0.
+  const unsigned wn = sbits + 4;
+  const unsigned wshift = std::max(wn, ebits + 2);
+  SMTExprRef a8 = mkBVZeroExt(1, mkBVConcat(a_sig, mkBVZero3(*this)));
+  SMTExprRef b8 = mkBVZeroExt(1, mkBVConcat(b_sig, mkBVZero3(*this)));
+  SMTExprRef shifted_neg = mkBVLshr(
+      wshift > wn ? mkBVZeroExt(wshift - wn, a8) : a8,
+      wshift > ebits + 2 ? mkBVZeroExt(wshift - (ebits + 2), neg_exp_diff)
+                         : neg_exp_diff);
+  if (wshift > wn)
+    shifted_neg = mkBVExtract(wn - 1, 0, shifted_neg);
+  SMTExprRef q_one_neg = mkBVUge(shifted_neg, b8);
+  SMTExprRef rem_neg = mkIte(q_one_neg, mkBVSub(shifted_neg, b8), shifted_neg);
+  SMTExprRef even_neg = mkNot(q_one_neg);
 
-  SMTExprRef shifted = mkIte(exp_diff_is_neg, mkBVAshr(a_sig_ext, rshift),
-                             mkBVShl(a_sig_ext, lshift));
-  SMTExprRef huge_rem = mkBVURem(shifted, b_sig_ext);
-  SMTExprRef huge_div = mkBVUDiv(shifted, b_sig_ext);
-  SMTExprRef huge_div_is_even =
-      mkEqual(mkBVExtract(0, 0, huge_div), mkBVZero1(*this));
+  // d > 0: square-and-multiply over the bits of d. d is positive here, so
+  // its sign bit is clear and bits [ebits:0] cover the whole value.
+  const unsigned w2 = sbits + 2;
+  const unsigned W = 2 * sbits + 3;
+  SMTExprRef one_W = mkBVFromDec(1, W);
+  SMTExprRef m2_W =
+      mkBVZeroExt(W - (sbits + 1), mkBVConcat(b_sig, mkBVZero1(*this)));
+  // Processing MSB-first, after consuming the top `lead` bits the
+  // accumulator is 2^(d >> (ebits+1-lead)), which stays below 2M as long as
+  // 2^lead - 1 <= sbits. Those first rounds therefore collapse into a single
+  // shift of 1, skipping their multiply/remainder pairs.
+  unsigned lead = 0;
+  while (lead < ebits + 1 && ((1u << (lead + 1)) - 1) <= sbits)
+    ++lead;
+  SMTExprRef acc;
+  if (lead > 0) {
+    SMTExprRef top_bits = mkBVExtract(ebits, ebits + 1 - lead, exp_diff);
+    acc = mkBVShl(mkBVFromDec(1, w2), mkBVZeroExt(w2 - lead, top_bits));
+  } else {
+    acc = mkBVFromDec(1, w2);
+  }
+  for (int i = static_cast<int>(ebits) - static_cast<int>(lead); i >= 0; --i) {
+    SMTExprRef sq = mkBVMul(mkBVZeroExt(W - w2, acc), mkBVZeroExt(W - w2, acc));
+    SMTExprRef bit_set =
+        mkEqual(mkBVExtract(static_cast<unsigned>(i), static_cast<unsigned>(i),
+                            exp_diff),
+                mkBVOne1(*this));
+    SMTExprRef dbl = mkIte(bit_set, mkBVShl(sq, one_W), sq);
+    acc = mkBVExtract(w2 - 1, 0, mkBVURem(dbl, m2_W));
+  }
+  SMTExprRef prod =
+      mkBVMul(mkBVZeroExt(W - sbits, a_sig), mkBVZeroExt(W - w2, acc));
+  SMTExprRef r2 = mkBVExtract(w2 - 1, 0, mkBVURem(prod, m2_W));
+  SMTExprRef m_w2 = mkBVZeroExt(2, b_sig);
+  SMTExprRef q_odd_pos = mkBVUge(r2, m_w2);
+  SMTExprRef r_pos = mkIte(q_odd_pos, mkBVSub(r2, m_w2), r2);
+  SMTExprRef rem_pos =
+      mkBVConcat(mkBVExtract(sbits, 0, r_pos), mkBVZero3(*this));
+  SMTExprRef even_pos = mkNot(q_odd_pos);
 
-  // Round the large remainder candidate to the target format first.
+  SMTExprRef huge_div_is_even = mkIte(exp_diff_is_neg, even_neg, even_pos);
+
+  // Round the remainder candidate to the target format first.
   SMTExprRef rndd_sgn = a_sgn;
   SMTExprRef rndd_exp = mkBVSub(b_exp_ext, b_lz_ext);
-  SMTExprRef rndd_sig = mkBVExtract(sbits + 3, 0, huge_rem);
+  SMTExprRef rndd_sig = mkIte(exp_diff_is_neg, rem_neg, rem_pos);
   SMTExprRef rne_bv = mkRM(RM::ROUND_TO_EVEN, FPEncoding::BV);
   SMTExprRef rndd_sig_lz = mkLeadingZeros(*this, rndd_sig, ebits + 2);
 


### PR DESCRIPTION
Stacked on #64 (it builds on the `camadafp.cpp` cleanups there); retarget to master once that merges.

**Correctness bug found and fixed.** A new host-CPU oracle (`std::remainder` is exact per IEEE-754, so the host is independent ground truth) exposed a bug inherited from Z3's `mk_rem`: with a subnormal divisor the normalized exponent difference reaches `(2^ebits - 3) + (sbits - 1)`, exceeding the `2^ebits - 3` bits of shift headroom the encoding allocates, so high significand bits were silently shifted out — e.g. `fp.rem(3.0e38f, 7.0e-39f)` returned a wrong value. This likely affects upstream Z3 as well.

**New encoding.** Instead of shifting the dividend significand left by up to `2^ebits` bits and dividing (float32: 280-bit vectors, float64: 2103, float128: 32K), compute the remainder candidate as `(a_sig * 2^d) mod M` with `2^d mod 2M` by square-and-multiply over the bits of `d`, at width `2*sbits + 3` (float64: 109 bits). Reducing mod `2M` also yields the integer quotient's parity for the ties-to-even adjustment. The headroom bug disappears structurally: only `d`'s bit-width matters, not its value. Huge-exponent formats no longer throw.

**Validation.** Structured oracle pairs (ties, signed zeros, subnormals, specials, the two previously-failing headroom pairs) run on every backend and both encodings, plus a seeded randomized 225-pair sweep on Bitwuzla.

**Performance.** Construction is neutral within measurement noise (verified with pinned-median runs plus a same-binary null test that exposed ~4% between-run drift in `compare-bench.py` p-values). Solve times on symbolic instances move in both directions: f64 fixed-divisor 4.5s -> 1.3s, f32 symbolic-divisor 6.1s -> 1.0s, f64 UNSAT 2.7x faster; f32 fixed-divisor 130 -> 320ms and f64 symbolic-divisor regressed past 300s (old: 132s). Neither encoding dominates and the variance is instance-dependent rather than format-dependent; the commit message and repo notes record the details and a possible small-`d` fast-path follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)