### PR TITLE
Add queryable backend capabilities via supports(SolverFeature)

### DIFF
--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -157,3 +157,17 @@ CAMADA_BITWUZLA_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
 
 #undef CAMADA_BITWUZLA_SMTLIB_SHARED_TEST
 #endif // SOLVER_SMTLIB_ENABLED
+
+TEST_CASE("Bitwuzla feature capabilities", "[Bitwuzla]") {
+  auto solver = camada::createBitwuzlaSolver();
+  using camada::SolverFeature;
+  REQUIRE_FALSE(solver->supports(SolverFeature::IntRealArithmetic));
+  REQUIRE(solver->supports(SolverFeature::Quantifiers));
+  REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
+  REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
+  REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
+  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE(solver->supports(SolverFeature::Timeouts));
+  REQUIRE(solver->supports(SolverFeature::ArrayModels));
+}

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -136,3 +136,17 @@ CAMADA_CVC5_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
 
 #undef CAMADA_CVC5_SMTLIB_SHARED_TEST
 #endif // SOLVER_SMTLIB_ENABLED
+
+TEST_CASE("CVC5 feature capabilities", "[CVC5]") {
+  auto solver = camada::createCVC5Solver();
+  using camada::SolverFeature;
+  REQUIRE(solver->supports(SolverFeature::IntRealArithmetic));
+  REQUIRE(solver->supports(SolverFeature::Quantifiers));
+  REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
+  REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE(solver->supports(SolverFeature::NativeTuples));
+  REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
+  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE(solver->supports(SolverFeature::Timeouts));
+  REQUIRE(solver->supports(SolverFeature::ArrayModels));
+}

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -214,3 +214,17 @@ CAMADA_MATHSAT_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
 
 #undef CAMADA_MATHSAT_SMTLIB_SHARED_TEST
 #endif // SOLVER_SMTLIB_ENABLED
+
+TEST_CASE("MathSAT feature capabilities", "[MathSAT]") {
+  auto solver = camada::createMathSATSolver();
+  using camada::SolverFeature;
+  REQUIRE(solver->supports(SolverFeature::IntRealArithmetic));
+  REQUIRE_FALSE(solver->supports(SolverFeature::Quantifiers));
+  REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
+  REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
+  REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
+  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE(solver->supports(SolverFeature::Timeouts));
+  REQUIRE(solver->supports(SolverFeature::ArrayModels));
+}

--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -349,3 +349,27 @@ TEST_CASE("SMTLIB write-only emits deep expression chains", "[SMTLIB]") {
 
   REQUIRE(Got.find("(check-sat)") != std::string::npos);
 }
+
+TEST_CASE("SMTLIB feature capabilities", "[SMTLIB]") {
+  std::string Path = makeTempPath();
+  auto solver = std::make_unique<camada::SMTLIBSolver>(Path);
+  using camada::SolverFeature;
+  REQUIRE(solver->supports(SolverFeature::IntRealArithmetic));
+  REQUIRE(solver->supports(SolverFeature::Quantifiers));
+  REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
+  REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE(solver->supports(SolverFeature::NativeTuples));
+  REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
+  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE_FALSE(solver->supports(SolverFeature::Timeouts));
+  REQUIRE_FALSE(solver->supports(SolverFeature::ArrayModels));
+
+  // Camada tuple lowering flips the native-tuples bit.
+  auto camadaTuples = std::make_unique<camada::SMTLIBSolver>(
+      Path, camada::TupleEncoding::Camada);
+  REQUIRE_FALSE(camadaTuples->supports(SolverFeature::NativeTuples));
+
+  solver.reset();
+  camadaTuples.reset();
+  std::remove(Path.c_str());
+}

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -18,3 +18,17 @@ TEST_CASE("Unsupported UF STP test", "[STP]") {
     (void)stp->mkSymbol("f", fn);
   });
 }
