### PR TITLE
Add sparse array model extraction via getArrayValues

### DIFF
--- a/regression/array.test.h
+++ b/regression/array.test.h
@@ -243,6 +243,75 @@ inline void const_array_select_survives_pop(
 
 // The lowerings interoperate: lazily and natively (or Auto-) lowered
 // constant arrays share array sorts and can appear in one formula.
+// Shared decoder for the array-model tests below: the model value at an
+// index is the first entry whose index matches, else the base, which must
+// then exist.
+inline int64_t array_model_value_at(const camada::SMTSolverRef &solver,
+                                    const camada::ArrayModel &Model,
+                                    int64_t Index) {
+  for (const auto &Entry : Model.Entries) {
+    auto IndexValue = solver->getBV(Entry.first);
+    REQUIRE(IndexValue);
+    if (IndexValue.value() == Index) {
+      auto ElemValue = solver->getBV(Entry.second);
+      REQUIRE(ElemValue);
+      return ElemValue.value();
+    }
+  }
+  REQUIRE(Model.Base);
+  auto BaseValue = solver->getBV(Model.Base);
+  REQUIRE(BaseValue);
+  return BaseValue.value();
+}
+
+inline void array_model_values(const camada::SMTSolverRef &solver) {
+  auto indexsort = solver->mkBVSort(8);
+  auto arr = solver->mkSymbol("arr", solver->mkArraySort(indexsort, indexsort));
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(arr, idx(1)), idx(10)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(arr, idx(2)), idx(20)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  auto Model = solver->getArrayValues(arr);
+  if (!Model) {
+    REQUIRE(Model.error().Code == camada::SMTErrorCode::UnsupportedOperation);
+    return;
+  }
+  REQUIRE(array_model_value_at(solver, Model.value(), 1) == 10);
+  REQUIRE(array_model_value_at(solver, Model.value(), 2) == 20);
+}
+
+inline void const_array_model_values(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto indexsort = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto arr = solver->mkArrayConst(indexsort, idx(7), Lowering);
+  arr = solver->mkArrayStore(arr, idx(3), idx(9));
+  arr = solver->mkArrayStore(arr, idx(3), idx(11)); // shadows the store of 9
+  // Touch the array so every backend has it in the formula.
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(arr, idx(0)), idx(7)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  auto Model = solver->getArrayValues(arr);
+  if (!Model) {
+    REQUIRE(Model.error().Code == camada::SMTErrorCode::UnsupportedOperation);
+    return;
+  }
+  // First matching entry wins: the outermost store shadows the inner one.
+  REQUIRE(array_model_value_at(solver, Model.value(), 3) == 11);
+  // Indexes never mentioned in the formula must read the initializer,
+  // through the base or an explicit entry.
+  REQUIRE(array_model_value_at(solver, Model.value(), 200) == 7);
+  // The sparse model must agree with the per-index query API.
+  auto Probe = solver->getBV(solver->getArrayElement(arr, idx(200)));
+  REQUIRE(Probe);
+  REQUIRE(Probe.value() == 7);
+}
+
 inline void const_array_lowering_interop(const camada::SMTSolverRef &solver) {
   auto idx = solver->mkBVSort(8);
   auto elem = solver->mkBVSort(8);

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -126,6 +126,8 @@ CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("symbol_cache_survives_push_pop",
                                    symbol_cache_survives_push_pop(solver),
                                    makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("array", array(solver), makeSMTLIBSolver)
+CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("array_model_values",
+                                   array_model_values(solver), makeSMTLIBSolver)
 CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("array_const_store_semantics",
                                    array_const_store_semantics(solver),
                                    makeSMTLIBSolver)

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -89,6 +89,8 @@ CAMADA_CVC5_SMTLIB_SHARED_TEST("symbol_cache_survives_push_pop",
                                symbol_cache_survives_push_pop(solver),
                                makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("array", array(solver), makeSMTLIBSolver)
+CAMADA_CVC5_SMTLIB_SHARED_TEST("array_model_values", array_model_values(solver),
+                               makeSMTLIBSolver)
 CAMADA_CVC5_SMTLIB_SHARED_TEST("array_const_store_semantics",
                                array_const_store_semantics(solver),
                                makeSMTLIBSolver)

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -176,6 +176,8 @@ CAMADA_MATHSAT_SMTLIB_SHARED_TEST("symbol_cache_survives_push_pop",
                                   symbol_cache_survives_push_pop(solver),
                                   makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("array", array(solver), makeSMTLIBSolver)
+CAMADA_MATHSAT_SMTLIB_SHARED_TEST("array_model_values",
+                                  array_model_values(solver), makeSMTLIBSolver)
 CAMADA_MATHSAT_SMTLIB_SHARED_TEST("array_const_store_semantics",
                                   array_const_store_semantics(solver),
                                   makeSMTLIBSolver)

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -67,6 +67,9 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDARGTEST(array_const_survives_push_pop, LazyArrays);
   RESETANDARGTEST(wide_index_const_array_semantics, LazyArrays);
   RESETANDARGTEST(const_array_select_survives_pop, LazyArrays);
+  RESETANDTEST(array_model_values);
+  RESETANDTEST(const_array_model_values);
+  RESETANDARGTEST(const_array_model_values, LazyArrays);
   RESETANDTEST(const_array_lowering_interop);
   RESETANDTEST(tuple_semantics);
   RESETANDTEST(tuple_with_array_field);

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -123,6 +123,8 @@ CAMADA_Z3_SMTLIB_SHARED_TEST("symbol_cache_survives_push_pop",
                              symbol_cache_survives_push_pop(solver),
                              makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("array", array(solver), makeSMTLIBSolver)
+CAMADA_Z3_SMTLIB_SHARED_TEST("array_model_values", array_model_values(solver),
+                             makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("array_const_store_semantics",
                              array_const_store_semantics(solver),
                              makeSMTLIBSolver)

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -785,6 +785,34 @@ SMTExprRef BitwuzlaSolver::getArrayElementImpl(const SMTExprRef &Array,
       bitwuzla_get_value(Context, toSolverExpr<BitwExpr>(*select).Expr));
 }
 
+SMTResult<ArrayModel>
+BitwuzlaSolver::getArrayValuesImpl(const SMTExprRef &Array) {
+  const SMTSortRef &IndexSort = Array->Sort->getIndexSort();
+  const SMTSortRef &ElemSort = Array->Sort->getElementSort();
+  const auto wrap = [&](BitwuzlaTerm Value, const SMTSortRef &Sort) {
+    return makeExprRef<BitwExpr>(valueKindForSort(Sort), Context, Sort, Value);
+  };
+
+  BitwuzlaTerm Val =
+      bitwuzla_get_value(Context, toSolverExpr<BitwExpr>(*Array).Expr);
+  ArrayModel Result;
+  while (bitwuzla_term_get_kind(Val) == BITWUZLA_KIND_ARRAY_STORE) {
+    size_t Size = 0;
+    BitwuzlaTerm *Children = bitwuzla_term_get_children(Val, &Size);
+    fatalErrorIf(Size != 3, "Malformed bitwuzla array store in model");
+    Result.Entries.emplace_back(wrap(Children[1], IndexSort),
+                                wrap(Children[2], ElemSort));
+    Val = Children[0];
+  }
+  if (bitwuzla_term_get_kind(Val) == BITWUZLA_KIND_CONST_ARRAY) {
+    size_t Size = 0;
+    BitwuzlaTerm *Children = bitwuzla_term_get_children(Val, &Size);
+    fatalErrorIf(Size != 1, "Malformed bitwuzla constant array in model");
+    Result.Base = wrap(Children[0], ElemSort);
+  }
+  return Result;
+}
+
 SMTExprRef BitwuzlaSolver::mkBoolImpl(const bool b) {
   return makeExprRef<BitwExpr>(SMTExprKind::BoolConst, Context, mkBoolSort(),
                                b ? bitwuzla_mk_true(TermManager)

--- a/src/bitwuzlasolver.h
+++ b/src/bitwuzlasolver.h
@@ -213,6 +213,8 @@ protected:
   SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
                                  const SMTExprRef &Index) override;
 
+  SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
+
   SMTExprRef mkBoolImpl(const bool b) override;
   SMTExprRef mkBVFromDecImpl(const int64_t Int,
                              const SMTSortRef &Sort) override;

--- a/src/camada.h
+++ b/src/camada.h
@@ -187,6 +187,23 @@ private:
   bool HasValue_ = false;
 };
 
+/// Sparse model of an array expression, produced by
+/// SMTSolver::getArrayValues after a SAT check.
+///
+/// The model value of the array at index `i` is the element of the first
+/// entry whose index has the same model value as `i`, or the value of
+/// `Base` when no entry matches. `Base` is a null ref when the solver did
+/// not report a default — every constrained index is then covered by an
+/// entry, and unlisted indexes are unconstrained.
+///
+/// Both expressions in each entry and `Base` are valid arguments to the
+/// model-value getters (getBV, getBool, ...) for as long as the model that
+/// produced them stays current (no new constraints or checks).
+struct ArrayModel {
+  SMTExprRef Base;
+  std::vector<std::pair<SMTExprRef, SMTExprRef>> Entries;
+};
+
 /// Generic base class for SMT Solvers
 ///
 /// This class is responsible for wrapping all sorts and expression generation,
@@ -635,6 +652,16 @@ public:
   /// If a model is available, returns the Expr in position Index of Array
   virtual SMTExprRef getArrayElement(const SMTExprRef &Array,
                                      const SMTExprRef &Index) = 0;
+
+  /// If a model is available, returns the model's sparse representation of
+  /// an array expression: the finite set of (index, element) entries the
+  /// solver's model distinguishes, plus the default element every other
+  /// index reads (see ArrayModel). The entry list is whatever finite shape
+  /// the model uses — it is not an enumeration of the index space, and its
+  /// size is unspecified. Backends without a walkable array model (STP
+  /// symbol arrays, the SMT-LIB pipeline) return an UnsupportedOperation
+  /// error.
+  virtual SMTResult<ArrayModel> getArrayValues(const SMTExprRef &Array) = 0;
 
   /// Constructs an SMTExprRef from a boolean.
   virtual SMTExprRef mkBool(const bool b) = 0;

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -1205,6 +1205,17 @@ void SMTSolverImpl::instantiateLazyDefaults(const SMTExprRef &Array,
   }
 }
 
+std::string SMTSolverImpl::lazyIndexModelBits(const SMTExprRef &Exp) {
+  if (Exp->isBoolSort()) {
+    SMTResult<bool> Value = getBool(Exp);
+    return Value ? std::string(Value.value() ? "1" : "0") : std::string();
+  }
+  if (!Exp->isBVSort())
+    return std::string(); // unsupported index sort: backend fallback
+  SMTResult<std::string> Value = getBVInBin(Exp);
+  return Value ? Value.value() : std::string();
+}
+
 SMTExprRef SMTSolverImpl::resolveLazyArrayElement(const SMTExprRef &Array,
                                                   const SMTExprRef &Index) {
   // Post-check model query: the solver's model is unconstrained at indexes
@@ -1212,14 +1223,7 @@ SMTExprRef SMTSolverImpl::resolveLazyArrayElement(const SMTExprRef &Array,
   // derivation chain instead. Returns a null ref when the chain cannot be
   // resolved, in which case the caller falls back to the backend.
   const auto modelBits = [this](const SMTExprRef &E) {
-    if (E->isBoolSort()) {
-      SMTResult<bool> Value = getBool(E);
-      return Value ? std::string(Value.value() ? "1" : "0") : std::string();
-    }
-    if (!E->isBVSort())
-      return std::string(); // unsupported index sort: backend fallback
-    SMTResult<std::string> Value = getBVInBin(E);
-    return Value ? Value.value() : std::string();
+    return lazyIndexModelBits(E);
   };
 
   const std::string QueryBits = modelBits(Index);
@@ -1434,6 +1438,78 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
   SMTExprRef theExp = getArrayElementImpl(Array, Index);
   assert(theExp->Sort == Array->Sort->getElementSort());
   return theExp;
+}
+
+SMTResult<ArrayModel> SMTSolverImpl::getArrayValues(const SMTExprRef &Array) {
+  fatalErrorIf(!Array->isArraySort(), "Expected array expression");
+  if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
+    return lazyArrayModel(Array);
+  return getArrayValuesImpl(Array);
+}
+
+SMTResult<ArrayModel> SMTSolverImpl::lazyArrayModel(const SMTExprRef &Array) {
+  // The backend's model is unconstrained at indexes whose lazy defaults
+  // were never instantiated, so walk the tracked derivation chain instead:
+  // stores become entries (outermost first, so shadowed stores at the same
+  // model index are skipped), ites follow the model's branch, and the
+  // reached root's initializer becomes the default.
+  ArrayModel Model;
+  std::set<std::string> SeenIndexBits;
+  const SMTExpr *Cur = &*Array;
+  while (true) {
+    if (auto It = LazyArrayStores.find(Cur); It != LazyArrayStores.end()) {
+      const std::string StepBits = lazyIndexModelBits(It->second.Index);
+      if (StepBits.empty())
+        return SMTError{SMTErrorCode::BackendError,
+                        CachedBoolExprs[0]->getBackendKind(),
+                        "Could not evaluate a store index while walking a "
+                        "lazily lowered array model"};
+      if (SeenIndexBits.insert(StepBits).second)
+        Model.Entries.emplace_back(It->second.Index, It->second.Value);
+      Cur = It->second.Parent;
+      continue;
+    }
+    if (auto It = LazyArrayItes.find(Cur); It != LazyArrayItes.end()) {
+      SMTResult<bool> Cond = getBool(It->second.Cond);
+      if (!Cond)
+        return Cond.error();
+      Cur = Cond.value() ? It->second.TrueArr : It->second.FalseArr;
+      continue;
+    }
+    if (auto It = LazyConstArrayRoots.find(Cur);
+        It != LazyConstArrayRoots.end()) {
+      Model.Base = It->second.Init;
+      return Model;
+    }
+    return SMTError{SMTErrorCode::BackendError,
+                    CachedBoolExprs[0]->getBackendKind(),
+                    "Untracked derivation while walking a lazily lowered "
+                    "array model"};
+  }
+}
+
+SMTResult<ArrayModel> SMTSolverImpl::getArrayValuesImpl(const SMTExprRef &) {
+  return SMTError{SMTErrorCode::UnsupportedOperation,
+                  CachedBoolExprs[0]->getBackendKind(),
+                  "Array model extraction is not supported by this backend"};
+}
+
+SMTExprKind SMTSolverImpl::valueKindForSort(const SMTSortRef &Sort) {
+  if (Sort->isBoolSort())
+    return SMTExprKind::BoolConst;
+  if (Sort->isBVSort())
+    return SMTExprKind::BVConst;
+  if (Sort->isFPSort())
+    return SMTExprKind::FPConst;
+  if (Sort->isRMSort())
+    return SMTExprKind::RMConst;
+  if (Sort->isArraySort())
+    return SMTExprKind::ArrayConst;
+  if (Sort->isIntSort())
+    return SMTExprKind::IntConst;
+  if (Sort->isRealSort())
+    return SMTExprKind::RealConst;
+  return SMTExprKind::Unknown;
 }
 
 SMTExprRef SMTSolverImpl::mkBool(const bool b) {

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -190,6 +190,17 @@ protected:
   SMTExprRef resolveLazyArrayElement(const SMTExprRef &Array,
                                      const SMTExprRef &Index);
 
+  /// Model bits of a bool/BV-sorted expression after a SAT check, used to
+  /// compare index terms by model value. Empty string when the sort is
+  /// unsupported or the model query fails.
+  std::string lazyIndexModelBits(const SMTExprRef &Exp);
+
+  /// Sparse model for an expression that reaches a lazily lowered constant
+  /// array, built from the tracked derivation chain instead of the backend
+  /// model (the backend's model is unconstrained at indexes whose defaults
+  /// were never instantiated).
+  SMTResult<ArrayModel> lazyArrayModel(const SMTExprRef &Array);
+
   std::shared_ptr<SMTHandleState> HandleState =
       std::make_shared<SMTHandleState>();
 
@@ -393,6 +404,7 @@ public:
   SMTResult<double> getFP64(const SMTExprRef &Exp) override final;
   SMTExprRef getArrayElement(const SMTExprRef &Array,
                              const SMTExprRef &Index) override final;
+  SMTResult<ArrayModel> getArrayValues(const SMTExprRef &Array) override final;
   SMTExprRef mkBool(const bool b) override final;
   SMTExprRef mkInt(int64_t v) override final;
   SMTExprRef mkInt(const std::string &v) override final;
@@ -724,6 +736,16 @@ protected:
 
   virtual SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
                                          const SMTExprRef &Index) = 0;
+
+  /// Walk the backend model's representation of Array (store chains over a
+  /// constant array, function interpretations, ...) into an ArrayModel.
+  /// The default returns UnsupportedOperation for backends without a
+  /// walkable array model.
+  virtual SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array);
+
+  /// SMTExprKind of a model-value constant of the given sort, for backends
+  /// wrapping walked model terms.
+  static SMTExprKind valueKindForSort(const SMTSortRef &Sort);
 
   virtual SMTExprRef mkBoolImpl(const bool b) = 0;
 

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -1020,6 +1020,25 @@ SMTExprRef CVC5Solver::getArrayElementImpl(const SMTExprRef &Array,
       Context.getValue(toSolverExpr<CVC5Expr>(*sel).Expr));
 }
 
+SMTResult<ArrayModel> CVC5Solver::getArrayValuesImpl(const SMTExprRef &Array) {
+  const SMTSortRef &IndexSort = Array->Sort->getIndexSort();
+  const SMTSortRef &ElemSort = Array->Sort->getElementSort();
+  const auto wrap = [&](const cvc5::Term &Value, const SMTSortRef &Sort) {
+    return makeExprRef<CVC5Expr>(valueKindForSort(Sort), &Context, Sort, Value);
+  };
+
+  cvc5::Term Val = Context.getValue(toSolverExpr<CVC5Expr>(*Array).Expr);
+  ArrayModel Result;
+  while (Val.getKind() == cvc5::Kind::STORE) {
+    Result.Entries.emplace_back(wrap(Val[1], IndexSort),
+                                wrap(Val[2], ElemSort));
+    Val = Val[0];
+  }
+  if (Val.getKind() == cvc5::Kind::CONST_ARRAY)
+    Result.Base = wrap(Val.getConstArrayBase(), ElemSort);
+  return Result;
+}
+
 SMTExprRef CVC5Solver::mkBoolImpl(const bool b) {
   return makeExprRef<CVC5Expr>(SMTExprKind::BoolConst, &Context, mkBoolSort(),
                                Terms.mkBoolean(b));

--- a/src/cvc5solver.h
+++ b/src/cvc5solver.h
@@ -321,6 +321,8 @@ protected:
   SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
                                  const SMTExprRef &Index) override;
 
+  SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
+
   SMTExprRef mkBoolImpl(const bool b) override;
   SMTExprRef mkIntImpl(int64_t v) override;
   SMTExprRef mkIntImpl(const std::string &v) override;

--- a/src/mathsatsolver.cpp
+++ b/src/mathsatsolver.cpp
@@ -933,6 +933,30 @@ SMTExprRef MathSATSolver::getArrayElementImpl(const SMTExprRef &Array,
       msat_get_model_value(Context, toMathSATTerm(sel)));
 }
 
+SMTResult<ArrayModel>
+MathSATSolver::getArrayValuesImpl(const SMTExprRef &Array) {
+  const SMTSortRef &IndexSort = Array->Sort->getIndexSort();
+  const SMTSortRef &ElemSort = Array->Sort->getElementSort();
+  const auto wrap = [&](msat_term Value, const SMTSortRef &Sort) {
+    return makeExprRef<MathSATExpr>(valueKindForSort(Sort), &Context, Sort,
+                                    Value);
+  };
+
+  msat_term Val = msat_get_model_value(Context, toMathSATTerm(Array));
+  if (MSAT_ERROR_TERM(Val))
+    return SMTError{SMTErrorCode::BackendError, SMTBackendKind::MathSAT,
+                    "MathSAT could not evaluate the array in the model"};
+  ArrayModel Result;
+  while (msat_term_is_array_write(Context, Val)) {
+    Result.Entries.emplace_back(wrap(msat_term_get_arg(Val, 1), IndexSort),
+                                wrap(msat_term_get_arg(Val, 2), ElemSort));
+    Val = msat_term_get_arg(Val, 0);
+  }
+  if (msat_term_is_array_const(Context, Val))
+    Result.Base = wrap(msat_term_get_arg(Val, 0), ElemSort);
+  return Result;
+}
+
 SMTExprRef MathSATSolver::mkBoolImpl(const bool Bool) {
   return makeExprRef<MathSATExpr>(
       SMTExprKind::BoolConst, &Context, mkBoolSort(),

--- a/src/mathsatsolver.h
+++ b/src/mathsatsolver.h
@@ -293,6 +293,8 @@ protected:
   SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
                                  const SMTExprRef &Index) override;
 
+  SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
+
   SMTExprRef mkBoolImpl(const bool b) override;
   SMTExprRef mkIntImpl(int64_t v) override;
   SMTExprRef mkIntImpl(const std::string &v) override;

--- a/src/yicessolver.cpp
+++ b/src/yicessolver.cpp
@@ -757,6 +757,88 @@ SMTExprRef YicesSolver::getArrayElementImpl(const SMTExprRef &Array,
       result.value(), elementSort->getFPExponentWidth(), FPEncoding::BV);
 }
 
+SMTResult<ArrayModel> YicesSolver::getArrayValuesImpl(const SMTExprRef &Array) {
+  model_t *Model = yices_get_model(Context, 1);
+  yval_t Root;
+  if (yices_get_value(Model, toSolverExpr<YicesExpr>(*Array).Expr, &Root) !=
+          0 ||
+      Root.node_tag != YVAL_FUNCTION)
+    return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Yices,
+                    "Yices did not produce a function value for the array"};
+
+  // Camada arrays are unary Yices functions; the expansion below writes
+  // one index descriptor per mapping into a one-slot buffer.
+  if (yices_val_function_arity(Model, &Root) != 1)
+    return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Yices,
+                    "Yices array model has unexpected function arity"};
+
+  const SMTSortRef &IndexSort = Array->Sort->getIndexSort();
+  const SMTSortRef &ElemSort = Array->Sort->getElementSort();
+  // Yices model values are descriptor nodes, not terms: rebuild each leaf
+  // as a constant term of the Camada-facing sort. Returns a null ref for
+  // shapes the backend cannot hold (nested functions).
+  const auto wrap = [&](const yval_t &Value,
+                        const SMTSortRef &Sort) -> SMTExprRef {
+    if (Sort->isBoolSort()) {
+      int32_t B = 0;
+      if (yices_val_get_bool(Model, &Value, &B) != 0)
+        return {};
+      return makeExprRef<YicesExpr>(SMTExprKind::BoolConst, Context, Sort,
+                                    B ? yices_true() : yices_false());
+    }
+    std::vector<int32_t> Bits(Sort->getWidth());
+    if (Bits.empty() || yices_val_get_bv(Model, &Value, Bits.data()) != 0)
+      return {};
+    return makeExprRef<YicesExpr>(
+        valueKindForSort(Sort), Context, Sort,
+        yices_bvconst_from_array(static_cast<uint32_t>(Bits.size()),
+                                 Bits.data()));
+  };
+
+  yval_t Def;
+  yval_vector_t Mappings;
+  yices_init_yval_vector(&Mappings);
+  if (yices_val_expand_function(Model, &Root, &Def, &Mappings) != 0) {
+    yices_delete_yval_vector(&Mappings);
+    return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Yices,
+                    "Yices could not expand the array's function value"};
+  }
+
+  ArrayModel Result;
+  for (uint32_t I = 0; I < Mappings.size; ++I) {
+    yval_t IndexVal[1];
+    yval_t ElemVal;
+    if (yices_val_expand_mapping(Model, &Mappings.data[I], IndexVal,
+                                 &ElemVal) != 0) {
+      // A mapping the model distinguishes but we cannot read would decode
+      // as the default value — error out instead of dropping it.
+      yices_delete_yval_vector(&Mappings);
+      return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Yices,
+                      "Yices could not expand an array model mapping"};
+    }
+    SMTExprRef IndexExpr = wrap(IndexVal[0], IndexSort);
+    SMTExprRef ElemExpr = wrap(ElemVal, ElemSort);
+    if (!IndexExpr || !ElemExpr) {
+      yices_delete_yval_vector(&Mappings);
+      return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Yices,
+                      "Yices array model entry has an unsupported shape"};
+    }
+    Result.Entries.emplace_back(std::move(IndexExpr), std::move(ElemExpr));
+  }
+  if (Def.node_tag != YVAL_UNKNOWN) {
+    Result.Base = wrap(Def, ElemSort);
+    if (!Result.Base) {
+      // Yices reported a default we cannot read; a null Base would claim
+      // the unlisted indexes are unconstrained.
+      yices_delete_yval_vector(&Mappings);
+      return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Yices,
+                      "Yices array model default has an unsupported shape"};
+    }
+  }
+  yices_delete_yval_vector(&Mappings);
+  return Result;
+}
+
 SMTExprRef YicesSolver::mkBoolImpl(const bool b) {
   return makeExprRef<YicesExpr>(SMTExprKind::BoolConst, Context, mkBoolSort(),
                                 b ? yices_true() : yices_false());

--- a/src/yicessolver.h
+++ b/src/yicessolver.h
@@ -236,6 +236,8 @@ protected:
   SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
                                  const SMTExprRef &Index) override;
 
