### PR TITLE
Add assumption-based solving: checkSatAssuming and getUnsatAssumptions

### DIFF
--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -117,6 +117,9 @@ CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("implies_semantics",
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("implies_true_implies_false",
                                    implies_true_implies_false(solver),
                                    makeSMTLIBSolver)
+CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("check_sat_assuming_semantics",
+                                   check_sat_assuming_semantics(solver),
+                                   makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("bv_lshr_semantics",
                                    bv_lshr_semantics(solver), makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("incremental_push_pop",

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -81,6 +81,9 @@ CAMADA_CVC5_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver),
 CAMADA_CVC5_SMTLIB_SHARED_TEST("implies_true_implies_false",
                                implies_true_implies_false(solver),
                                makeSMTLIBSolver)
+CAMADA_CVC5_SMTLIB_SHARED_TEST("check_sat_assuming_semantics",
+                               check_sat_assuming_semantics(solver),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver),
                                makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("incremental_push_pop",

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -167,6 +167,9 @@ CAMADA_MATHSAT_SMTLIB_SHARED_TEST("implies_semantics",
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("implies_true_implies_false",
                                   implies_true_implies_false(solver),
                                   makeSMTLIBSolver)
+CAMADA_MATHSAT_SMTLIB_SHARED_TEST("check_sat_assuming_semantics",
+                                  check_sat_assuming_semantics(solver),
+                                  makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("bv_lshr_semantics",
                                   bv_lshr_semantics(solver), makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("incremental_push_pop",

--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -80,6 +80,51 @@ inline void implies_true_implies_false(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::checkResult::UNSAT);
 }
 
+inline void check_sat_assuming_semantics(const camada::SMTSolverRef &solver) {
+  auto a = solver->mkSymbol("a", solver->mkBoolSort());
+  auto b = solver->mkSymbol("b", solver->mkBoolSort());
+  solver->addConstraint(solver->mkOr(a, b));
+
+  // Assuming both false contradicts (or a b).
+  const std::vector<camada::SMTExprRef> negBoth = {solver->mkNot(a),
+                                                   solver->mkNot(b)};
+  REQUIRE(solver->checkSatAssuming(negBoth) == camada::checkResult::UNSAT);
+
+  auto core = solver->getUnsatAssumptions();
+  if (core) {
+    // The core must be a non-empty subset that is itself sufficient:
+    // re-checking under only the returned assumptions stays UNSAT.
+    REQUIRE(!core.value().empty());
+    REQUIRE(solver->checkSatAssuming(core.value()) ==
+            camada::checkResult::UNSAT);
+  } else {
+    REQUIRE(core.error().Code == camada::SMTErrorCode::UnsupportedOperation);
+  }
+
+  // A compound (non-literal) assumption must work too — backends whose
+  // native API only accepts literals lower it through activation literals.
+  REQUIRE(solver->checkSatAssuming({solver->mkNot(solver->mkOr(a, b))}) ==
+          camada::checkResult::UNSAT);
+
+  // Assumptions are per-query: they do not persist into later checks.
+  REQUIRE(solver->checkSatAssuming({a}) == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // After a check that was not an UNSAT checkSatAssuming, the unsat
+  // assumptions are stale and querying them is an error.
+  REQUIRE(!solver->getUnsatAssumptions());
+
+  // Mutating the solver state after an UNSAT checkSatAssuming also
+  // invalidates the unsat assumptions.
+  REQUIRE(solver->checkSatAssuming(negBoth) == camada::checkResult::UNSAT);
+  solver->push();
+  REQUIRE(!solver->getUnsatAssumptions());
+  solver->pop();
+
+  // An empty assumption set degenerates to a plain check.
+  REQUIRE(solver->checkSatAssuming({}) == camada::checkResult::SAT);
+}
+
 inline void bv_lshr_semantics(const camada::SMTSolverRef &solver) {
   auto value = solver->mkBVFromBin("1000", 4);
   auto shift = solver->mkBVFromDec(1, 4);

--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -74,6 +74,7 @@ TEST_CASE("SMTLIB write-only emits a minimal script", "[SMTLIB]") {
 
   const std::string Expected = "(set-option :print-success false)\n"
                                "(set-option :produce-models true)\n"
+                               "(set-option :produce-unsat-assumptions true)\n"
                                "(set-option :global-declarations true)\n"
                                "(set-info :status unknown)\n"
                                "(set-logic ALL)\n"
@@ -277,6 +278,7 @@ TEST_CASE("SMTLIB write-only let-binds shared subterms", "[SMTLIB]") {
   const std::string Expected =
       "(set-option :print-success false)\n"
       "(set-option :produce-models true)\n"
+      "(set-option :produce-unsat-assumptions true)\n"
       "(set-option :global-declarations true)\n"
       "(set-info :status unknown)\n"
       "(set-logic ALL)\n"
@@ -311,6 +313,7 @@ TEST_CASE("SMTLIB write-only let temporaries cannot capture user symbols",
 
   const std::string Expected = "(set-option :print-success false)\n"
                                "(set-option :produce-models true)\n"
+                               "(set-option :produce-unsat-assumptions true)\n"
                                "(set-option :global-declarations true)\n"
                                "(set-info :status unknown)\n"
                                "(set-logic ALL)\n"

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -48,6 +48,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(implies_true_implies_false);
   RESETANDTEST(bv_lshr_semantics);
   RESETANDTEST(bv_overflow_semantics);
+  RESETANDTEST(check_sat_assuming_semantics);
   RESETANDTEST(narrow_bv_decimal_model_value);
   RESETANDTEST(shared_subterm_model_value);
   RESETANDTEST(wide_bv_decimal_model_value);

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -172,6 +172,9 @@ CAMADA_YICES_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver),
 CAMADA_YICES_SMTLIB_SHARED_TEST("implies_true_implies_false",
                                 implies_true_implies_false(solver),
                                 makeSMTLIBSolver)
+CAMADA_YICES_SMTLIB_SHARED_TEST("check_sat_assuming_semantics",
+                                check_sat_assuming_semantics(solver),
+                                makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver),
                                 makeSMTLIBSolver)
 CAMADA_YICES_SMTLIB_SHARED_TEST("incremental_push_pop",

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -115,6 +115,9 @@ CAMADA_Z3_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver),
 CAMADA_Z3_SMTLIB_SHARED_TEST("implies_true_implies_false",
                              implies_true_implies_false(solver),
                              makeSMTLIBSolver)
+CAMADA_Z3_SMTLIB_SHARED_TEST("check_sat_assuming_semantics",
+                             check_sat_assuming_semantics(solver),
+                             makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver),
                              makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("incremental_push_pop",

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -127,6 +127,7 @@ void BitwuzlaSolver::initializeContext() {
   TermManager = bitwuzla_term_manager_new();
   Options = bitwuzla_options_new();
   bitwuzla_set_option(Options, BITWUZLA_OPT_PRODUCE_MODELS, 1);
+  bitwuzla_set_option(Options, BITWUZLA_OPT_PRODUCE_UNSAT_ASSUMPTIONS, 1);
   bitwuzla_set_abort_callback(bitwuzlaErrorHandler);
   Context = bitwuzla_new(TermManager, Options);
 }
@@ -974,6 +975,35 @@ checkResult BitwuzlaSolver::checkImpl() {
   if (res == BITWUZLA_UNSAT)
     return checkResult::UNSAT;
   return checkResult::UNKNOWN;
+}
+
+checkResult BitwuzlaSolver::checkSatAssumingImpl(
+    const std::vector<SMTExprRef> &Assumptions) {
+  std::vector<BitwuzlaTerm> assumptions;
+  assumptions.reserve(Assumptions.size());
+  for (const SMTExprRef &Assumption : Assumptions)
+    assumptions.push_back(toSolverExpr<BitwExpr>(*Assumption).Expr);
+
+  BitwuzlaResult res = bitwuzla_check_sat_assuming(
+      Context, static_cast<uint32_t>(assumptions.size()), assumptions.data());
+  if (res == BITWUZLA_SAT)
+    return checkResult::SAT;
+  if (res == BITWUZLA_UNSAT)
+    return checkResult::UNSAT;
+  return checkResult::UNKNOWN;
+}
+
+SMTResult<std::vector<SMTExprRef>> BitwuzlaSolver::getUnsatAssumptionsImpl() {
+  size_t size = 0;
+  const BitwuzlaTerm *core = bitwuzla_get_unsat_assumptions(Context, &size);
+  std::vector<SMTExprRef> Result;
+  for (size_t i = 0; i < size; ++i)
+    for (const SMTExprRef &Assumption : LastAssumptions)
+      if (core[i] == toSolverExpr<BitwExpr>(*Assumption).Expr) {
+        Result.push_back(Assumption);
+        break;
+      }
+  return Result;
 }
 
 void BitwuzlaSolver::resetImpl() {

--- a/src/bitwuzlasolver.h
+++ b/src/bitwuzlasolver.h
@@ -233,6 +233,9 @@ protected:
   SMTExprRef mkIEEEFPToBVImpl(const SMTExprRef &Exp) override;
 
   checkResult checkImpl() override;
+  checkResult
+  checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
+  SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/camada.h
+++ b/src/camada.h
@@ -744,6 +744,20 @@ public:
   /// Check if the constraints are satisfiable
   virtual checkResult check() = 0;
 
+  /// Check if the constraints conjoined with the given boolean assumptions
+  /// are satisfiable. The assumptions are only active for this query; they
+  /// are not asserted and do not persist into later checks.
+  virtual checkResult
+  checkSatAssuming(const std::vector<SMTExprRef> &Assumptions) = 0;
+
+  /// Returns the subset of the assumptions the solver used to derive
+  /// unsatisfiability. Only valid right after a checkSatAssuming() call
+  /// that returned UNSAT: any solver mutation (addConstraint, push, pop,
+  /// reset) or later check invalidates the result, and querying it then is
+  /// an error. Backends without native unsat-assumption support (STP)
+  /// return an UnsupportedOperation error.
+  virtual SMTResult<std::vector<SMTExprRef>> getUnsatAssumptions() = 0;
+
   /// Reset the solver and remove all constraints.
   virtual void reset() = 0;
 

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -210,6 +210,11 @@ void SMTSolverImpl::clearSortCaches() {
   TupleSortCache.clear();
 }
 
+void SMTSolverImpl::invalidateUnsatAssumptions() {
+  LastAssumptions.clear();
+  UnsatAssumptionsValid = false;
+}
+
 void SMTSolverImpl::clearExprCaches() {
   CachedBoolExprs.fill({});
   CachedBVOne1Expr = {};
@@ -226,6 +231,7 @@ void SMTSolverImpl::clearExprCaches() {
   LazyArrayItes.clear();
   LazyTouched.clear();
   LazyConstraintLevels.assign(1, {});
+  invalidateUnsatAssumptions();
 }
 
 void SMTSolverImpl::initializeCommonSingletons() {
@@ -479,6 +485,7 @@ SMTSortRef SMTSolverImpl::mkFunctionSortImpl(const std::vector<SMTSortRef> &,
 
 void SMTSolverImpl::addConstraint(const SMTExprRef &Exp) {
   requireBoolSort(Exp, "Expected boolean constraint");
+  invalidateUnsatAssumptions();
   return addConstraintImpl(Exp);
 }
 
@@ -1715,7 +1722,71 @@ SMTExprRef SMTSolverImpl::mkIEEEFPToBV(const SMTExprRef &Exp) {
   return theExp;
 }
 
-checkResult SMTSolverImpl::check() { return checkImpl(); }
+checkResult SMTSolverImpl::check() {
+  invalidateUnsatAssumptions();
+  return checkImpl();
+}
+
+checkResult
+SMTSolverImpl::checkSatAssuming(const std::vector<SMTExprRef> &Assumptions) {
+  for (const SMTExprRef &Assumption : Assumptions)
+    requireBoolSort(Assumption, "Expected boolean assumption");
+  // checkSatAssumingImpl may route through the public
+  // addConstraint/push/pop (the default fallback and the activation-literal
+  // lowerings do), all of which invalidate the unsat-assumption state, so
+  // record it only after the check completes.
+  const checkResult Result =
+      Assumptions.empty() ? checkImpl() : checkSatAssumingImpl(Assumptions);
+  UnsatAssumptionsValid = Result == checkResult::UNSAT;
+  LastAssumptions =
+      UnsatAssumptionsValid ? Assumptions : std::vector<SMTExprRef>{};
+  return Result;
+}
+
+checkResult SMTSolverImpl::checkSatAssumingImpl(
+    const std::vector<SMTExprRef> &Assumptions) {
+  push();
+  for (const SMTExprRef &Assumption : Assumptions)
+    addConstraint(Assumption);
+  const checkResult Result = checkImpl();
+  pop();
+  return Result;
+}
+
+SMTResult<std::vector<SMTExprRef>> SMTSolverImpl::getUnsatAssumptions() {
+  if (!UnsatAssumptionsValid)
+    return SMTError{SMTErrorCode::BackendError,
+                    CachedBoolExprs[0]->getBackendKind(),
+                    "getUnsatAssumptions is only valid right after a "
+                    "checkSatAssuming call that returned UNSAT, before the "
+                    "solver state is mutated or checked again"};
+  if (LastAssumptions.empty())
+    return std::vector<SMTExprRef>{};
+  SMTResult<std::vector<SMTExprRef>> Core = getUnsatAssumptionsImpl();
+  if (!Core)
+    return Core;
+  // Normalize across backends: a duplicated assumption must not yield a
+  // duplicated core entry (activation-literal lowerings mint one literal
+  // per position, so their raw cores can repeat an expression).
+  std::vector<SMTExprRef> Deduped;
+  for (SMTExprRef &Assumption : Core.value()) {
+    bool Seen = false;
+    for (const SMTExprRef &Kept : Deduped)
+      if (&*Kept == &*Assumption) {
+        Seen = true;
+        break;
+      }
+    if (!Seen)
+      Deduped.push_back(std::move(Assumption));
+  }
+  return Deduped;
+}
+
+SMTResult<std::vector<SMTExprRef>> SMTSolverImpl::getUnsatAssumptionsImpl() {
+  return SMTError{SMTErrorCode::UnsupportedOperation,
+                  CachedBoolExprs[0]->getBackendKind(),
+                  "Unsat assumptions are not supported by this backend"};
+}
 
 void SMTSolverImpl::reset() {
   invalidateGeneratedObjects();
@@ -1724,11 +1795,13 @@ void SMTSolverImpl::reset() {
 }
 
 void SMTSolverImpl::push(unsigned nscopes) {
+  invalidateUnsatAssumptions();
   LazyConstraintLevels.resize(LazyConstraintLevels.size() + nscopes);
   pushImpl(nscopes);
 }
 
 void SMTSolverImpl::pop(unsigned nscopes) {
+  invalidateUnsatAssumptions();
   // Lazy default axioms and extensionality lemmas asserted inside the
   // popped scopes are scope-independent facts about expressions that
   // outlive the pop, so re-assert them at the outer level instead of

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -190,6 +190,17 @@ protected:
   SMTExprRef resolveLazyArrayElement(const SMTExprRef &Array,
                                      const SMTExprRef &Index);
 
+  // --- Assumption-based solving ---
+  // The assumptions of the most recent checkSatAssuming() call, kept so
+  // backends can map the solver's native unsat core back to the caller's
+  // SMTExprRefs. UnsatAssumptionsValid gates getUnsatAssumptions(): it is
+  // set only when that call returned UNSAT and cleared by anything that
+  // invalidates the solver's core — a plain check(), addConstraint(),
+  // push(), pop(), or reset().
+  std::vector<SMTExprRef> LastAssumptions;
+  bool UnsatAssumptionsValid = false;
+  void invalidateUnsatAssumptions();
+
   std::shared_ptr<SMTHandleState> HandleState =
       std::make_shared<SMTHandleState>();
 
@@ -431,6 +442,9 @@ public:
                           const SMTSortRef &To) override final;
   SMTExprRef mkIEEEFPToBV(const SMTExprRef &Exp) override final;
   checkResult check() override final;
+  checkResult
+  checkSatAssuming(const std::vector<SMTExprRef> &Assumptions) override final;
+  SMTResult<std::vector<SMTExprRef>> getUnsatAssumptions() override final;
   void reset() override final;
   void push(unsigned nscopes = 1) override final;
   void pop(unsigned nscopes = 1) override final;
@@ -776,6 +790,19 @@ protected:
                            unsigned SWidth);
 
   virtual checkResult checkImpl() = 0;
+
+  /// Default fallback for backends without native assumption support:
+  /// push a scope, assert each assumption, check, pop. Goes through the
+  /// public push/pop/addConstraint so the lazy constant-array journal
+  /// stays consistent.
+  virtual checkResult
+  checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions);
+
+  /// Only dispatched right after checkSatAssumingImpl returned UNSAT for a
+  /// non-empty assumption set (the wrapper answers the trivial cases).
+  /// Native backends map the solver's core back to the SMTExprRefs stored
+  /// in LastAssumptions.
+  virtual SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl();
 
   virtual void resetImpl() = 0;
 

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -108,6 +108,7 @@ CVC5Solver::CVC5Solver() : Context(Terms) {
   Context.setOption("arrays-exp", "true");
   Context.setOption("produce-models", "true");
   Context.setOption("produce-assertions", "true");
+  Context.setOption("produce-unsat-assumptions", "true");
   initializeCommonSingletons();
 }
 
@@ -1213,6 +1214,35 @@ checkResult CVC5Solver::checkImpl() {
     return checkResult::UNKNOWN;
 
   return checkResult::UNSAT;
+}
+
+checkResult
+CVC5Solver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
+  std::vector<cvc5::Term> assumptions;
+  assumptions.reserve(Assumptions.size());
+  for (const SMTExprRef &Assumption : Assumptions)
+    assumptions.push_back(toSolverExpr<CVC5Expr>(*Assumption).Expr);
+
+  cvc5::Result res = Context.checkSatAssuming(assumptions);
+  if (res.isSat())
+    return checkResult::SAT;
+
+  if (res.isUnknown())
+    return checkResult::UNKNOWN;
+
+  return checkResult::UNSAT;
+}
+
+SMTResult<std::vector<SMTExprRef>> CVC5Solver::getUnsatAssumptionsImpl() {
+  std::vector<cvc5::Term> core = Context.getUnsatAssumptions();
+  std::vector<SMTExprRef> Result;
+  for (const cvc5::Term &Term : core)
+    for (const SMTExprRef &Assumption : LastAssumptions)
+      if (Term == toSolverExpr<CVC5Expr>(*Assumption).Expr) {
+        Result.push_back(Assumption);
+        break;
+      }
+  return Result;
 }
 
 void CVC5Solver::resetImpl() { Context.resetAssertions(); }

--- a/src/cvc5solver.h
+++ b/src/cvc5solver.h
@@ -357,6 +357,11 @@ protected:
 
   checkResult checkImpl() override;
 
+  checkResult
+  checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
+
+  SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
+
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/mathsatsolver.cpp
+++ b/src/mathsatsolver.cpp
@@ -1101,7 +1101,56 @@ checkResult MathSATSolver::checkImpl() {
   return checkResult::UNKNOWN;
 }
 
+checkResult MathSATSolver::checkSatAssumingImpl(
+    const std::vector<SMTExprRef> &Assumptions) {
+  // msat_solve_with_assumptions rejects anything but (negated) Boolean
+  // constants, so activate each assumption through a fresh literal:
+  // assert (=> lit assumption), then assume the literal. Equisatisfiable
+  // with assuming the term directly, and the core maps back through the
+  // literals. The implications stay asserted at the current backtrack
+  // level after the call; with the literals otherwise unconstrained they
+  // are vacuously satisfiable, so later checks are unaffected.
+  LastAssumptionLits.clear();
+  std::vector<msat_term> lits;
+  lits.reserve(Assumptions.size());
+  for (const SMTExprRef &Assumption : Assumptions) {
+    const SMTExprRef Lit = mkSymbolUnchecked(
+        "__CAMADA_assume_" + std::to_string(NextAssumeId++), mkBoolSort());
+    addConstraint(mkImplies(Lit, Assumption));
+    lits.push_back(toMathSATTerm(Lit));
+    LastAssumptionLits.emplace_back(msat_term_id(lits.back()), Assumption);
+  }
+
+  msat_result res =
+      msat_solve_with_assumptions(Context, lits.data(), lits.size());
+  if (res == MSAT_SAT)
+    return checkResult::SAT;
+
+  if (res == MSAT_UNSAT)
+    return checkResult::UNSAT;
+
+  return checkResult::UNKNOWN;
+}
+
+SMTResult<std::vector<SMTExprRef>> MathSATSolver::getUnsatAssumptionsImpl() {
+  size_t size = 0;
+  msat_term *core = msat_get_unsat_assumptions(Context, &size);
+  if (!core)
+    return SMTError{SMTErrorCode::BackendError, SMTBackendKind::MathSAT,
+                    "MathSAT could not retrieve the unsat assumptions"};
+  std::vector<SMTExprRef> Result;
+  for (size_t i = 0; i < size; ++i)
+    for (const auto &[LitId, Assumption] : LastAssumptionLits)
+      if (msat_term_id(core[i]) == LitId) {
+        Result.push_back(Assumption);
+        break;
+      }
+  msat_free(core);
+  return Result;
+}
+
 void MathSATSolver::resetImpl() {
+  LastAssumptionLits.clear();
   destroyContext();
   initializeContext();
 }

--- a/src/mathsatsolver.h
+++ b/src/mathsatsolver.h
@@ -329,6 +329,11 @@ protected:
 
   checkResult checkImpl() override;
 
+  checkResult
+  checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
+
+  SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
+
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;
@@ -345,6 +350,14 @@ private:
 
   msat_config Config{};
   msat_env Context{};
+
+  // msat_solve_with_assumptions accepts only (negated) Boolean constants,
+  // so checkSatAssumingImpl assumes fresh activation literals
+  // (`__CAMADA_assume_N`) implying the caller's terms instead. This maps
+  // each literal's term id from the most recent call back to the
+  // assumption it activates, for decoding msat_get_unsat_assumptions.
+  uint64_t NextAssumeId = 0;
+  std::vector<std::pair<size_t, SMTExprRef>> LastAssumptionLits;
 }; // end class MathSATSolver
 
 } // namespace camada

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -719,6 +719,19 @@ void SMTLIBSolver::emitPreamble() {
   // explicitly enabled; z3 and yices-smt2 default to producing models. Set
   // the option unconditionally for protocol portability.
   emitLine("(set-option :produce-models true)");
+  // Needed for (get-unsat-assumptions). Unlike the options above, not every
+  // child implements it, and the standard reply for an unimplemented option
+  // is `unsupported` — not an error — so this one bypasses emitLine's
+  // success-or-die handling and records the answer instead.
+  const std::string UnsatAssumptionsOpt =
+      "(set-option :produce-unsat-assumptions true)\n";
+  if (File)
+    File->emitRaw(UnsatAssumptionsOpt);
+  if (Proc) {
+    Proc->emitRaw(UnsatAssumptionsOpt);
+    Proc->flush();
+    UnsatAssumptionsSupported = Proc->readResponse() == "success";
+  }
   // Without :global-declarations true, declarations made inside a (push) are
   // discarded on (pop). Camada's API lets a caller mkSymbol() inside a pushed
   // scope and use the returned expression after pop(); without this option,
@@ -2176,6 +2189,96 @@ checkResult SMTLIBSolver::checkImpl() {
   return checkResult::UNKNOWN;
 }
 
+checkResult
+SMTLIBSolver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
+  // Activate each assumption through a fresh literal: assert
+  // (=> lit assumption), then assume the literal. This is equisatisfiable
+  // with assuming the term directly, stays inside the standard's
+  // literals-only grammar for (check-sat-assuming ...), and makes the
+  // (get-unsat-assumptions) response trivially decodable by symbol name.
+  // The implications remain asserted at the current push level after the
+  // call; with the literals otherwise unconstrained they are vacuously
+  // satisfiable, so later checks are unaffected.
+  LastAssumptionLits.clear();
+  std::string Cmd = "(check-sat-assuming (";
+  for (const SMTExprRef &Assumption : Assumptions) {
+    std::string Lit = "__CAMADA_assume_" + std::to_string(NextAssumeId++);
+    addConstraint(mkImplies(mkSymbolUnchecked(Lit, mkBoolSort()), Assumption));
+    if (!LastAssumptionLits.empty())
+      Cmd.push_back(' ');
+    Cmd.append(Lit);
+    LastAssumptionLits.emplace_back(std::move(Lit), Assumption);
+  }
+  Cmd.append("))\n");
+
+  // Like (check-sat), this is a query — no `success` ack, so bypass
+  // emitLine and read the verdict directly.
+  if (File)
+    File->emitRaw(Cmd);
+  if (Proc) {
+    Proc->emitRaw(Cmd);
+    Proc->flush();
+    std::string Resp = Proc->readResponse();
+    if (Resp == "sat")
+      return checkResult::SAT;
+    if (Resp == "unsat")
+      return checkResult::UNSAT;
+    return checkResult::UNKNOWN;
+  }
+  if (File)
+    File->flush();
+  return checkResult::UNKNOWN;
+}
+
+SMTResult<std::vector<SMTExprRef>> SMTLIBSolver::getUnsatAssumptionsImpl() {
+  if (!Proc)
+    return SMTError{SMTErrorCode::BackendError, SMTBackendKind::SMTLIB,
+                    "SMTLIBSolver: no child process to query for unsat "
+                    "assumptions in write-only mode"};
+  if (!UnsatAssumptionsSupported)
+    return SMTError{SMTErrorCode::UnsupportedOperation, SMTBackendKind::SMTLIB,
+                    "The child solver does not support "
+                    ":produce-unsat-assumptions"};
+
+  const std::string Cmd = "(get-unsat-assumptions)\n";
+  if (File)
+    File->emitRaw(Cmd);
+  Proc->emitRaw(Cmd);
+  Proc->flush();
+  std::string Resp = Proc->readResponse();
+  if (Resp.compare(0, 6, "(error") == 0 || Resp.empty())
+    return SMTError{SMTErrorCode::BackendError, SMTBackendKind::SMTLIB,
+                    "SMTLIBSolver: (get-unsat-assumptions) failed: " + Resp};
+
+  // The response is a list of the assumed activation literals, e.g.
+  // `(__CAMADA_assume_0 __CAMADA_assume_2)`. Tokenize and map each literal
+  // back to the assumption it activated. `|` is a delimiter too: quoting
+  // is semantically transparent in SMT-LIB, so a child may legally echo
+  // the literals as `|__CAMADA_assume_0|`, and the names contain no `|`.
+  std::vector<SMTExprRef> Result;
+  std::string Token;
+  auto FlushToken = [&]() {
+    if (Token.empty())
+      return;
+    for (const auto &[Lit, Assumption] : LastAssumptionLits)
+      if (Token == Lit) {
+        Result.push_back(Assumption);
+        break;
+      }
+    Token.clear();
+  };
+  for (const char C : Resp) {
+    if (C == '(' || C == ')' || C == '|' || C == ' ' || C == '\t' ||
+        C == '\n' || C == '\r') {
+      FlushToken();
+      continue;
+    }
+    Token.push_back(C);
+  }
+  FlushToken();
+  return Result;
+}
+
 void SMTLIBSolver::resetImpl() {
   // (reset) is non-uniform across solvers:
   //   - z3, bitwuzla, yices: ack `(reset)` with `success`.
@@ -2210,6 +2313,7 @@ void SMTLIBSolver::resetImpl() {
     // is already in the kernel pipe by the time we reach this point.
     Proc->drainResponses(200);
   }
+  LastAssumptionLits.clear();
   emitPreamble();
 }
 

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -376,6 +376,9 @@ protected:
 
   // --- check / push / pop / reset ---
   checkResult checkImpl() override;
+  checkResult
+  checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
+  SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;
@@ -441,6 +444,23 @@ private:
   // we bind every const-array literal to a fresh symbol up front and
   // reference the symbol from then on.
   uint64_t NextArrConstId = 0;
+
+  // Whether the child solver acknowledged
+  // `(set-option :produce-unsat-assumptions true)` with `success`.
+  // Children that answer `unsupported` (the standard reply for an
+  // unimplemented option) still solve normally; only
+  // getUnsatAssumptions() degrades to an error.
+  bool UnsatAssumptionsSupported = false;
+
+  // checkSatAssumingImpl assumes fresh activation literals
+  // (`__CAMADA_assume_N`) instead of the caller's terms: the standard
+  // restricts (check-sat-assuming ...) to property literals, and
+  // (get-unsat-assumptions) echoes whatever was assumed, so minted
+  // symbols make the response trivially and unambiguously decodable.
+  // This maps each literal of the most recent call back to the
+  // assumption it activates.
+  uint64_t NextAssumeId = 0;
+  std::vector<std::pair<std::string, SMTExprRef>> LastAssumptionLits;
 };
 
 } // namespace camada

--- a/src/yicessolver.cpp
+++ b/src/yicessolver.cpp
@@ -830,6 +830,44 @@ checkResult YicesSolver::checkImpl() {
   return checkResult::UNKNOWN;
 }
 
+checkResult
+YicesSolver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
+  std::vector<term_t> assumptions;
+  assumptions.reserve(Assumptions.size());
+  for (const SMTExprRef &Assumption : Assumptions)
+    assumptions.push_back(toSolverExpr<YicesExpr>(*Assumption).Expr);
+
+  smt_status_t res = yices_check_context_with_assumptions(
+      Context, nullptr, static_cast<uint32_t>(assumptions.size()),
+      assumptions.data());
+  if (res == YICES_STATUS_SAT)
+    return checkResult::SAT;
+
+  if (res == YICES_STATUS_UNSAT)
+    return checkResult::UNSAT;
+
+  return checkResult::UNKNOWN;
+}
+
+SMTResult<std::vector<SMTExprRef>> YicesSolver::getUnsatAssumptionsImpl() {
+  term_vector_t core;
+  yices_init_term_vector(&core);
+  if (yices_get_unsat_core(Context, &core) != 0) {
+    yices_delete_term_vector(&core);
+    return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Yices,
+                    "Yices could not retrieve the unsat core"};
+  }
+  std::vector<SMTExprRef> Result;
+  for (uint32_t i = 0; i < core.size; ++i)
+    for (const SMTExprRef &Assumption : LastAssumptions)
+      if (core.data[i] == toSolverExpr<YicesExpr>(*Assumption).Expr) {
+        Result.push_back(Assumption);
+        break;
+      }
+  yices_delete_term_vector(&core);
+  return Result;
+}
+
 void YicesSolver::resetImpl() {
   Assertions.clear();
   AssertionScopeSizes.clear();

--- a/src/yicessolver.h
+++ b/src/yicessolver.h
@@ -264,6 +264,11 @@ protected:
 
   checkResult checkImpl() override;
 
+  checkResult
+  checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
+
+  SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
+
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -1064,6 +1064,43 @@ checkResult Z3Solver::checkImpl() {
   return checkResult::UNKNOWN;
 }
 
+checkResult
+Z3Solver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
+  // Tactic-built solvers (see setSolver) do not track assumption cores
+  // unless asked: they answer UNSAT with an empty unsat_core(). The plain
+  // smt solver tracks them regardless, so setting the parameter here is a
+  // harmless no-op for it. Set per call because setSolver can swap the
+  // solver instance at any time.
+  z3::params params(*Context);
+  params.set("unsat_core", true);
+  Solver.set(params);
+
+  z3::expr_vector assumptions(*Context);
+  for (const SMTExprRef &Assumption : Assumptions)
+    assumptions.push_back(toZ3Expr(Assumption));
+
+  z3::check_result res = Solver.check(assumptions);
+  if (res == z3::check_result::sat)
+    return checkResult::SAT;
+
+  if (res == z3::check_result::unsat)
+    return checkResult::UNSAT;
+
+  return checkResult::UNKNOWN;
+}
+
+SMTResult<std::vector<SMTExprRef>> Z3Solver::getUnsatAssumptionsImpl() {
+  z3::expr_vector core = Solver.unsat_core();
+  std::vector<SMTExprRef> Result;
+  for (unsigned i = 0; i < core.size(); ++i)
+    for (const SMTExprRef &Assumption : LastAssumptions)
+      if (z3::eq(core[static_cast<int>(i)], toZ3Expr(Assumption))) {
+        Result.push_back(Assumption);
+        break;
+      }
+  return Result;
+}
+
 void Z3Solver::resetImpl() { Solver.reset(); }
 
 void Z3Solver::pushImpl(unsigned nscopes) {

--- a/src/z3solver.h
+++ b/src/z3solver.h
@@ -366,6 +366,11 @@ protected:
 
   checkResult checkImpl() override;
 
+  checkResult
+  checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
+
+  SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
+
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;


### PR DESCRIPTION
Closes #76.

## What

Two new methods on `SMTSolver`:

```cpp
checkResult checkSatAssuming(const std::vector<SMTExprRef> &Assumptions);
SMTResult<std::vector<SMTExprRef>> getUnsatAssumptions();
```

`checkSatAssuming` checks the asserted constraints conjoined with per-query boolean assumptions (they don't persist). After an UNSAT answer, `getUnsatAssumptions` returns the subset of those assumptions the solver used to derive unsatisfiability — the primitive incremental BMC / k-induction loops and core-minimization (smt-switch's `UnsatCoreReducer`) are built on.

## Design

- **Common layer** validates bool sorts, answers the trivial cases (empty assumption set degenerates to a plain check; empty-set core fast path), records `LastAssumptions` for backends to map native core terms back to caller `SMTExprRef`s, and dedupes the returned core. The unsat-assumption state is invalidated by *anything* that invalidates the solver's core — plain `check()`, `addConstraint()`, `push()`, `pop()`, `reset()` — so a stale query is a uniform, graceful error on every backend (bitwuzla would otherwise abort the process).
- **Z3**: `check(expr_vector)` + `unsat_core()`, with `unsat_core=true` set per call so tactic-built solvers (which otherwise answer UNSAT with an empty core) track assumptions too.
- **Bitwuzla**: native `check_sat_assuming` / `get_unsat_assumptions`, `PRODUCE_UNSAT_ASSUMPTIONS` enabled at context init.
- **CVC5**: native `checkSatAssuming` / `getUnsatAssumptions`, `produce-unsat-assumptions` ctor option.
- **MathSAT**: `msat_solve_with_assumptions` only accepts (negated) Boolean constants, so arbitrary assumptions are lowered through fresh activation literals (`assert (=> lit A)`, assume `lit`) and the core is mapped back through the literal term ids.
- **Yices**: `yices_check_context_with_assumptions` + `yices_get_unsat_core`.
- **STP**: no native assumptions — common-layer push/assert/check/pop fallback; `getUnsatAssumptions` returns an `UnsupportedOperation` error.
- **SMT-LIB pipe**: same activation-literal lowering as MathSAT (the standard restricts `(check-sat-assuming ...)` to literals, and minted `__CAMADA_assume_N` symbols make the `(get-unsat-assumptions)` response trivially decodable). The preamble gains `:produce-unsat-assumptions true` with tolerant ack handling: a child that answers `unsupported` (the standard reply) still solves normally, only `getUnsatAssumptions` degrades to an error.

## Testing

New `check_sat_assuming_semantics` fixture (UNSAT under contradicting assumptions, core non-empty + re-check of the core alone stays UNSAT, compound non-literal assumption, per-query semantics, stale-query and mutation-invalidation errors, empty-set degeneration) registered for all native backends and all five SMT-LIB pipeline children (z3, cvc5, bitwuzla, mathsat, yices-smt2). SMT-LIB write-only golden scripts updated for the new preamble line. Full suite: 152/152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
