### PR TITLE
Use native integer APIs for BV constants up to 64 bits

### DIFF
--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -93,6 +93,31 @@ inline void bv_lshr_semantics(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::checkResult::SAT);
 }
 
+// Pins the narrow (width <= 64) decimal-constant path, which backends may
+// serve through native integer APIs: negative values must produce the
+// two's-complement pattern and values must be masked to the sort width.
+inline void narrow_bv_decimal_model_value(const camada::SMTSolverRef &solver) {
+  auto bv32 = solver->mkBVSort(32);
+  auto x = solver->mkSymbol("x", bv32);
+  solver->addConstraint(solver->mkEqual(x, solver->mkBVFromDec(-42, bv32)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  auto bin = solver->getBVInBin(x);
+  REQUIRE(bin);
+  // -42 in 32-bit two's complement.
+  REQUIRE(bin.value() == "11111111111111111111111111010110");
+
+  solver->reset();
+  auto bv3 = solver->mkBVSort(3);
+  auto y = solver->mkSymbol("y", bv3);
+  solver->addConstraint(solver->mkEqual(y, solver->mkBVFromDec(-1, bv3)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  auto bin3 = solver->getBVInBin(y);
+  REQUIRE(bin3);
+  REQUIRE(bin3.value() == "111");
+}
+
 // Pin model parsing for bit-vector widths above 64. Solvers that emit BV
 // model values in the `(_ bv<n> <w>)` decimal form (mathsat is the canonical
 // example over the SMT-LIB pipe) need an arbitrary-precision decimal-to-

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -47,6 +47,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(implies_semantics);
   RESETANDTEST(implies_true_implies_false);
   RESETANDTEST(bv_lshr_semantics);
+  RESETANDTEST(narrow_bv_decimal_model_value);
   RESETANDTEST(wide_bv_decimal_model_value);
   RESETANDTEST(incremental_push_pop);
   RESETANDTEST(symbol_cache_survives_push_pop);

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -747,11 +747,23 @@ SMTExprRef BitwuzlaSolver::mkBoolImpl(const bool b) {
 
 SMTExprRef BitwuzlaSolver::mkBVFromDecImpl(const int64_t Int,
                                            const SMTSortRef &Sort) {
+  const unsigned Width = Sort->getWidth();
+  if (Width <= 64) {
+    // Mask to the sort width so the value always satisfies bitwuzla's
+    // requirement that it fit the sort. This skips the binary-string
+    // round-trip (building the string here, re-parsing it inside bitwuzla).
+    uint64_t Bits = static_cast<uint64_t>(Int);
+    if (Width < 64)
+      Bits &= (uint64_t{1} << Width) - 1;
+    return makeExprRef<BitwExpr>(
+        SMTExprKind::BVConst, Context, Sort,
+        bitwuzla_mk_bv_value_uint64(TermManager,
+                                    toSolverSort<BitwSort>(*Sort).Sort, Bits));
+  }
   return makeExprRef<BitwExpr>(
       SMTExprKind::BVConst, Context, Sort,
       bitwuzla_mk_bv_value(TermManager, toSolverSort<BitwSort>(*Sort).Sort,
-                           toTwosComplementBin(Int, Sort->getWidth()).c_str(),
-                           2));
+                           toTwosComplementBin(Int, Width).c_str(), 2));
 }
 
 SMTExprRef BitwuzlaSolver::mkBVFromBinImpl(const std::string &Int,

--- a/src/camadacommon.h
+++ b/src/camadacommon.h
@@ -22,7 +22,6 @@
 #ifndef CAMADACOMMON_H_
 #define CAMADACOMMON_H_
 
-#include <bitset>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -65,11 +64,12 @@ static inline void fatalErrorIf(bool Cond, const char *Message) {
 
 static inline std::string toTwosComplementBin(int64_t Value, unsigned Width) {
   const uint64_t RawBits = static_cast<uint64_t>(Value);
-  std::string Bits = std::bitset<64>(RawBits).to_string();
-  if (Width < 64)
-    Bits = Bits.substr(64 - Width);
-  else if (Width > 64)
-    Bits.insert(Bits.begin(), Width - 64, Value < 0 ? '1' : '0');
+  // Sign-fill, then overwrite the low min(Width, 64) bits: one allocation
+  // instead of the bitset-to_string/substr/insert sequence.
+  std::string Bits(Width, Value < 0 ? '1' : '0');
+  const unsigned Low = Width < 64 ? Width : 64;
+  for (unsigned I = 0; I < Low; ++I)
+    Bits[Width - 1 - I] = ((RawBits >> I) & 1) != 0 ? '1' : '0';
   return Bits;
 }
 

--- a/src/mathsatsolver.cpp
+++ b/src/mathsatsolver.cpp
@@ -27,6 +27,7 @@
 
 #include <cstdio>
 #include <gmp.h>
+#include <limits>
 #include <type_traits>
 #include <vector>
 
@@ -969,11 +970,18 @@ SMTExprRef MathSATSolver::mkRealImpl(int64_t num, int64_t den) {
 
 SMTExprRef MathSATSolver::mkBVFromDecImpl(const int64_t Int,
                                           const SMTSortRef &Sort) {
+  const unsigned Width = Sort->getWidth();
+  // msat_make_bv_int_number takes a non-negative int that must fit the
+  // width; everything else falls back to the binary-string path.
+  if (Int >= 0 && Int <= std::numeric_limits<int>::max() &&
+      (Width >= 63 || static_cast<uint64_t>(Int) < (uint64_t{1} << Width)))
+    return makeExprRef<MathSATExpr>(
+        SMTExprKind::BVConst, &Context, Sort,
+        msat_make_bv_int_number(Context, static_cast<int>(Int), Width));
   return makeExprRef<MathSATExpr>(
       SMTExprKind::BVConst, &Context, Sort,
-      msat_make_bv_number(Context,
-                          toTwosComplementBin(Int, Sort->getWidth()).c_str(),
-                          Sort->getWidth(), 2));
+      msat_make_bv_number(Context, toTwosComplementBin(Int, Width).c_str(),
+                          Width, 2));
 }
 
 SMTExprRef MathSATSolver::mkBVFromBinImpl(const std::string &Int,

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -523,10 +523,21 @@ SMTExprRef STPSolver::mkBoolImpl(const bool b) {
 
 SMTExprRef STPSolver::mkBVFromDecImpl(const int64_t Int,
                                       const SMTSortRef &Sort) {
+  const unsigned Width = Sort->getWidth();
+  if (Width <= 64) {
+    // Mask to the sort width so the value's bit representation always fits,
+    // skipping the binary-string round-trip.
+    uint64_t Bits = static_cast<uint64_t>(Int);
+    if (Width < 64)
+      Bits &= (uint64_t{1} << Width) - 1;
+    return makeExprRef<STPExpr>(
+        SMTExprKind::BVConst, &Context, Sort,
+        STP::vc_bvConstExprFromLL(Context, static_cast<int>(Width), Bits));
+  }
   return makeExprRef<STPExpr>(
       SMTExprKind::BVConst, &Context, Sort,
-      STP::vc_bvConstExprFromStr(
-          Context, toTwosComplementBin(Int, Sort->getWidth()).c_str()));
+      STP::vc_bvConstExprFromStr(Context,
+                                 toTwosComplementBin(Int, Width).c_str()));
 }
 
 SMTExprRef STPSolver::mkBVFromBinImpl(const std::string &Int,


### PR DESCRIPTION
Bitwuzla, MathSAT, and STP built every decimal BV constant by formatting a binary string (`toTwosComplementBin`) that the solver then re-parsed. Z3, CVC5, and Yices already used native integer APIs. This switches the three stragglers to their native paths for widths <= 64 (value masked to the sort width; MathSAT limited to non-negative `int` per its API), keeps the string fallback for wide sorts, builds `toTwosComplementBin` in a single allocation, and pins the negative/masked-value semantics with a model round-trip test on every backend.

Measured against a fresh worktree build of pre-change master (see note below):

- **MathSAT**: `bv_const_varied` ~10x faster, `fp_construct` 1.70x faster, 89% fewer heap blocks / 74% fewer bytes — `msat_make_bv_number`'s string parsing dominated entire workloads.
- **Bitwuzla**: `bv_const_varied` 1.77x faster, `fp_rem_only` 1.10x, `fp_construct` 1.08x; 5.2% fewer heap blocks.
- **STP**: 5.1% fewer heap blocks (timing not isolable: `camada-bench stp` aborts at `function_sort_cache_hit` because STP lacks UF — pre-existing, worth gating like the FP cases).

Measurement note: `build-baseline/`'s binaries carry an RPATH into `build/lib`, so the usual baseline-vs-current hyperfine workflow silently compares the current library against itself. The numbers above use a separate git-worktree build whose binaries resolve their own library. `build-baseline` should be rebuilt in place to fix the standard workflow.

All 147 regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)