+  SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
+
   SMTExprRef mkBoolImpl(const bool b) override;
   SMTExprRef mkIntImpl(int64_t v) override;
   SMTExprRef mkIntImpl(const std::string &v) override;

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -892,6 +892,48 @@ SMTExprRef Z3Solver::getArrayElementImpl(const SMTExprRef &Array,
                              Solver.get_model().eval(toZ3Expr(sel), true));
 }
 
+SMTResult<ArrayModel> Z3Solver::getArrayValuesImpl(const SMTExprRef &Array) {
+  const SMTSortRef &IndexSort = Array->Sort->getIndexSort();
+  const SMTSortRef &ElemSort = Array->Sort->getElementSort();
+  const auto wrap = [&](const z3::expr &Value, const SMTSortRef &Sort) {
+    return makeExprRef<Z3Expr>(valueKindForSort(Sort), Context, Sort, Value);
+  };
+
+  z3::model Model = Solver.get_model();
+  z3::expr Val = Model.eval(toZ3Expr(Array), true);
+  ArrayModel Result;
+  while (Val.is_app() && Val.decl().decl_kind() == Z3_OP_STORE) {
+    Result.Entries.emplace_back(wrap(Val.arg(1), IndexSort),
+                                wrap(Val.arg(2), ElemSort));
+    Val = Val.arg(0);
+  }
+  if (Val.is_app() && Val.decl().decl_kind() == Z3_OP_CONST_ARRAY) {
+    Result.Base = wrap(Val.arg(0), ElemSort);
+    return Result;
+  }
+  if (Val.is_app() && Val.decl().decl_kind() == Z3_OP_AS_ARRAY) {
+    // The model chose a function-graph representation: read the entries
+    // and the else-branch off the function interpretation.
+    z3::func_decl Decl(*Context, Z3_get_as_array_func_decl(*Context, Val));
+    z3::func_interp Interp = Model.get_func_interp(Decl);
+    for (unsigned I = 0; I < Interp.num_entries(); ++I) {
+      z3::func_entry Entry = Interp.entry(I);
+      Result.Entries.emplace_back(wrap(Entry.arg(0), IndexSort),
+                                  wrap(Entry.value(), ElemSort));
+    }
+    Result.Base = wrap(Interp.else_value(), ElemSort);
+    return Result;
+  }
+  // A bare uninterpreted constant is a true bottom: the array really is
+  // unconstrained at the remaining indexes. Any other shape (e.g. a lambda
+  // model) is one this walk does not understand — error out rather than
+  // return a model the contract decodes as unconstrained.
+  if (Val.is_const())
+    return Result;
+  return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Z3,
+                  "Unrecognized Z3 array model shape: " + Val.to_string()};
+}
+
 SMTExprRef Z3Solver::mkBoolImpl(const bool b) {
   return makeExprRef<Z3Expr>(SMTExprKind::BoolConst, Context, mkBoolSort(),
                              Context->bool_val(b));

--- a/src/z3solver.h
+++ b/src/z3solver.h
@@ -330,6 +330,8 @@ protected:
   SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
                                  const SMTExprRef &Index) override;
 