+
+TEST_CASE("STP feature capabilities", "[STP]") {
+  auto solver = camada::createSTPSolver();
+  using camada::SolverFeature;
+  REQUIRE_FALSE(solver->supports(SolverFeature::IntRealArithmetic));
+  REQUIRE_FALSE(solver->supports(SolverFeature::Quantifiers));
+  REQUIRE_FALSE(solver->supports(SolverFeature::UninterpretedFunctions));
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeConstantArrays));
+  REQUIRE_FALSE(solver->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE_FALSE(solver->supports(SolverFeature::Timeouts));
+  REQUIRE_FALSE(solver->supports(SolverFeature::ArrayModels));
+}

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -210,3 +210,21 @@ CAMADA_YICES_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
 
 #undef CAMADA_YICES_SMTLIB_SHARED_TEST
 #endif // SOLVER_SMTLIB_ENABLED
+
+TEST_CASE("Yices feature capabilities", "[Yices]") {
+  auto solver = camada::createYicesSolver();
+  using camada::SolverFeature;
+  REQUIRE(solver->supports(SolverFeature::IntRealArithmetic));
+  REQUIRE_FALSE(solver->supports(SolverFeature::Quantifiers));
+  REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeConstantArrays));
+  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+#if defined(_WIN32)
+  REQUIRE_FALSE(solver->supports(SolverFeature::Timeouts));
+#else
+  REQUIRE(solver->supports(SolverFeature::Timeouts));
+#endif
+  REQUIRE(solver->supports(SolverFeature::ArrayModels));
+}

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -169,3 +169,17 @@ CAMADA_Z3_SMTLIB_SHARED_TEST("empty_tuple_semantics [Camada]",
 
 #undef CAMADA_Z3_SMTLIB_SHARED_TEST
 #endif // SOLVER_SMTLIB_ENABLED
+
+TEST_CASE("Z3 feature capabilities", "[Z3]") {
+  auto solver = camada::createZ3Solver();
+  using camada::SolverFeature;
+  REQUIRE(solver->supports(SolverFeature::IntRealArithmetic));
+  REQUIRE(solver->supports(SolverFeature::Quantifiers));
+  REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
+  REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE(solver->supports(SolverFeature::NativeTuples));
+  REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
+  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE(solver->supports(SolverFeature::Timeouts));
+  REQUIRE(solver->supports(SolverFeature::ArrayModels));
+}

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -967,6 +967,24 @@ SMTExprRef BitwuzlaSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
   return newSymbol;
 }
 
