### PR TITLE
Make SMT-LIB expressions structural with let-binding emission

### DIFF
--- a/regression/bench/main.cpp
+++ b/regression/bench/main.cpp
@@ -121,14 +121,6 @@ bool backendSupportsTuples(const std::string &backend) {
   return backend == "cvc5" || backend == "z3" || backend == "smtlib";
 }
 
-// The FP bench cases use the BV-blasted FP encoding. The SMT-LIB backend
-// stores each node as fully inlined text, so flattening the heavily shared
-// DAGs that encoding produces explodes combinatorially — even a single
-// iteration does not terminate in reasonable time. Skip those cases there.
-bool backendSupportsBlastedFP(const std::string &backend) {
-  return backend != "smtlib";
-}
-
 // Optional substring filter on benchmark case names (third CLI argument).
 // Empty means "run everything".
 std::string caseFilter;
@@ -508,18 +500,15 @@ int main(int argc, char **argv) {
     if (backendSupportsTuples(backend))
       runCase(backend, "tuple_sort_cache_hit", iterations,
               benchmarkTupleSortCacheHit);
-    if (backendSupportsBlastedFP(backend)) {
-      runCase(backend, "fp_from_bv", iterations, benchmarkFPFromBV);
-      runCase(backend, "fp_add_only", iterations, benchmarkFPAddOnly);
-      runCase(backend, "fp_div_only", iterations, benchmarkFPDivOnly);
-      runCase(backend, "fp_integral_only", iterations, benchmarkFPIntegralOnly);
-      runCase(backend, "fp_ieee_to_bv_only", iterations,
-              benchmarkFPIEEEToBVOnly);
-      runCase(backend, "fp_sqrt_only", iterations, benchmarkFPSqrtOnly);
-      runCase(backend, "fp_fma_only", iterations, benchmarkFPFMAOnly);
-      runCase(backend, "fp_rem_only", iterations, benchmarkFPRemOnly);
-      runCase(backend, "fp_construct", iterations, benchmarkFPConstruct);
-    }
+    runCase(backend, "fp_from_bv", iterations, benchmarkFPFromBV);
+    runCase(backend, "fp_add_only", iterations, benchmarkFPAddOnly);
+    runCase(backend, "fp_div_only", iterations, benchmarkFPDivOnly);
+    runCase(backend, "fp_integral_only", iterations, benchmarkFPIntegralOnly);
+    runCase(backend, "fp_ieee_to_bv_only", iterations, benchmarkFPIEEEToBVOnly);
+    runCase(backend, "fp_sqrt_only", iterations, benchmarkFPSqrtOnly);
+    runCase(backend, "fp_fma_only", iterations, benchmarkFPFMAOnly);
+    runCase(backend, "fp_rem_only", iterations, benchmarkFPRemOnly);
+    runCase(backend, "fp_construct", iterations, benchmarkFPConstruct);
     runCase(backend, "reset_cycle_memory", iterations,
             benchmarkResetCycleMemory);
     runCase(backend, "reset_cycle_expr_chain", iterations,

--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -432,3 +432,19 @@ inline void arena_stress_test(const camada::SMTSolverRef &solver) {
   solver->addConstraint(solver->mkEqual(expr, expr));
   REQUIRE(solver->check() == camada::checkResult::SAT);
 }
+
+// Model query over a term with a shared subterm. On the SMT-LIB backend the
+// (get-value ...) argument contains a let binding; child solvers must
+// accept it and return the right value.
+inline void shared_subterm_model_value(const camada::SMTSolverRef &solver) {
+  auto bv8 = solver->mkBVSort(8);
+  auto x = solver->mkSymbol("sst_x", bv8);
+  auto sum = solver->mkBVAdd(x, x);
+  auto prod = solver->mkBVMul(sum, sum);
+  solver->addConstraint(solver->mkEqual(x, solver->mkBVFromDec(3, bv8)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  auto val = solver->getBV(prod);
+  REQUIRE(val);
+  REQUIRE(val.value() == 36);
+}

--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -256,3 +256,96 @@ TEST_CASE("SMTLIB getInt accepts integral unreduced rationals", "[SMTLIB]") {
   REQUIRE(SMTLIBSolver::parseIntModelValueForTest(
               "(/ 100000000000000000000 50000000000000000000)") == "2");
 }
+
+// Pin the let-binding emission for shared subterms: a DAG node referenced
+// twice is bound to a %t temporary at its first occurrence and referenced
+// by name afterwards; once-used nodes stay inline.
+TEST_CASE("SMTLIB write-only let-binds shared subterms", "[SMTLIB]") {
+  std::string Path = makeTempPath();
+
+  {
+    auto Solver = std::make_unique<camada::SMTLIBSolver>(Path);
+    auto BV8 = Solver->mkBVSort(8);
+    auto X = Solver->mkSymbol("x", BV8);
+    auto Y = Solver->mkSymbol("y", BV8);
+    auto Sum = Solver->mkBVAdd(X, Y);      // shared twice
+    auto Prod = Solver->mkBVMul(Sum, Sum); // shares Sum
+    Solver->addConstraint(Solver->mkEqual(Prod, X));
+    Solver->check();
+  }
+
+  const std::string Expected =
+      "(set-option :print-success false)\n"
+      "(set-option :produce-models true)\n"
+      "(set-option :global-declarations true)\n"
+      "(set-info :status unknown)\n"
+      "(set-logic ALL)\n"
+      "(declare-fun |x| () (_ BitVec 8))\n"
+      "(declare-fun |y| () (_ BitVec 8))\n"
+      "(assert (let ((%t0 (bvadd |x| |y|))) (= (bvmul %t0 %t0) |x|)))\n"
+      "(check-sat)\n";
+
+  std::string Got = readFile(Path);
+  std::remove(Path.c_str());
+
+  REQUIRE(Got == Expected);
+}
+
+// Symbols spelled like let temporaries must not be captured: quoteSymbol
+// encodes every literal '%' as "%25", so a user symbol "%t0" renders as
+// |%25t0| and can never alias the unquoted %t0 temporary.
+TEST_CASE("SMTLIB write-only let temporaries cannot capture user symbols",
+          "[SMTLIB]") {
+  std::string Path = makeTempPath();
+
+  {
+    auto Solver = std::make_unique<camada::SMTLIBSolver>(Path);
+    auto BV8 = Solver->mkBVSort(8);
+    auto Hostile = Solver->mkSymbol("%t0", BV8);
+    auto Y = Solver->mkSymbol("y", BV8);
+    auto Sum = Solver->mkBVAdd(Y, Y); // let-bound as %t0
+    Solver->addConstraint(Solver->mkEqual(
+        Solver->mkBVAdd(Solver->mkBVMul(Sum, Sum), Hostile), Y));
+    Solver->check();
+  }
+
+  const std::string Expected = "(set-option :print-success false)\n"
+                               "(set-option :produce-models true)\n"
+                               "(set-option :global-declarations true)\n"
+                               "(set-info :status unknown)\n"
+                               "(set-logic ALL)\n"
+                               "(declare-fun |%25t0| () (_ BitVec 8))\n"
+                               "(declare-fun |y| () (_ BitVec 8))\n"
+                               "(assert (let ((%t0 (bvadd |y| |y|))) "
+                               "(= (bvadd (bvmul %t0 %t0) |%25t0|) |y|)))\n"
+                               "(check-sat)\n";
+
+  std::string Got = readFile(Path);
+  std::remove(Path.c_str());
+
+  REQUIRE(Got == Expected);
+}
+
+// Deep, lightly shared chains must emit without exhausting the stack: the
+// renderer is iterative (a 50k-node linear chain overflows a recursive
+// emitter long before this size).
+TEST_CASE("SMTLIB write-only emits deep expression chains", "[SMTLIB]") {
+  std::string Path = makeTempPath();
+
+  {
+    auto Solver = std::make_unique<camada::SMTLIBSolver>(Path);
+    auto BV8 = Solver->mkBVSort(8);
+    auto X = Solver->mkSymbol("x", BV8);
+    auto One = Solver->mkBVFromBin("00000001", BV8);
+    auto Chain = X;
+    for (int I = 0; I < 50000; ++I)
+      Chain = Solver->mkBVAdd(Chain, One);
+    Solver->addConstraint(Solver->mkEqual(Chain, X));
+    Solver->check();
+  }
+
+  std::string Got = readFile(Path);
+  std::remove(Path.c_str());
+
+  REQUIRE(Got.find("(check-sat)") != std::string::npos);
+}

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -48,6 +48,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(implies_true_implies_false);
   RESETANDTEST(bv_lshr_semantics);
   RESETANDTEST(narrow_bv_decimal_model_value);
+  RESETANDTEST(shared_subterm_model_value);
   RESETANDTEST(wide_bv_decimal_model_value);
   RESETANDTEST(incremental_push_pop);
   RESETANDTEST(symbol_cache_survives_push_pop);

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -41,6 +41,91 @@
 
 namespace camada {
 
+namespace {
+
+// Render a structural SMT-LIB term to text. Subterms referenced more than
+// once within one emission are bound to let temporaries at their first
+// occurrence (the strategy of ESBMC's emit_ast): bindings accumulate in
+// Prefix in dependency order and the matching closing parens are appended
+// at the end. Once-used subterms are inlined, so tree-shaped formulas are
+// emitted exactly as before, without lets.
+class SMTLIBRenderer {
+public:
+  std::string render(const SMTExpr &Root) {
+    countRefs(Root);
+    std::string Body = emit(Root);
+    if (OpenLets == 0)
+      return Body;
+    std::string Out = std::move(Prefix);
+    Out += Body;
+    Out.append(OpenLets, ')');
+    return Out;
+  }
+
+private:
+  static const SMTLIBTerm &termOf(const SMTExpr &E) {
+    return toSolverExpr<SMTLIBExpr>(E).Expr;
+  }
+
+  void countRefs(const SMTExpr &Root) {
+    std::vector<const SMTExpr *> Stack{&Root};
+    while (!Stack.empty()) {
+      const SMTExpr *E = Stack.back();
+      Stack.pop_back();
+      if (++RefCount[E] > 1)
+        continue;
+      const SMTLIBTerm &T = termOf(*E);
+      if (T.OwnScope)
+        continue; // binder args render in their own scope
+      for (const SMTExprRef &Arg : T.Args)
+        Stack.push_back(&*Arg);
+    }
+  }
+
+  std::string emit(const SMTExpr &E) {
+    const SMTLIBTerm &T = termOf(E);
+    if (T.Args.empty())
+      return T.Head; // terminals are cheap: always inline
+    if (auto It = Memo.find(&E); It != Memo.end())
+      return It->second;
+    std::string Text = "(";
+    Text += T.Head;
+    for (const SMTExprRef &Arg : T.Args) {
+      Text += " ";
+      // Binder arguments must not share subterms with the outside of the
+      // binder, so they render in a fresh scope. Inner let temporaries may
+      // shadow outer ones; that is harmless because a fresh scope never
+      // references outer temporaries.
+      Text += T.OwnScope ? SMTLIBRenderer().render(*Arg) : emit(*Arg);
+    }
+    Text += ")";
+    if (RefCount[&E] > 1) {
+      std::string Temp = "?x" + std::to_string(NextTemp++);
+      Prefix += "(let ((" + Temp + " " + Text + ")) ";
+      ++OpenLets;
+      Memo.emplace(&E, Temp);
+      return Temp;
+    }
+    return Text;
+  }
+
+  std::unordered_map<const SMTExpr *, unsigned> RefCount;
+  std::unordered_map<const SMTExpr *, std::string> Memo;
+  std::string Prefix;
+  unsigned OpenLets = 0;
+  unsigned NextTemp = 0;
+};
+
+std::string renderSMTLIBExpr(const SMTExpr &E) {
+  return SMTLIBRenderer().render(E);
+}
+
+std::string renderSMTLIBExpr(const SMTExprRef &E) {
+  return SMTLIBRenderer().render(*E);
+}
+
+} // namespace
+
 // ---------------------------------------------------------------------------
 // SMTLIBSort / SMTLIBExpr
 // ---------------------------------------------------------------------------
@@ -70,7 +155,14 @@ void SMTLIBSort::dump(std::string &Out) const {
 bool SMTLIBExpr::equal_to(SMTExpr const &Other) const {
   if (Sort != Other.Sort || Other.getBackendKind() != getBackendKind())
     return false;
-  return Expr == static_cast<const SMTLIBExpr &>(Other).Expr;
+  const auto &O = static_cast<const SMTLIBExpr &>(Other);
+  if (Expr.Head != O.Expr.Head || Expr.OwnScope != O.Expr.OwnScope ||
+      Expr.Args.size() != O.Expr.Args.size())
+    return false;
+  for (std::size_t I = 0; I < Expr.Args.size(); ++I)
+    if (!(*Expr.Args[I] == *O.Expr.Args[I]))
+      return false;
+  return true;
 }
 
 void SMTLIBExpr::dump() const {
@@ -80,7 +172,7 @@ void SMTLIBExpr::dump() const {
 }
 
 void SMTLIBExpr::dump(std::string &Out) const {
-  Out = Expr;
+  Out = renderSMTLIBExpr(*this);
   Out += "\n";
 }
 
@@ -538,10 +630,6 @@ std::string quoteSymbol(const std::string &Name) {
   return Out;
 }
 
-const std::string &textOf(const SMTExprRef &E) {
-  return toSolverExpr<SMTLIBExpr>(*E).Expr;
-}
-
 const std::string &textOf(const SMTSortRef &S) {
   return toSolverSort<SMTLIBSort>(*S).Sort;
 }
@@ -627,7 +715,17 @@ void SMTLIBSolver::emitLine(const std::string &Text) const {
 SMTExprRef SMTLIBSolver::makeSMTLIBExpr(SMTExprKind Kind,
                                         const SMTSortRef &Sort,
                                         std::string Text) {
-  return makeExprRef<SMTLIBExpr>(Kind, this, Sort, std::move(Text));
+  return makeExprRef<SMTLIBExpr>(Kind, this, Sort,
+                                 SMTLIBTerm{std::move(Text), {}, false});
+}
+
+SMTExprRef SMTLIBSolver::makeSMTLIBExpr(SMTExprKind Kind,
+                                        const SMTSortRef &Sort,
+                                        std::string Head,
+                                        std::vector<SMTExprRef> Args,
+                                        bool OwnScope) {
+  return makeExprRef<SMTLIBExpr>(
+      Kind, this, Sort, SMTLIBTerm{std::move(Head), std::move(Args), OwnScope});
 }
 
 // --- core dispatch helpers ---
@@ -640,7 +738,7 @@ SMTExprRef SMTLIBSolver::rewrapExprImpl(const SMTExpr &Exp,
 }
 
 void SMTLIBSolver::addConstraintImpl(const SMTExprRef &Exp) {
-  emitLine("(assert " + textOf(Exp) + ")");
+  emitLine("(assert " + renderSMTLIBExpr(Exp) + ")");
 }
 
 // --- sorts ---
@@ -758,25 +856,20 @@ SMTSortRef SMTLIBSolver::mkArraySortImpl(const SMTSortRef &IndexSort,
 
 #define CAMADA_SMTLIB_UNARY(Name, OpStr, Kind, ResultSort)                     \
   SMTExprRef SMTLIBSolver::Name(const SMTExprRef &Exp) {                       \
-    return makeSMTLIBExpr(SMTExprKind::Kind, ResultSort,                       \
-                          "(" OpStr " " + textOf(Exp) + ")");                  \
+    return makeSMTLIBExpr(SMTExprKind::Kind, ResultSort, OpStr, {Exp});        \
   }
 
 #define CAMADA_SMTLIB_BINARY(Name, OpStr, Kind, ResultSort)                    \
   SMTExprRef SMTLIBSolver::Name(const SMTExprRef &LHS,                         \
                                 const SMTExprRef &RHS) {                       \
-    return makeSMTLIBExpr(SMTExprKind::Kind, ResultSort,                       \
-                          "(" OpStr " " + textOf(LHS) + " " + textOf(RHS) +    \
-                              ")");                                            \
+    return makeSMTLIBExpr(SMTExprKind::Kind, ResultSort, OpStr, {LHS, RHS});   \
   }
 
 // Rounded binary FP arithmetic: (op rm lhs rhs).
 #define CAMADA_SMTLIB_RM_BINARY(Name, OpStr, Kind)                             \
   SMTExprRef SMTLIBSolver::Name(const SMTExprRef &LHS, const SMTExprRef &RHS,  \
                                 const SMTExprRef &R) {                         \
-    return makeSMTLIBExpr(SMTExprKind::Kind, LHS->Sort,                        \
-                          "(" OpStr " " + textOf(R) + " " + textOf(LHS) +      \
-                              " " + textOf(RHS) + ")");                        \
+    return makeSMTLIBExpr(SMTExprKind::Kind, LHS->Sort, OpStr, {R, LHS, RHS}); \
   }
 
 CAMADA_SMTLIB_UNARY(mkBVNegImpl, "bvneg", BVNeg, Exp->Sort)
@@ -806,52 +899,47 @@ CAMADA_SMTLIB_BINARY(mkOrImpl, "or", Or, mkBoolSort())
 
 SMTExprRef SMTLIBSolver::mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                                    const SMTExprRef &F) {
-  return makeSMTLIBExpr(SMTExprKind::Ite, T->Sort,
-                        "(ite " + textOf(Cond) + " " + textOf(T) + " " +
-                            textOf(F) + ")");
+  return makeSMTLIBExpr(SMTExprKind::Ite, T->Sort, "ite", {Cond, T, F});
 }
 
 SMTExprRef SMTLIBSolver::mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) {
   unsigned NewWidth = Exp->getWidth() + i;
   return makeSMTLIBExpr(SMTExprKind::BVSignExt, mkBVSort(NewWidth),
-                        "((_ sign_extend " + utoa(i) + ") " + textOf(Exp) +
-                            ")");
+                        "(_ sign_extend " + utoa(i) + ")", {Exp});
 }
 
 SMTExprRef SMTLIBSolver::mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) {
   unsigned NewWidth = Exp->getWidth() + i;
   return makeSMTLIBExpr(SMTExprKind::BVZeroExt, mkBVSort(NewWidth),
-                        "((_ zero_extend " + utoa(i) + ") " + textOf(Exp) +
-                            ")");
+                        "(_ zero_extend " + utoa(i) + ")", {Exp});
 }
 
 SMTExprRef SMTLIBSolver::mkBVExtractImpl(unsigned High, unsigned Low,
                                          const SMTExprRef &Exp) {
   unsigned Width = High - Low + 1;
   return makeSMTLIBExpr(SMTExprKind::BVExtract, mkBVSort(Width),
-                        "((_ extract " + utoa(High) + " " + utoa(Low) + ") " +
-                            textOf(Exp) + ")");
+                        "(_ extract " + utoa(High) + " " + utoa(Low) + ")",
+                        {Exp});
 }
 
 SMTExprRef SMTLIBSolver::mkBVConcatImpl(const SMTExprRef &LHS,
                                         const SMTExprRef &RHS) {
   unsigned Width = LHS->getWidth() + RHS->getWidth();
-  return makeSMTLIBExpr(SMTExprKind::BVConcat, mkBVSort(Width),
-                        "(concat " + textOf(LHS) + " " + textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::BVConcat, mkBVSort(Width), "concat",
+                        {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkArraySelectImpl(const SMTExprRef &Array,
                                            const SMTExprRef &Index) {
   return makeSMTLIBExpr(SMTExprKind::ArraySelect, Array->Sort->getElementSort(),
-                        "(select " + textOf(Array) + " " + textOf(Index) + ")");
+                        "select", {Array, Index});
 }
 
 SMTExprRef SMTLIBSolver::mkArrayStoreImpl(const SMTExprRef &Array,
                                           const SMTExprRef &Index,
                                           const SMTExprRef &Element) {
-  return makeSMTLIBExpr(SMTExprKind::ArrayStore, Array->Sort,
-                        "(store " + textOf(Array) + " " + textOf(Index) + " " +
-                            textOf(Element) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArrayStore, Array->Sort, "store",
+                        {Array, Index, Element});
 }
 
 // --- constants and symbols ---
@@ -920,7 +1008,7 @@ SMTExprRef SMTLIBSolver::mkArrayConstImpl(const SMTSortRef &IndexSort,
   const std::string Name = "__CAMADA_aconst" + std::to_string(NextArrConstId++);
   std::string Quoted = quoteSymbol(Name);
   std::string LiteralText =
-      "((as const " + textOf(Arr) + ") " + textOf(InitValue) + ")";
+      "((as const " + textOf(Arr) + ") " + renderSMTLIBExpr(InitValue) + ")";
   std::string Defn =
       "(define-fun " + Quoted + " () " + textOf(Arr) + " " + LiteralText + ")";
   emitLine(Defn);
@@ -1003,8 +1091,7 @@ SMTExprRef SMTLIBSolver::mkFPNegImpl(const SMTExprRef &Exp,
   // SMT-LIB's fp.neg has PreserveNaNPayload semantics — sign bit flipped on
   // non-NaNs, NaN payload preserved. That maps directly.
   if (Behavior == FPNegBehavior::PreserveNaNPayload)
-    return makeSMTLIBExpr(SMTExprKind::FPNeg, Exp->Sort,
-                          "(fp.neg " + textOf(Exp) + ")");
+    return makeSMTLIBExpr(SMTExprKind::FPNeg, Exp->Sort, "fp.neg", {Exp});
 
   // FlipSignBit must flip the top bit unconditionally, NaN included. SMT-LIB
   // has no direct op for that, so round-trip through the IEEE BV view: pull
@@ -1038,15 +1125,12 @@ CAMADA_SMTLIB_BINARY(mkFPRemImpl, "fp.rem", FPRem, LHS->Sort)
 
 SMTExprRef SMTLIBSolver::mkFPSqrtImpl(const SMTExprRef &Exp,
                                       const SMTExprRef &R) {
-  return makeSMTLIBExpr(SMTExprKind::FPSqrt, Exp->Sort,
-                        "(fp.sqrt " + textOf(R) + " " + textOf(Exp) + ")");
+  return makeSMTLIBExpr(SMTExprKind::FPSqrt, Exp->Sort, "fp.sqrt", {R, Exp});
 }
 
 SMTExprRef SMTLIBSolver::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
                                      const SMTExprRef &Z, const SMTExprRef &R) {
-  return makeSMTLIBExpr(SMTExprKind::FPFMA, X->Sort,
-                        "(fp.fma " + textOf(R) + " " + textOf(X) + " " +
-                            textOf(Y) + " " + textOf(Z) + ")");
+  return makeSMTLIBExpr(SMTExprKind::FPFMA, X->Sort, "fp.fma", {R, X, Y, Z});
 }
 
 CAMADA_SMTLIB_BINARY(mkFPLtImpl, "fp.lt", FPLt, mkBoolSort())
@@ -1062,64 +1146,55 @@ CAMADA_SMTLIB_BINARY(mkFPEqualImpl, "fp.eq", FPEqual, mkBoolSort())
 SMTExprRef SMTLIBSolver::mkFPtoFPImpl(const SMTExprRef &From,
                                       const SMTSortRef &To,
                                       const SMTExprRef &R) {
-  std::string Text = "((_ to_fp " + utoa(To->getFPExponentWidth()) + " " +
-                     utoa(To->getFPSignificandWidth() + 1) + ") " + textOf(R) +
-                     " " + textOf(From) + ")";
-  return makeSMTLIBExpr(SMTExprKind::FPtoFP, To, std::move(Text));
+  std::string Head = "(_ to_fp " + utoa(To->getFPExponentWidth()) + " " +
+                     utoa(To->getFPSignificandWidth() + 1) + ")";
+  return makeSMTLIBExpr(SMTExprKind::FPtoFP, To, std::move(Head), {R, From});
 }
 
 SMTExprRef SMTLIBSolver::mkSBVtoFPImpl(const SMTExprRef &From,
                                        const SMTSortRef &To,
                                        const SMTExprRef &R) {
   // Same opcode as fp→fp; SMT-LIB disambiguates by argument sort.
-  std::string Text = "((_ to_fp " + utoa(To->getFPExponentWidth()) + " " +
-                     utoa(To->getFPSignificandWidth() + 1) + ") " + textOf(R) +
-                     " " + textOf(From) + ")";
-  return makeSMTLIBExpr(SMTExprKind::SBVtoFP, To, std::move(Text));
+  std::string Head = "(_ to_fp " + utoa(To->getFPExponentWidth()) + " " +
+                     utoa(To->getFPSignificandWidth() + 1) + ")";
+  return makeSMTLIBExpr(SMTExprKind::SBVtoFP, To, std::move(Head), {R, From});
 }
 
 SMTExprRef SMTLIBSolver::mkUBVtoFPImpl(const SMTExprRef &From,
                                        const SMTSortRef &To,
                                        const SMTExprRef &R) {
-  std::string Text = "((_ to_fp_unsigned " + utoa(To->getFPExponentWidth()) +
-                     " " + utoa(To->getFPSignificandWidth() + 1) + ") " +
-                     textOf(R) + " " + textOf(From) + ")";
-  return makeSMTLIBExpr(SMTExprKind::UBVtoFP, To, std::move(Text));
+  std::string Head = "(_ to_fp_unsigned " + utoa(To->getFPExponentWidth()) +
+                     " " + utoa(To->getFPSignificandWidth() + 1) + ")";
+  return makeSMTLIBExpr(SMTExprKind::UBVtoFP, To, std::move(Head), {R, From});
 }
 
 SMTExprRef SMTLIBSolver::mkFPtoSBVImpl(const SMTExprRef &From,
                                        unsigned ToWidth) {
   const SMTExprRef &R = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
-  std::string Text = "((_ fp.to_sbv " + utoa(ToWidth) + ") " + textOf(R) + " " +
-                     textOf(From) + ")";
   return makeSMTLIBExpr(SMTExprKind::FPtoSBV, mkBVSort(ToWidth),
-                        std::move(Text));
+                        "(_ fp.to_sbv " + utoa(ToWidth) + ")", {R, From});
 }
 
 SMTExprRef SMTLIBSolver::mkFPtoUBVImpl(const SMTExprRef &From,
                                        unsigned ToWidth) {
   const SMTExprRef &R = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
-  std::string Text = "((_ fp.to_ubv " + utoa(ToWidth) + ") " + textOf(R) + " " +
-                     textOf(From) + ")";
   return makeSMTLIBExpr(SMTExprKind::FPtoUBV, mkBVSort(ToWidth),
-                        std::move(Text));
+                        "(_ fp.to_ubv " + utoa(ToWidth) + ")", {R, From});
 }
 
 SMTExprRef SMTLIBSolver::mkFPtoIntegralImpl(const SMTExprRef &From,
                                             const SMTExprRef &R) {
   return makeSMTLIBExpr(SMTExprKind::FPtoIntegral, From->Sort,
-                        "(fp.roundToIntegral " + textOf(R) + " " +
-                            textOf(From) + ")");
+                        "fp.roundToIntegral", {R, From});
 }
 
 SMTExprRef SMTLIBSolver::mkBVToIEEEFPImpl(const SMTExprRef &Exp,
                                           const SMTSortRef &To) {
   // ((_ to_fp eb sb) bv) form (no rounding mode) reinterprets a same-width BV
   // as an IEEE FP.
-  std::string Text = "((_ to_fp " + utoa(To->getFPExponentWidth()) + " " +
-                     utoa(To->getFPSignificandWidth() + 1) + ") " +
-                     textOf(Exp) + ")";
-  return makeSMTLIBExpr(SMTExprKind::BVToIEEEFP, To, std::move(Text));
+  std::string Head = "(_ to_fp " + utoa(To->getFPExponentWidth()) + " " +
+                     utoa(To->getFPSignificandWidth() + 1) + ")";
+  return makeSMTLIBExpr(SMTExprKind::BVToIEEEFP, To, std::move(Head), {Exp});
 }
 
 SMTExprRef SMTLIBSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
@@ -1210,26 +1285,22 @@ SMTExprRef SMTLIBSolver::mkRealImpl(int64_t num, int64_t den) {
 }
 
 SMTExprRef SMTLIBSolver::mkArithNegImpl(const SMTExprRef &Exp) {
-  return makeSMTLIBExpr(SMTExprKind::ArithNeg, Exp->Sort,
-                        "(- " + textOf(Exp) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithNeg, Exp->Sort, "-", {Exp});
 }
 
 SMTExprRef SMTLIBSolver::mkArithAddImpl(const SMTExprRef &LHS,
                                         const SMTExprRef &RHS) {
-  return makeSMTLIBExpr(SMTExprKind::ArithAdd, LHS->Sort,
-                        "(+ " + textOf(LHS) + " " + textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithAdd, LHS->Sort, "+", {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkArithSubImpl(const SMTExprRef &LHS,
                                         const SMTExprRef &RHS) {
-  return makeSMTLIBExpr(SMTExprKind::ArithSub, LHS->Sort,
-                        "(- " + textOf(LHS) + " " + textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithSub, LHS->Sort, "-", {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkArithMulImpl(const SMTExprRef &LHS,
                                         const SMTExprRef &RHS) {
-  return makeSMTLIBExpr(SMTExprKind::ArithMul, LHS->Sort,
-                        "(* " + textOf(LHS) + " " + textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithMul, LHS->Sort, "*", {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkArithDivImpl(const SMTExprRef &LHS,
@@ -1238,54 +1309,44 @@ SMTExprRef SMTLIBSolver::mkArithDivImpl(const SMTExprRef &LHS,
   // Camada dispatches on operand sort, so this method receives both kinds —
   // pick the right token based on the LHS sort.
   const char *Op = LHS->Sort->isIntSort() ? "div" : "/";
-  return makeSMTLIBExpr(SMTExprKind::ArithDiv, LHS->Sort,
-                        std::string("(") + Op + " " + textOf(LHS) + " " +
-                            textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithDiv, LHS->Sort, Op, {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkArithModImpl(const SMTExprRef &LHS,
                                         const SMTExprRef &RHS) {
-  return makeSMTLIBExpr(SMTExprKind::ArithMod, mkIntSort(),
-                        "(mod " + textOf(LHS) + " " + textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithMod, mkIntSort(), "mod", {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkArithLtImpl(const SMTExprRef &LHS,
                                        const SMTExprRef &RHS) {
-  return makeSMTLIBExpr(SMTExprKind::ArithLt, mkBoolSort(),
-                        "(< " + textOf(LHS) + " " + textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithLt, mkBoolSort(), "<", {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkArithGtImpl(const SMTExprRef &LHS,
                                        const SMTExprRef &RHS) {
-  return makeSMTLIBExpr(SMTExprKind::ArithGt, mkBoolSort(),
-                        "(> " + textOf(LHS) + " " + textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithGt, mkBoolSort(), ">", {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkArithLeImpl(const SMTExprRef &LHS,
                                        const SMTExprRef &RHS) {
-  return makeSMTLIBExpr(SMTExprKind::ArithLe, mkBoolSort(),
-                        "(<= " + textOf(LHS) + " " + textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithLe, mkBoolSort(), "<=", {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkArithGeImpl(const SMTExprRef &LHS,
                                        const SMTExprRef &RHS) {
-  return makeSMTLIBExpr(SMTExprKind::ArithGe, mkBoolSort(),
-                        "(>= " + textOf(LHS) + " " + textOf(RHS) + ")");
+  return makeSMTLIBExpr(SMTExprKind::ArithGe, mkBoolSort(), ">=", {LHS, RHS});
 }
 
 SMTExprRef SMTLIBSolver::mkInt2RealImpl(const SMTExprRef &Exp) {
-  return makeSMTLIBExpr(SMTExprKind::Int2Real, mkRealSort(),
-                        "(to_real " + textOf(Exp) + ")");
+  return makeSMTLIBExpr(SMTExprKind::Int2Real, mkRealSort(), "to_real", {Exp});
 }
 
 SMTExprRef SMTLIBSolver::mkReal2IntImpl(const SMTExprRef &Exp) {
-  return makeSMTLIBExpr(SMTExprKind::Real2Int, mkIntSort(),
-                        "(to_int " + textOf(Exp) + ")");
+  return makeSMTLIBExpr(SMTExprKind::Real2Int, mkIntSort(), "to_int", {Exp});
 }
 
 SMTExprRef SMTLIBSolver::mkIsIntImpl(const SMTExprRef &Exp) {
-  return makeSMTLIBExpr(SMTExprKind::IsInt, mkBoolSort(),
-                        "(is_int " + textOf(Exp) + ")");
+  return makeSMTLIBExpr(SMTExprKind::IsInt, mkBoolSort(), "is_int", {Exp});
 }
 
 // --- UF + quantifiers ---
@@ -1294,18 +1355,14 @@ SMTExprRef SMTLIBSolver::mkIsIntImpl(const SMTExprRef &Exp) {
 // the function symbol name (set when the symbol was declared).
 SMTExprRef SMTLIBSolver::mkApplyImpl(const SMTExprRef &Function,
                                      const std::vector<SMTExprRef> &Args) {
-  std::string Text = "(" + textOf(Function);
-  for (const auto &Arg : Args) {
-    Text += " ";
-    Text += textOf(Arg);
-  }
-  Text += ")";
+  // Function is always a declared symbol, so its Head is the (quoted)
+  // function name; the application node carries the operands.
   return makeSMTLIBExpr(SMTExprKind::Apply, Function->Sort->getCodomainSort(),
-                        std::move(Text));
+                        toSolverExpr<SMTLIBExpr>(*Function).Expr.Head, Args);
 }
 
 // Render a quantifier's bound-variable list `((v1 S1) (v2 S2) ...)`. Each var
-// is a Symbol expression whose textOf() is the already-quoted variable name.
+// is a Symbol expression whose Head is the already-quoted variable name.
 //
 // Camada's regression tests pass quantifier vars that were created via
 // mkSymbol — which means we already emitted `(declare-fun v () S)` at the
@@ -1319,7 +1376,7 @@ static std::string renderBinders(const std::vector<SMTExprRef> &Vars) {
     if (I)
       Out += " ";
     Out += "(";
-    Out += static_cast<const SMTLIBExpr &>(*Vars[I]).Expr;
+    Out += static_cast<const SMTLIBExpr &>(*Vars[I]).Expr.Head;
     Out += " ";
     Out += static_cast<const SMTLIBSort &>(*Vars[I]->Sort).Sort;
     Out += ")";
@@ -1329,16 +1386,16 @@ static std::string renderBinders(const std::vector<SMTExprRef> &Vars) {
 
 SMTExprRef SMTLIBSolver::mkForallImpl(const std::vector<SMTExprRef> &Vars,
                                       const SMTExprRef &Body) {
-  std::string Text =
-      "(forall (" + renderBinders(Vars) + ") " + textOf(Body) + ")";
-  return makeSMTLIBExpr(SMTExprKind::Forall, mkBoolSort(), std::move(Text));
+  return makeSMTLIBExpr(SMTExprKind::Forall, mkBoolSort(),
+                        "forall (" + renderBinders(Vars) + ")", {Body},
+                        /*OwnScope=*/true);
 }
 
 SMTExprRef SMTLIBSolver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
                                       const SMTExprRef &Body) {
-  std::string Text =
-      "(exists (" + renderBinders(Vars) + ") " + textOf(Body) + ")";
-  return makeSMTLIBExpr(SMTExprKind::Exists, mkBoolSort(), std::move(Text));
+  return makeSMTLIBExpr(SMTExprKind::Exists, mkBoolSort(),
+                        "exists (" + renderBinders(Vars) + ")", {Body},
+                        /*OwnScope=*/true);
 }
 
 // --- tuples ---
@@ -1353,28 +1410,19 @@ SMTExprRef SMTLIBSolver::mkTupleImpl(const std::vector<SMTExprRef> &Elements) {
     ElementSorts.push_back(E->Sort);
   SMTSortRef TupleSort = mkTupleSort(ElementSorts);
   const std::string &Name = static_cast<const SMTLIBSort &>(*TupleSort).Sort;
-  std::string Text;
-  if (Elements.empty()) {
-    Text = Name + "_mk";
-  } else {
-    Text = "(" + Name + "_mk";
-    for (const auto &E : Elements) {
-      Text += " ";
-      Text += textOf(E);
-    }
-    Text += ")";
-  }
-  return makeSMTLIBExpr(SMTExprKind::TupleConst, TupleSort, std::move(Text));
+  if (Elements.empty())
+    return makeSMTLIBExpr(SMTExprKind::TupleConst, TupleSort, Name + "_mk");
+  return makeSMTLIBExpr(SMTExprKind::TupleConst, TupleSort, Name + "_mk",
+                        Elements);
 }
 
 // Project tuple field i: (<sortname>_p<i> t).
 SMTExprRef SMTLIBSolver::mkTupleSelectImpl(const SMTExprRef &Tuple,
                                            unsigned Index) {
   const std::string &Name = static_cast<const SMTLIBSort &>(*Tuple->Sort).Sort;
-  std::string Text =
-      "(" + Name + "_p" + utoa(Index) + " " + textOf(Tuple) + ")";
   SMTSortRef ElementSort = Tuple->Sort->getTupleElementSorts()[Index];
-  return makeSMTLIBExpr(SMTExprKind::TupleSelect, ElementSort, std::move(Text));
+  return makeSMTLIBExpr(SMTExprKind::TupleSelect, ElementSort,
+                        Name + "_p" + utoa(Index), {Tuple});
 }
 
 // --- write-only model queries / check ---
@@ -1976,7 +2024,7 @@ SMTResult<std::string> SMTLIBSolver::sendGetValue(const SMTExprRef &Exp,
     return SMTError{SMTErrorCode::UnsupportedOperation, SMTBackendKind::SMTLIB,
                     "SMTLIBSolver write-only mode does not support get*"};
 
-  const std::string Cmd = "(get-value (" + textOf(Exp) + "))\n";
+  const std::string Cmd = "(get-value (" + renderSMTLIBExpr(Exp) + "))\n";
   if (File)
     File->emitRaw(Cmd);
   Proc->emitRaw(Cmd);

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -82,31 +82,71 @@ private:
     }
   }
 
-  std::string emit(const SMTExpr &E) {
-    const SMTLIBTerm &T = termOf(E);
-    if (T.Args.empty())
-      return T.Head; // terminals are cheap: always inline
-    if (auto It = Memo.find(&E); It != Memo.end())
-      return It->second;
-    std::string Text = "(";
-    Text += T.Head;
-    for (const SMTExprRef &Arg : T.Args) {
-      Text += " ";
-      // Binder arguments must not share subterms with the outside of the
-      // binder, so they render in a fresh scope. Inner let temporaries may
-      // shadow outer ones; that is harmless because a fresh scope never
-      // references outer temporaries.
-      Text += T.OwnScope ? SMTLIBRenderer().render(*Arg) : emit(*Arg);
+  // Iterative post-order emission: recursion would overflow the stack on
+  // deep, lightly shared chains (SSA-style formulas reach hundreds of
+  // thousands of nodes).
+  std::string emit(const SMTExpr &Root) {
+    struct Frame {
+      const SMTExpr *E;
+      const SMTLIBTerm *T;
+      std::size_t NextArg;
+      std::string Text;
+    };
+    std::string Leaf;
+    std::vector<Frame> Stack;
+    // Returns true when the expression's text is available immediately in
+    // Leaf (terminal or memoized); otherwise opens a frame for it.
+    const auto enter = [&](const SMTExpr &E) {
+      const SMTLIBTerm &T = termOf(E);
+      if (T.Args.empty()) {
+        Leaf = T.Head; // terminals are cheap: always inline
+        return true;
+      }
+      if (auto It = Memo.find(&E); It != Memo.end()) {
+        Leaf = It->second;
+        return true;
+      }
+      Stack.push_back(Frame{&E, &T, 0, "(" + T.Head});
+      return false;
+    };
+    if (enter(Root))
+      return Leaf;
+    while (true) {
+      Frame &F = Stack.back();
+      if (F.NextArg < F.T->Args.size()) {
+        const SMTExprRef &Arg = F.T->Args[F.NextArg];
+        F.Text += " ";
+        ++F.NextArg;
+        // Binder arguments must not share subterms with the outside of the
+        // binder, so they render in a fresh scope. Inner let temporaries
+        // may shadow outer ones; that is harmless because a fresh scope
+        // never references outer temporaries.
+        if (F.T->OwnScope) {
+          F.Text += SMTLIBRenderer().render(*Arg);
+          continue;
+        }
+        if (enter(*Arg))
+          Stack.back().Text += Leaf; // enter() may have re-seated back()
+        continue;
+      }
+      F.Text += ")";
+      std::string Done = std::move(F.Text);
+      const SMTExpr *E = F.E;
+      Stack.pop_back();
+      if (RefCount[E] > 1) {
+        // Temp names contain a bare '%', which quoteSymbol output can never
+        // produce (every literal '%' in a user name is encoded as "%25"),
+        // so a temporary can never capture a user symbol.
+        std::string Temp = "%t" + std::to_string(NextTemp++);
+        Prefix += "(let ((" + Temp + " " + Done + ")) ";
+        ++OpenLets;
+        Memo.emplace(E, Temp);
+        Done = std::move(Temp);
+      }
+      if (Stack.empty())
+        return Done;
+      Stack.back().Text += Done;
     }
-    Text += ")";
-    if (RefCount[&E] > 1) {
-      std::string Temp = "?x" + std::to_string(NextTemp++);
-      Prefix += "(let ((" + Temp + " " + Text + ")) ";
-      ++OpenLets;
-      Memo.emplace(&E, Temp);
-      return Temp;
-    }
-    return Text;
   }
 
   std::unordered_map<const SMTExpr *, unsigned> RefCount;
@@ -160,7 +200,8 @@ bool SMTLIBExpr::equal_to(SMTExpr const &Other) const {
       Expr.Args.size() != O.Expr.Args.size())
     return false;
   for (std::size_t I = 0; I < Expr.Args.size(); ++I)
-    if (!(*Expr.Args[I] == *O.Expr.Args[I]))
+    if (&*Expr.Args[I] != &*O.Expr.Args[I] &&
+        !(*Expr.Args[I] == *O.Expr.Args[I]))
       return false;
   return true;
 }
@@ -994,9 +1035,9 @@ SMTExprRef SMTLIBSolver::mkArrayConstImpl(const SMTSortRef &IndexSort,
   // Materialize through a fresh `(define-fun)` rather than inlining. Two
   // reasons:
   //   1. mathsat's SMT-LIB parser rejects `(as const ...)` inside
-  //      `(get-value ...)`. Camada's expression printer is inline-only, so
-  //      any later expression that wraps the const-array and is queried via
-  //      `(get-value ...)` would hit that parser bug. Binding the literal
+  //      `(get-value ...)`, so any later expression that inlines the
+  //      const-array literal and is queried via `(get-value ...)` would
+  //      hit that parser bug. Binding the literal
   //      to a name once up front means every downstream expression
   //      references the bare symbol.
   //   2. (define-fun ...) is permanent under :global-declarations true and
@@ -1357,6 +1398,8 @@ SMTExprRef SMTLIBSolver::mkApplyImpl(const SMTExprRef &Function,
                                      const std::vector<SMTExprRef> &Args) {
   // Function is always a declared symbol, so its Head is the (quoted)
   // function name; the application node carries the operands.
+  assert(toSolverExpr<SMTLIBExpr>(*Function).Expr.Args.empty() &&
+         "Function expressions must be plain symbols");
   return makeSMTLIBExpr(SMTExprKind::Apply, Function->Sort->getCodomainSort(),
                         toSolverExpr<SMTLIBExpr>(*Function).Expr.Head, Args);
 }

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -54,13 +54,26 @@ public:
   void dump(std::string &Out) const override;
 };
 
-/// SMT-LIB expression. The "native" representation is the SMT-LIB text for
-/// the expression — either inline like "(bvadd a b)" or, after let-binding,
-/// a temporary symbol name like "?x3".
-class SMTLIBExpr : public SolverExpr<SMTLIBContextRef, std::string> {
+/// Structural SMT-LIB term. Head is either the complete text of a terminal
+/// (symbol, literal) or the operator head of a compound term whose operands
+/// are in Args. Text is produced only at emission time (assert, get-value,
+/// define-fun, dump): subterms referenced more than once within an emission
+/// are bound to let temporaries, so heavily shared DAGs cost wire text
+/// linear in the DAG size instead of their unfolded tree size.
+struct SMTLIBTerm {
+  std::string Head;
+  std::vector<SMTExprRef> Args;
+  /// Binder-style nodes (quantifiers): every Arg is rendered in its own
+  /// let scope, since hoisting a subterm that mentions a bound variable
+  /// past the binder would unbind it.
+  bool OwnScope = false;
+};
+
+/// SMT-LIB expression carrying a structural SMTLIBTerm.
+class SMTLIBExpr : public SolverExpr<SMTLIBContextRef, SMTLIBTerm> {
 public:
   static constexpr SMTBackendKind BackendKindValue = SMTBackendKind::SMTLIB;
-  using SolverExpr<SMTLIBContextRef, std::string>::SolverExpr;
+  using SolverExpr<SMTLIBContextRef, SMTLIBTerm>::SolverExpr;
   ~SMTLIBExpr() override = default;
 
   SMTBackendKind getBackendKind() const override { return BackendKindValue; }
@@ -382,9 +395,14 @@ public:
   static std::string parseIntModelValueForTest(const std::string &Value);
 
 private:
-  // Build a bare expression carrying the given SMT-LIB text.
+  // Build a terminal expression (symbol or literal) carrying its full text.
   SMTExprRef makeSMTLIBExpr(SMTExprKind Kind, const SMTSortRef &Sort,
                             std::string Text);
+
+  // Build a compound expression from an operator head and its operands.
+  SMTExprRef makeSMTLIBExpr(SMTExprKind Kind, const SMTSortRef &Sort,
+                            std::string Head, std::vector<SMTExprRef> Args,
+                            bool OwnScope = false);
 
   // Emit a single line (newline appended) to the active emitter(s).
   void emitLine(const std::string &Text) const;


### PR DESCRIPTION
Fixes #70. Each `SMTLIBExpr` used to store the complete SMT-LIB text of its subtree, so every reuse of a shared subterm duplicated its full text: heavily shared DAGs — the BV-encoded FP fallback above all — exploded **exponentially** on the wire and in memory. A chain of six BVFP `fp.add`s exceeded 150 GB of RSS without terminating, which is why the bench driver gated all FP cases off this backend.

**Design** (ESBMC's `emit_ast` strategy, adapted): expressions carry a structural term — `Head` (terminal text or operator head) plus operand references, with an own-scope flag for binders. Text is produced only at emission time (assert, get-value, define-fun, dump) by a renderer that:
- counts references first and **inlines once-used subterms**, so tree-shaped formulas emit byte-identically to before (the golden write-only tests pass unchanged);
- binds shared compound subterms to `%tN` let temporaries at first occurrence, accumulated in dependency order;
- renders quantifier bodies in a fresh scope, since hoisting a subterm past a binder would unbind its variables;
- is fully iterative (no recursion on DAG depth).

**Results:** `fp_add_only` at 20 iterations on the smtlib backend: **0.1 s / 17 MB** (previously 6 iterations > 150 GB, non-terminating). The full 19-case bench at 50 iterations: **1.2 s / 30 MB**. The BVFP gating in the bench driver is removed — the smtlib backend now runs everything.

**Review hardening** (both findings were reproduced live by the reviewer): let temporaries were named `?xN`, which a user symbol named `?x0` could silently capture (`|?x0|` ≡ `?x0` in SMT-LIB; all four child solvers returned wrong values) — temps are now `%tN`, which `quoteSymbol` output can structurally never produce since literal `%` encodes as `%25`; and the emitter recursed to DAG depth, overflowing the stack near depth 3000 — now iterative, pinned by a 50k-node chain test. Expression equality is structural (with a pointer-identity shortcut) instead of text comparison.

**Tests:** 147/147 — all golden byte-exact write-only fixtures unchanged, new golden tests pinning the let shape and the capture-immunity, the deep-chain regression, and a shared-subterm model query exercising `let` inside `(get-value ...)` against every live child solver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)