+  SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
+
   SMTExprRef mkBoolImpl(const bool b) override;
   SMTExprRef mkIntImpl(int64_t v) override;
   SMTExprRef mkIntImpl(const std::string &v) override;


### PR DESCRIPTION
Closes #79.

## What

```cpp
struct ArrayModel {
  SMTExprRef Base; // default element; null when no default is known
  std::vector<std::pair<SMTExprRef, SMTExprRef>> Entries;
};
SMTResult<ArrayModel> getArrayValues(const SMTExprRef &Array);
```

After a SAT check, returns the model's **sparse** representation of an array: the finite set of (index, element) entries the model distinguishes, plus the default element every other index reads. The model value at index `i` is the first entry whose index has the same model value as `i`, else `Base`. This is deliberately not an enumeration API — the entry list is whatever finite shape the solver's model uses, so cost is proportional to the model, never to the index space. Valid for constant and non-constant arrays alike. Entries and `Base` are ordinary expressions accepted by the model getters (`getBV`, `getBool`, ...).

## Per-backend extraction

- **Z3**: `model.eval(arr, true)`, walk the `store` chain; base from `const-array`, or function-graph models (`as-array`) read through the function interpretation's entries + else. A bare uninterpreted constant is a true "unconstrained elsewhere" bottom; any other shape (e.g. lambda models) errors out rather than decoding as unconstrained.
- **Bitwuzla / CVC5 / MathSAT**: walk the native store chain down to the constant-array base (`ARRAY_STORE`/`CONST_ARRAY`, `Kind::STORE`/`getConstArrayBase`, `msat_term_is_array_write`/`msat_term_is_array_const` — the latter mirrors smt-switch's reference walk).
- **Yices**: arrays are function values — `yices_val_expand_function` mappings become entries, the function default becomes `Base`; leaves are rebuilt as constant terms. Unreadable mappings or defaults are hard errors, never silent drops.
- **Lazily lowered constant arrays** (always on STP/Yices, opt-in elsewhere): answered entirely in the common layer from the tracked derivation chain — stores become entries outermost-first (shadowed stores at the same model index are skipped), ites follow the model's branch, and the root's initializer becomes `Base`. This is exact under camada's lazy semantics, where the backend model alone would be unconstrained at uninstantiated indexes.
- **STP symbol arrays / SMT-LIB pipe**: `UnsupportedOperation` (no walkable array model; the pipe would need a full s-expression term parser).

All entry orderings are outermost-store-first, so first-match-wins decoding makes shadowed stores mask correctly — pinned by a dedicated shadowing regression.

## Testing

`array_model_values` (symbol array) and `const_array_model_values` (const array + shadowed stores, parameterized over `ConstArrayLowering::Auto`/`Lazy`) registered for all native backends and the z3/cvc5/bitwuzla/mathsat SMT-LIB pipeline children, checking entry values, the initializer default at untouched indexes, shadowing, and agreement with the per-index `getArrayElement` API. Full suite: 151/151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