+bool BitwuzlaSolver::supportsImpl(SolverFeature Feature) const {
+  switch (Feature) {
+  case SolverFeature::Quantifiers: // BV/FP quantifiers only
+  case SolverFeature::UninterpretedFunctions:
+  case SolverFeature::NativeFloatingPoint:
+  case SolverFeature::UnsatAssumptions:
+  case SolverFeature::Timeouts:
+  case SolverFeature::ArrayModels:
+    return true;
+  case SolverFeature::IntRealArithmetic:
+    return false;
+  case SolverFeature::NativeTuples:
+  case SolverFeature::NativeConstantArrays:
+    break; // answered by the common layer's hooks
+  }
+  return false;
+}
+
 checkResult BitwuzlaSolver::checkImpl() {
   BitwuzlaResult res = bitwuzla_check_sat(Context);
   if (res == BITWUZLA_SAT)

--- a/src/bitwuzlasolver.h
+++ b/src/bitwuzlasolver.h
@@ -233,6 +233,8 @@ protected:
   SMTExprRef mkIEEEFPToBVImpl(const SMTExprRef &Exp) override;
 
   checkResult checkImpl() override;
+
+  bool supportsImpl(SolverFeature Feature) const override;
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/camada.h
+++ b/src/camada.h
@@ -121,6 +121,43 @@ std::string getCamadaVersion();
 
 enum class checkResult { SAT, UNSAT, UNKNOWN };
 
+/// Capabilities a backend may or may not implement, queryable through
+/// SMTSolver::supports() instead of discovering them through aborts or
+/// UnsupportedOperation errors.
+///
+/// A true bit means the corresponding API surface is implemented for the
+/// backend; individual calls can still fail for input-specific reasons
+/// through their SMTResult. On the SMT-LIB pipeline backend the bits
+/// describe what Camada emits — a particular child solver may still
+/// reject a construct at runtime.
+enum class SolverFeature {
+  /// Int/Real sorts and arithmetic (mkIntSort, mkRealSort, mkArith*).
+  IntRealArithmetic,
+  /// Quantified formulas (mkForall, mkExists).
+  Quantifiers,
+  /// Uninterpreted functions (mkFunctionSort, mkApply).
+  UninterpretedFunctions,
+  /// FPEncoding::Native sorts and operations; FPEncoding::BV works on
+  /// every backend regardless.
+  NativeFloatingPoint,
+  /// Backend-native tuple/datatype sorts; other backends route tuples
+  /// through the Camada per-field lowering.
+  NativeTuples,
+  /// Backend-native `((as const ...) v)` constant arrays; other backends
+  /// lower them lazily (see ConstArrayLowering).
+  NativeConstantArrays,
+  /// Unsat-assumption extraction after an UNSAT checkSatAssuming()
+  /// (see issue #76). checkSatAssuming itself works on every backend
+  /// through a push/assert/check/pop fallback.
+  UnsatAssumptions,
+  /// Per-check wall-clock limits via setTimeout() (see issue #77).
+  Timeouts,
+  /// Sparse array model extraction via getArrayValues() for arbitrary
+  /// arrays (see issue #79). Lazily lowered constant arrays are answered
+  /// by the common layer on every backend regardless.
+  ArrayModels,
+};
+
 /// Coarse-grained error categories for operations that return `SMTResult<T>`.
 ///
 /// These are intended for user-triggerable failures such as unsupported
@@ -752,6 +789,10 @@ public:
 
   /// Pop one or more assertion scopes.
   virtual void pop(unsigned nscopes = 1) = 0;
+
+  /// Returns whether this backend implements the given feature. See the
+  /// SolverFeature enumerators for what each bit covers.
+  virtual bool supports(SolverFeature Feature) const = 0;
 
   /// Returns the solver name and version
   virtual std::string getSolverNameAndVersion() const = 0;

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -1717,6 +1717,19 @@ SMTExprRef SMTSolverImpl::mkIEEEFPToBV(const SMTExprRef &Exp) {
 
 checkResult SMTSolverImpl::check() { return checkImpl(); }
 
+bool SMTSolverImpl::supports(SolverFeature Feature) const {
+  switch (Feature) {
+  case SolverFeature::NativeTuples:
+    return nativeTupleSupport();
+  case SolverFeature::NativeConstantArrays:
+    return nativeConstArraySupport();
+  default:
+    return supportsImpl(Feature);
+  }
+}
+
+bool SMTSolverImpl::supportsImpl(SolverFeature) const { return false; }
+
 void SMTSolverImpl::reset() {
   invalidateGeneratedObjects();
   resetImpl();

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -431,6 +431,7 @@ public:
                           const SMTSortRef &To) override final;
   SMTExprRef mkIEEEFPToBV(const SMTExprRef &Exp) override final;
   checkResult check() override final;
+  bool supports(SolverFeature Feature) const override final;
   void reset() override final;
   void push(unsigned nscopes = 1) override final;
   void pop(unsigned nscopes = 1) override final;
@@ -776,6 +777,12 @@ protected:
                            unsigned SWidth);
 
   virtual checkResult checkImpl() = 0;
+
+  /// Backend feature bits for everything supports() cannot answer from
+  /// the existing capability hooks (nativeTupleSupport,
+  /// nativeConstArraySupport). The default claims nothing; backends
+  /// override with a switch over the features they implement.
+  virtual bool supportsImpl(SolverFeature Feature) const;
 
   virtual void resetImpl() = 0;
 

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -1204,6 +1204,23 @@ SMTExprRef CVC5Solver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
       Terms.mkTerm(cvc5::Kind::EXISTS, {bound_list, substituted_body}));
 }
 
