### PR TITLE
Harden Z3 model extraction against negative-internal BV numerals

### DIFF
--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -757,11 +757,28 @@ SMTResult<bool> Z3Solver::getBoolImpl(const SMTExprRef &Exp) {
                   "Bool model value is neither true nor false"};
 }
 
+// Extract the binary form of a bit-vector numeral. Z3's model evaluator can
+// return a numeral it stores with a negative internal value (printed as
+// e.g. "(bvneg #x...)"); expr::as_binary relies on
+// Z3_get_numeral_binary_string, which rejects those with Z3_INVALID_ARG and
+// kills the process through the error handler. Read the sign-aware decimal
+// representation first and, when negative, let Z3 renormalize it modulo
+// 2^Width before extracting the binary form. See the equivalent fix in
+// ESBMC's z3_convt::get_bv (esbmc/esbmc#5208).
+static bool bvNumeralToBinary(z3::context &Ctx, const z3::expr &Value,
+                              unsigned Width, std::string &Out) {
+  if (!Value.is_numeral())
+    return false;
+  std::string Dec = Z3_get_numeral_string(Ctx, Value);
+  if (!Dec.empty() && Dec[0] == '-')
+    return Ctx.bv_val(Dec.c_str(), Width).as_binary(Out);
+  return Value.as_binary(Out);
+}
+
 SMTResult<std::string> Z3Solver::getBVInBinImpl(const SMTExprRef &Exp) {
   z3::expr Value = Solver.get_model().eval(toZ3Expr(Exp), true);
   std::string bv;
-  bool is_num = Value.as_binary(bv);
-  if (!is_num)
+  if (!bvNumeralToBinary(*Context, Value, Exp->getWidth(), bv))
     return SMTError{SMTErrorCode::InvalidModelValue, SMTBackendKind::Z3,
                     "Failed to get bit-vector model value from Z3"};
   return bv;
@@ -810,8 +827,7 @@ SMTResult<std::string> Z3Solver::getFPInBinImpl(const SMTExprRef &Exp) {
   z3::expr Value = Solver.get_model().eval(toZ3Expr(Exp), true);
   z3::expr fp_value = Solver.get_model().eval(Value.mk_to_ieee_bv(), true);
   std::string bv;
-  bool is_num = fp_value.as_binary(bv);
-  if (!is_num)
+  if (!bvNumeralToBinary(*Context, fp_value, Exp->getWidth(), bv))
     return SMTError{SMTErrorCode::InvalidModelValue, SMTBackendKind::Z3,
                     "Failed to convert FP model value to BV in Z3"};
   return bv;


### PR DESCRIPTION
Ports the fix from ESBMC commit e6f28c4e ([esbmc/esbmc#5208](https://github.com/esbmc/esbmc/pull/5208)): Z3's model evaluator can return a bit-vector numeral stored with a negative internal value (printed as `(bvneg #x...)`), and `expr::as_binary` / `Z3_get_numeral_binary_string` rejects those with `Z3_INVALID_ARG`, killing the process. Camada had the same exposure at both `getBVInBinImpl` and `getFPInBinImpl` — the `is_num` check doesn't help because `as_binary` returns false for non-numerals but *raises* for negative numerals.

The fix reads the sign-aware decimal form first (`Z3_get_numeral_string`) and, when negative, lets Z3 renormalize it modulo 2^width via `bv_val(dec, width)` before extracting the binary string. Camada has no arbitrary-precision integer type, so renormalizing through Z3 replaces ESBMC's BigInt-based reinterpretation.

The trigger is not reproducible through camada's public API (Z3 normalizes numerals at construction; only the evaluator emits the negative-internal form, on instances like ESBMC's k-induction overflow counterexamples), so this is a defensive port validated by ESBMC's end-to-end regression. All 147 camada tests pass.

The companion ESBMC commit 00ddf75e (Int-constant truncation past int64) was reviewed and does **not** apply: camada's `mkInt` already has int64 and arbitrary-precision string overloads, and all backends route the string overload to arbitrary-precision APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)