+bool CVC5Solver::supportsImpl(SolverFeature Feature) const {
+  switch (Feature) {
+  case SolverFeature::IntRealArithmetic:
+  case SolverFeature::Quantifiers:
+  case SolverFeature::UninterpretedFunctions:
+  case SolverFeature::NativeFloatingPoint:
+  case SolverFeature::UnsatAssumptions:
+  case SolverFeature::Timeouts:
+  case SolverFeature::ArrayModels:
+    return true;
+  case SolverFeature::NativeTuples:
+  case SolverFeature::NativeConstantArrays:
+    break; // answered by the common layer's hooks
+  }
+  return false;
+}
+
 checkResult CVC5Solver::checkImpl() {
   cvc5::Result res = Context.checkSat();
   if (res.isSat())

--- a/src/cvc5solver.h
+++ b/src/cvc5solver.h
@@ -357,6 +357,8 @@ protected:
 
   checkResult checkImpl() override;
 
+  bool supportsImpl(SolverFeature Feature) const override;
+
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/mathsatsolver.cpp
+++ b/src/mathsatsolver.cpp
@@ -1090,6 +1090,24 @@ SMTExprRef MathSATSolver::mkArrayConstImpl(const SMTSortRef &IndexSort,
                             backend_init));
 }
 
+bool MathSATSolver::supportsImpl(SolverFeature Feature) const {
+  switch (Feature) {
+  case SolverFeature::IntRealArithmetic:
+  case SolverFeature::UninterpretedFunctions:
+  case SolverFeature::NativeFloatingPoint:
+  case SolverFeature::UnsatAssumptions:
+  case SolverFeature::Timeouts:
+  case SolverFeature::ArrayModels:
+    return true;
+  case SolverFeature::Quantifiers:
+    return false;
+  case SolverFeature::NativeTuples:
+  case SolverFeature::NativeConstantArrays:
+    break; // answered by the common layer's hooks
+  }
+  return false;
+}
+
 checkResult MathSATSolver::checkImpl() {
   msat_result res = msat_solve(Context);
   if (res == MSAT_SAT)

--- a/src/mathsatsolver.h
+++ b/src/mathsatsolver.h
@@ -329,6 +329,8 @@ protected:
 
   checkResult checkImpl() override;
 
+  bool supportsImpl(SolverFeature Feature) const override;
+
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -2153,6 +2153,27 @@ SMTExprRef SMTLIBSolver::getArrayElementImpl(const SMTExprRef &Array,
   return mkArraySelect(Array, Index);
 }
 
+bool SMTLIBSolver::supportsImpl(SolverFeature Feature) const {
+  switch (Feature) {
+  // These bits describe what the emitter can put on the wire; a given
+  // child solver may still reject a construct at runtime (yices-smt2 has
+  // no FP, bitwuzla no Int/Real, ...).
+  case SolverFeature::IntRealArithmetic:
+  case SolverFeature::Quantifiers:
+  case SolverFeature::UninterpretedFunctions:
+  case SolverFeature::NativeFloatingPoint:
+  case SolverFeature::UnsatAssumptions:
+    return true;
+  case SolverFeature::Timeouts:
+  case SolverFeature::ArrayModels:
+    return false;
+  case SolverFeature::NativeTuples:
+  case SolverFeature::NativeConstantArrays:
+    break; // answered by the common layer's hooks
+  }
+  return false;
+}
+
 checkResult SMTLIBSolver::checkImpl() {
   // (check-sat) is a query — it does NOT produce a `success` ack even when
   // :print-success is true. Bypass emitLine's resync logic; write the

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -376,6 +376,8 @@ protected:
 
   // --- check / push / pop / reset ---
   checkResult checkImpl() override;
+
+  bool supportsImpl(SolverFeature Feature) const override;
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/yicessolver.cpp
+++ b/src/yicessolver.cpp
@@ -819,6 +819,30 @@ SMTExprRef YicesSolver::mkArrayConstImpl(const SMTSortRef &,
   fatalError("Yices constant arrays are lowered lazily by the common layer");
 }
 
+bool YicesSolver::supportsImpl(SolverFeature Feature) const {
+  switch (Feature) {
+  case SolverFeature::IntRealArithmetic:
+  case SolverFeature::UninterpretedFunctions:
+  case SolverFeature::UnsatAssumptions:
+  case SolverFeature::ArrayModels:
+    return true;
+  case SolverFeature::Timeouts:
+    // Enforced through SIGALRM + yices_stop_search; POSIX only.
+#if defined(_WIN32)
+    return false;
+#else
+    return true;
+#endif
+  case SolverFeature::Quantifiers:
+  case SolverFeature::NativeFloatingPoint:
+    return false;
+  case SolverFeature::NativeTuples:
+  case SolverFeature::NativeConstantArrays:
+    break; // answered by the common layer's hooks
+  }
+  return false;
+}
+
 checkResult YicesSolver::checkImpl() {
   smt_status_t res = yices_check_context(Context, nullptr);
   if (res == YICES_STATUS_SAT)

--- a/src/yicessolver.h
+++ b/src/yicessolver.h
@@ -264,6 +264,8 @@ protected:
 
   checkResult checkImpl() override;
 
+  bool supportsImpl(SolverFeature Feature) const override;
+
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -1053,6 +1053,23 @@ SMTExprRef Z3Solver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
                              z3::exists(bound_vars, toZ3Expr(Body)));
 }
 
+bool Z3Solver::supportsImpl(SolverFeature Feature) const {
+  switch (Feature) {
+  case SolverFeature::IntRealArithmetic:
+  case SolverFeature::Quantifiers:
+  case SolverFeature::UninterpretedFunctions:
+  case SolverFeature::NativeFloatingPoint:
+  case SolverFeature::UnsatAssumptions:
+  case SolverFeature::Timeouts:
+  case SolverFeature::ArrayModels:
+    return true;
+  case SolverFeature::NativeTuples:
+  case SolverFeature::NativeConstantArrays:
+    break; // answered by the common layer's hooks
+  }
+  return false;
+}
+
 checkResult Z3Solver::checkImpl() {
   z3::check_result res = Solver.check();
   if (res == z3::check_result::sat)

--- a/src/z3solver.h
+++ b/src/z3solver.h
@@ -366,6 +366,8 @@ protected:
 
   checkResult checkImpl() override;
 
+  bool supportsImpl(SolverFeature Feature) const override;
+
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;


### PR DESCRIPTION
Closes #78.

## What

```cpp
enum class SolverFeature {
  IntRealArithmetic, Quantifiers, UninterpretedFunctions,
  NativeFloatingPoint, NativeTuples, NativeConstantArrays,
  UnsatAssumptions, Timeouts, ArrayModels,
};
bool supports(SolverFeature Feature) const;
```

Lets users query what a backend implements instead of discovering it through aborts (`unsupportedFeature` fatal errors) or `UnsupportedOperation` results.

## Design

- The common layer answers `NativeTuples` / `NativeConstantArrays` from the existing `nativeTupleSupport()` / `nativeConstArraySupport()` hooks, so instance-sensitive answers fall out automatically (an SMT-LIB solver constructed with `TupleEncoding::Camada` reports no native tuples).
- Everything else dispatches to a per-backend `supportsImpl` table. The switches deliberately have **no `default:`** — adding a new `SolverFeature` enumerator makes `-Wswitch` under `-Werror` fail every backend until it takes an explicit position, instead of silently defaulting to false.
- On the SMT-LIB pipeline the bits describe what the emitter can put on the wire; a particular child may still reject a construct at runtime (yices-smt2 has no FP, bitwuzla no Int/Real).
- The `UnsatAssumptions` / `Timeouts` / `ArrayModels` bits are set to the final values implemented by #76 / #77 / #79, so no follow-up flip is needed regardless of merge order; until those land, the gated methods don't exist and a true bit is unobservable.

Truth table:

| Feature | Z3 | CVC5 | Bitwuzla | MathSAT | Yices | STP | SMT-LIB |
|---|---|---|---|---|---|---|---|
| IntRealArithmetic | ✓ | ✓ | — | ✓ | ✓ | — | ✓ |
| Quantifiers | ✓ | ✓ | ✓ | — | — | — | ✓ |
| UninterpretedFunctions | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ |
| NativeFloatingPoint | ✓ | ✓ | ✓ | ✓ | — | — | ✓ |
| NativeTuples | ✓ | ✓ | — | — | — | — | mode |
| NativeConstantArrays | ✓ | ✓ | ✓ | ✓ | — | — | ✓ |
| UnsatAssumptions (#76) | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ |
| Timeouts (#77) | ✓ | ✓ | ✓ | ✓ | POSIX | — | — |
| ArrayModels (#79) | ✓ | ✓ | ✓ | ✓ | ✓ | — | — |

## Testing

One "feature capabilities" test case per backend pinning the full 9-bit table, including STP all-false and the SMT-LIB `TupleEncoding::Camada` flip. Full suite: 154/154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
