### PR TITLE
Bring Z3 4.16 back

### DIFF
--- a/.github/workflows/benchmark-master.yml
+++ b/.github/workflows/benchmark-master.yml
@@ -27,13 +27,13 @@ jobs:
             schedtool
 
       - name: Cache deps
-        id: cache-deps-bench-v2
+        id: cache-deps-bench-v3
         uses: actions/cache@v4
         with:
           path: |
             build/deps
             build/_deps
-          key: ${{ runner.os }}-bench-deps-v2
+          key: ${{ runner.os }}-bench-deps-v3
 
       - name: Configure Camada
         run: >

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -37,13 +37,13 @@ jobs:
             schedtool
 
       - name: Cache deps
-        id: cache-deps-bench-v2
+        id: cache-deps-bench-v3
         uses: actions/cache@v4
         with:
           path: |
             build/deps
             build/_deps
-          key: ${{ runner.os }}-bench-deps-v2
+          key: ${{ runner.os }}-bench-deps-v3
 
       - name: Download latest master baseline
         id: download-master-baseline

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,13 +19,13 @@ jobs:
 
       # Setup/cache dependencies
     - name: Cache deps
-      id: cache-deps-v8
+      id: cache-deps-v9
       uses: actions/cache@v4
       with:
         path: |
           build/deps
           build/_deps
-        key: ${{ runner.os }}-deps-v8
+        key: ${{ runner.os }}-deps-v9
 
     - name: Configure Camada
       run: cmake -S . -B build -GNinja -DCAMADA_ENABLE_REGRESSION=ON -DBUILD_SHARED_LIBS=OFF -DCAMADA_DOWNLOAD_DEPENDENCIES=ALL -DCAMADA_SOLVER_BITWUZLA_ENABLE=ON -DCAMADA_SOLVER_CVC5_ENABLE=ON -DCAMADA_SOLVER_MATHSAT_ENABLE=ON -DCAMADA_SOLVER_STP_ENABLE=ON -DCAMADA_SOLVER_YICES_ENABLE=ON -DCAMADA_SOLVER_Z3_ENABLE=ON -DENABLE_WARNINGS=ON -DENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/release -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,13 +25,13 @@ jobs:
 
       # Setup/cache dependencies
     - name: Cache deps
-      id: cache-deps-v8
+      id: cache-deps-v9
       uses: actions/cache@v4
       with:
         path: |
           build/deps
           build/_deps
-        key: ${{ runner.os }}-deps-v8
+        key: ${{ runner.os }}-deps-v9
 
     - name: Configure Camada
       run: cmake -S . -B build -GNinja -DCAMADA_ENABLE_REGRESSION=ON -DBUILD_SHARED_LIBS=OFF -DCAMADA_DOWNLOAD_DEPENDENCIES=ALL -DCAMADA_SOLVER_BITWUZLA_ENABLE=ON -DCAMADA_SOLVER_CVC5_ENABLE=ON -DCAMADA_SOLVER_MATHSAT_ENABLE=ON -DCAMADA_SOLVER_STP_ENABLE=ON -DCAMADA_SOLVER_YICES_ENABLE=ON -DCAMADA_SOLVER_Z3_ENABLE=ON -DENABLE_WARNINGS=ON -DENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/release -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,13 +24,13 @@ jobs:
 
       # Setup/cache dependencies
     - name: Cache deps
-      id: cache-deps-v8
+      id: cache-deps-v9
       uses: actions/cache@v4
       with:
         path: |
           build/deps
           build/_deps
-        key: ${{ runner.os }}-deps-v8
+        key: ${{ runner.os }}-deps-v9
 
     - name: Configure Camada
       shell: pwsh

--- a/.github/workflows/release-consumer.yml
+++ b/.github/workflows/release-consumer.yml
@@ -29,7 +29,7 @@ jobs:
         path: |
           .build-release/deps
           .build-release/_deps
-        key: ${{ runner.os }}-release-deps-v1
+        key: ${{ runner.os }}-release-deps-v2
 
     - name: Generate release
       run: python3 ./scripts/release.py
@@ -55,7 +55,7 @@ jobs:
         path: |
           .build-release/deps
           .build-release/_deps
-        key: ${{ runner.os }}-release-deps-v1
+        key: ${{ runner.os }}-release-deps-v2
 
     - name: Generate release
       shell: pwsh
@@ -95,7 +95,7 @@ jobs:
         path: |
           .build-release/deps
           .build-release/_deps
-        key: ${{ runner.os }}-release-deps-v1
+        key: ${{ runner.os }}-release-deps-v2
 
     - name: Generate release
       run: python3 ./scripts/release.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ config_solver(CVC5 1.0.8)
 config_solver(MathSAT 5.6.3)
 config_solver(STP 2.3.4)
 config_solver(Yices 2.6.1)
-config_solver(Z3 4.15.4)
+config_solver(Z3 4.16.0)
 
 # The SMT-LIB pipeline backend drives an external SMT-LIB-speaking process via
 # fork/exec/setrlimit/select, so it is POSIX-only. Default ON elsewhere; force

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -45,8 +45,7 @@ TEST_CASE("Override Z3 Solver", "[Z3]") {
 
   class myZ3Solver : public camada::Z3Solver {
   public:
-    explicit myZ3Solver(std::unique_ptr<z3::context> C)
-        : camada::Z3Solver(std::move(C)) {
+    explicit myZ3Solver(z3::context C) : camada::Z3Solver(std::move(C)) {
       setSolver(makeSolver(context()));
     }
 
@@ -59,8 +58,7 @@ TEST_CASE("Override Z3 Solver", "[Z3]") {
   };
 
   // Create Z3 Solver
-  camada::SMTSolverRef z3 =
-      std::make_unique<myZ3Solver>(std::make_unique<z3::context>());
+  camada::SMTSolverRef z3 = std::make_unique<myZ3Solver>(z3::context{});
 
   tests(z3);
 }

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -26,22 +26,22 @@ set(CAMADA_DEPS_INSTALL_DIR
     CACHE PATH "Directory used to install downloaded solver dependencies")
 
 set(CAMADA_Z3_LINUX_X86_64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.15.4/z3-4.15.4-x64-glibc-2.39.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-x64-glibc-2.39.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for Linux x86_64")
 set(CAMADA_Z3_LINUX_AARCH64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.15.4/z3-4.15.4-arm64-glibc-2.34.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-arm64-glibc-2.38.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for Linux aarch64")
 set(CAMADA_Z3_MACOS_X86_64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.15.4/z3-4.15.4-x64-osx-13.7.6.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-x64-osx-15.7.3.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for macOS x86_64")
 set(CAMADA_Z3_MACOS_ARM64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.15.4/z3-4.15.4-arm64-osx-13.7.6.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-arm64-osx-15.7.3.zip"
     CACHE STRING "URL used to download the prebuilt Z3 archive for macOS arm64")
 set(CAMADA_Z3_WINDOWS_X86_64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.15.4/z3-4.15.4-x64-win.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-x64-win.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for Windows x86_64")
 set(CAMADA_CVC5_LINUX_X86_64_URL

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -436,10 +436,10 @@ SMTExprRef Z3Solver::mkBVAddOverflowImpl(const SMTExprRef &LHS,
                                          const SMTExprRef &RHS, bool IsSigned) {
   z3::expr L = toZ3Expr(LHS), R = toZ3Expr(RHS);
   z3::expr Ok =
-      z3::to_expr(*Context, Z3_mk_bvadd_no_overflow(*Context, L, R, IsSigned));
+      z3::to_expr(Context, Z3_mk_bvadd_no_overflow(Context, L, R, IsSigned));
   if (IsSigned)
-    Ok = Ok && z3::to_expr(*Context, Z3_mk_bvadd_no_underflow(*Context, L, R));
-  return makeExprRef<Z3Expr>(SMTExprKind::BVAddOverflow, Context, mkBoolSort(),
+    Ok = Ok && z3::to_expr(Context, Z3_mk_bvadd_no_underflow(Context, L, R));
+  return makeExprRef<Z3Expr>(SMTExprKind::BVAddOverflow, &Context, mkBoolSort(),
                              !Ok);
 }
 
@@ -447,10 +447,10 @@ SMTExprRef Z3Solver::mkBVSubOverflowImpl(const SMTExprRef &LHS,
                                          const SMTExprRef &RHS, bool IsSigned) {
   z3::expr L = toZ3Expr(LHS), R = toZ3Expr(RHS);
   z3::expr Ok =
-      z3::to_expr(*Context, Z3_mk_bvsub_no_underflow(*Context, L, R, IsSigned));
+      z3::to_expr(Context, Z3_mk_bvsub_no_underflow(Context, L, R, IsSigned));
   if (IsSigned)
-    Ok = Ok && z3::to_expr(*Context, Z3_mk_bvsub_no_overflow(*Context, L, R));
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSubOverflow, Context, mkBoolSort(),
+    Ok = Ok && z3::to_expr(Context, Z3_mk_bvsub_no_overflow(Context, L, R));
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSubOverflow, &Context, mkBoolSort(),
                              !Ok);
 }
 
@@ -458,26 +458,25 @@ SMTExprRef Z3Solver::mkBVMulOverflowImpl(const SMTExprRef &LHS,
                                          const SMTExprRef &RHS, bool IsSigned) {
   z3::expr L = toZ3Expr(LHS), R = toZ3Expr(RHS);
   z3::expr Ok =
-      z3::to_expr(*Context, Z3_mk_bvmul_no_overflow(*Context, L, R, IsSigned));
+      z3::to_expr(Context, Z3_mk_bvmul_no_overflow(Context, L, R, IsSigned));
   if (IsSigned)
-    Ok = Ok && z3::to_expr(*Context, Z3_mk_bvmul_no_underflow(*Context, L, R));
-  return makeExprRef<Z3Expr>(SMTExprKind::BVMulOverflow, Context, mkBoolSort(),
+    Ok = Ok && z3::to_expr(Context, Z3_mk_bvmul_no_underflow(Context, L, R));
+  return makeExprRef<Z3Expr>(SMTExprKind::BVMulOverflow, &Context, mkBoolSort(),
                              !Ok);
 }
 
 SMTExprRef Z3Solver::mkBVSDivOverflowImpl(const SMTExprRef &LHS,
                                           const SMTExprRef &RHS) {
-  z3::expr Ok =
-      z3::to_expr(*Context, Z3_mk_bvsdiv_no_overflow(*Context, toZ3Expr(LHS),
-                                                     toZ3Expr(RHS)));
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSDivOverflow, Context, mkBoolSort(),
-                             !Ok);
+  z3::expr Ok = z3::to_expr(
+      Context, Z3_mk_bvsdiv_no_overflow(Context, toZ3Expr(LHS), toZ3Expr(RHS)));
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSDivOverflow, &Context,
+                             mkBoolSort(), !Ok);
 }
 
 SMTExprRef Z3Solver::mkBVNegOverflowImpl(const SMTExprRef &Exp) {
   z3::expr Ok =
-      z3::to_expr(*Context, Z3_mk_bvneg_no_overflow(*Context, toZ3Expr(Exp)));
-  return makeExprRef<Z3Expr>(SMTExprKind::BVNegOverflow, Context, mkBoolSort(),
+      z3::to_expr(Context, Z3_mk_bvneg_no_overflow(Context, toZ3Expr(Exp)));
+  return makeExprRef<Z3Expr>(SMTExprKind::BVNegOverflow, &Context, mkBoolSort(),
                              !Ok);
 }
 
@@ -824,7 +823,7 @@ static bool bvNumeralToBinary(z3::context &Ctx, const z3::expr &Value,
 SMTResult<std::string> Z3Solver::getBVInBinImpl(const SMTExprRef &Exp) {
   z3::expr Value = Solver.get_model().eval(toZ3Expr(Exp), true);
   std::string bv;
-  if (!bvNumeralToBinary(*Context, Value, Exp->getWidth(), bv))
+  if (!bvNumeralToBinary(Context, Value, Exp->getWidth(), bv))
     return SMTError{SMTErrorCode::InvalidModelValue, SMTBackendKind::Z3,
                     "Failed to get bit-vector model value from Z3"};
   return bv;
@@ -873,7 +872,7 @@ SMTResult<std::string> Z3Solver::getFPInBinImpl(const SMTExprRef &Exp) {
   z3::expr Value = Solver.get_model().eval(toZ3Expr(Exp), true);
   z3::expr fp_value = Solver.get_model().eval(Value.mk_to_ieee_bv(), true);
   std::string bv;
-  if (!bvNumeralToBinary(*Context, fp_value, Exp->getWidth(), bv))
+  if (!bvNumeralToBinary(Context, fp_value, Exp->getWidth(), bv))
     return SMTError{SMTErrorCode::InvalidModelValue, SMTBackendKind::Z3,
                     "Failed to convert FP model value to BV in Z3"};
   return bv;

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -101,24 +101,19 @@ void Z3Expr::dump(std::string &Out) const {
   Out += "\n";
 }
 
-Z3Solver::Z3Solver()
-    : OwnedContext(std::make_unique<z3::context>()),
-      Context(OwnedContext.get()), Solver(*Context) {
+Z3Solver::Z3Solver() : Solver(Context) {
   // Needs to be set in order to convert NaN to bitvector
   z3::set_param("rewriter.hi_fp_unspecified", true);
   initializeCommonSingletons();
 }
 
-Z3Solver::Z3Solver(std::unique_ptr<z3::context> C)
-    : OwnedContext(std::move(C)), Context(OwnedContext.get()),
-      Solver(*Context) {
+Z3Solver::Z3Solver(z3::context C) : Context(std::move(C)), Solver(Context) {
   z3::set_param("rewriter.hi_fp_unspecified", true);
   initializeCommonSingletons();
 }
 
-Z3Solver::Z3Solver(std::unique_ptr<z3::context> C, z3::solver S)
-    : OwnedContext(std::move(C)), Context(OwnedContext.get()),
-      Solver(std::move(S)) {
+Z3Solver::Z3Solver(z3::context C, z3::solver S)
+    : Context(std::move(C)), Solver(std::move(S)) {
   // Needs to be set in order to convert NaN to bitvector
   z3::set_param("rewriter.hi_fp_unspecified", true);
   initializeCommonSingletons();
@@ -141,59 +136,59 @@ SMTExprRef Z3Solver::rewrapExprImpl(const SMTExpr &Exp, const SMTSortRef &Sort,
 }
 
 SMTSortRef Z3Solver::mkBoolSortImpl() {
-  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::Bool, Context,
-                                    Context->bool_sort(),
+  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::Bool, &Context,
+                                    Context.bool_sort(),
                                     SMTSort::ScalarSortData{1}));
 }
 
 SMTSortRef Z3Solver::mkIntSortImpl() {
   return makeSortRef<Z3Sort>(
-      Z3Sort(SMTSortKind::Int, Context, Context->int_sort()));
+      Z3Sort(SMTSortKind::Int, &Context, Context.int_sort()));
 }
 
 SMTSortRef Z3Solver::mkRealSortImpl() {
   return makeSortRef<Z3Sort>(
-      Z3Sort(SMTSortKind::Real, Context, Context->real_sort()));
+      Z3Sort(SMTSortKind::Real, &Context, Context.real_sort()));
 }
 
 SMTSortRef Z3Solver::mkBVSortImpl(unsigned BitWidth) {
-  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::BV, Context,
-                                    Context->bv_sort(BitWidth),
+  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::BV, &Context,
+                                    Context.bv_sort(BitWidth),
                                     SMTSort::ScalarSortData{BitWidth}));
 }
 
 SMTSortRef Z3Solver::mkRMSortImpl() {
-  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::RM, Context,
-                                    Context->fpa_rounding_mode_sort(),
+  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::RM, &Context,
+                                    Context.fpa_rounding_mode_sort(),
                                     SMTSort::ScalarSortData{3}));
 }
 
 SMTSortRef Z3Solver::mkFPSortImpl(const unsigned ExpWidth,
                                   const unsigned SigWidth) {
   return makeSortRef<Z3Sort>(Z3Sort(
-      SMTSortKind::FP, Context, Context->fpa_sort(ExpWidth, SigWidth + 1),
+      SMTSortKind::FP, &Context, Context.fpa_sort(ExpWidth, SigWidth + 1),
       SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth}));
 }
 
 SMTSortRef Z3Solver::mkBVFPSortImpl(const unsigned ExpWidth,
                                     const unsigned SigWidth) {
   return makeSortRef<Z3Sort>(Z3Sort(
-      SMTSortKind::BVFP, Context, Context->bv_sort(ExpWidth + SigWidth + 1),
+      SMTSortKind::BVFP, &Context, Context.bv_sort(ExpWidth + SigWidth + 1),
       SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth + 1}));
 }
 
 SMTSortRef Z3Solver::mkBVRMSortImpl() {
-  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::BVRM, Context,
-                                    Context->bv_sort(3),
+  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::BVRM, &Context,
+                                    Context.bv_sort(3),
                                     SMTSort::ScalarSortData{3}));
 }
 
 SMTSortRef Z3Solver::mkArraySortImpl(const SMTSortRef &IndexSort,
                                      const SMTSortRef &ElemSort) {
   return makeSortRef<Z3Sort>(
-      Z3Sort(SMTSortKind::Array, Context,
-             Context->array_sort(toSolverSort<Z3Sort>(*IndexSort).Sort,
-                                 toSolverSort<Z3Sort>(*ElemSort).Sort),
+      Z3Sort(SMTSortKind::Array, &Context,
+             Context.array_sort(toSolverSort<Z3Sort>(*IndexSort).Sort,
+                                toSolverSort<Z3Sort>(*ElemSort).Sort),
              SMTSort::ArraySortData{IndexSort, ElemSort}));
 }
 
@@ -201,7 +196,7 @@ SMTSortRef
 Z3Solver::mkFunctionSortImpl(const std::vector<SMTSortRef> &DomainSorts,
                              const SMTSortRef &CodomainSort) {
   return makeSortRef<Z3Sort>(Z3Sort(
-      SMTSortKind::Function, Context, toSolverSort<Z3Sort>(*CodomainSort).Sort,
+      SMTSortKind::Function, &Context, toSolverSort<Z3Sort>(*CodomainSort).Sort,
       SMTSort::FunctionSortData{DomainSorts, CodomainSort}));
 }
 
@@ -221,216 +216,216 @@ Z3Solver::mkTupleSortImpl(const std::vector<SMTSortRef> &ElementSorts) {
   for (const auto &Name : FieldNames)
     NamePtrs.push_back(Name.c_str());
 
-  z3::func_decl_vector Projs(*Context);
-  z3::func_decl Ctor = Context->tuple_sort(
+  z3::func_decl_vector Projs(Context);
+  z3::func_decl Ctor = Context.tuple_sort(
       ("camada_tuple_" + std::to_string(TupleCounter++)).c_str(),
       static_cast<unsigned>(Fields.size()), NamePtrs.data(), Fields.data(),
       Projs);
 
-  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::Tuple, Context, Ctor.range(),
+  return makeSortRef<Z3Sort>(Z3Sort(SMTSortKind::Tuple, &Context, Ctor.range(),
                                     SMTSort::TupleSortData{ElementSorts}));
 }
 
 SMTExprRef Z3Solver::mkBVNegImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVNeg, Context, Exp->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVNeg, &Context, Exp->Sort,
                              -toZ3Expr(Exp));
 }
 
 SMTExprRef Z3Solver::mkBVNotImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVNot, Context, Exp->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVNot, &Context, Exp->Sort,
                              ~toZ3Expr(Exp));
 }
 
 SMTExprRef Z3Solver::mkNotImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::Not, Context, Exp->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::Not, &Context, Exp->Sort,
                              !toZ3Expr(Exp));
 }
 
 SMTExprRef Z3Solver::mkBVRedOrImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVRedOr, Context, mkBVSort(1),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVRedOr, &Context, mkBVSort(1),
                              z3::bvredor(toZ3Expr(Exp)));
 }
 
 SMTExprRef Z3Solver::mkBVRedAndImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVRedAnd, Context, mkBVSort(1),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVRedAnd, &Context, mkBVSort(1),
                              z3::bvredand(toZ3Expr(Exp)));
 }
 
 SMTExprRef Z3Solver::mkArithNegImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithNeg, Context, Exp->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithNeg, &Context, Exp->Sort,
                              -toZ3Expr(Exp));
 }
 
 SMTExprRef Z3Solver::mkInt2RealImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::Int2Real, Context, mkRealSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::Int2Real, &Context, mkRealSort(),
                              z3::to_real(toZ3Expr(Exp)));
 }
 
 SMTExprRef Z3Solver::mkIsIntImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::IsInt, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::IsInt, &Context, mkBoolSort(),
                              z3::is_int(toZ3Expr(Exp)));
 }
 
 SMTExprRef Z3Solver::mkFPAbsImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPAbs, Context, Exp->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::FPAbs, &Context, Exp->Sort,
                              z3::abs(toZ3Expr(Exp)));
 }
 
 SMTExprRef Z3Solver::mkFPNegImpl(const SMTExprRef &Exp, FPNegBehavior) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPNeg, Context, Exp->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::FPNeg, &Context, Exp->Sort,
                              -toZ3Expr(Exp));
 }
 
 SMTExprRef Z3Solver::mkFPIsInfiniteImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPIsInfinite, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPIsInfinite, &Context, mkBoolSort(),
                              toZ3Expr(Exp).mk_is_inf());
 }
 
 SMTExprRef Z3Solver::mkFPIsNaNImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPIsNaN, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPIsNaN, &Context, mkBoolSort(),
                              toZ3Expr(Exp).mk_is_nan());
 }
 
 SMTExprRef Z3Solver::mkFPIsDenormalImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPIsDenormal, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPIsDenormal, &Context, mkBoolSort(),
                              toZ3Expr(Exp).mk_is_subnormal());
 }
 
 SMTExprRef Z3Solver::mkFPIsNormalImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPIsNormal, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPIsNormal, &Context, mkBoolSort(),
                              toZ3Expr(Exp).mk_is_normal());
 }
 
 SMTExprRef Z3Solver::mkFPIsZeroImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPIsZero, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPIsZero, &Context, mkBoolSort(),
                              toZ3Expr(Exp).mk_is_zero());
 }
 
 SMTExprRef Z3Solver::mkBVAddImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVAdd, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVAdd, &Context, LHS->Sort,
                              toZ3Expr(LHS) + toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkBVSubImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSub, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSub, &Context, LHS->Sort,
                              toZ3Expr(LHS) - toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkBVMulImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVMul, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVMul, &Context, LHS->Sort,
                              toZ3Expr(LHS) * toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkBVSRemImpl(const SMTExprRef &LHS,
                                   const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSRem, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSRem, &Context, LHS->Sort,
                              z3::srem(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVURemImpl(const SMTExprRef &LHS,
                                   const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVURem, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVURem, &Context, LHS->Sort,
                              z3::urem(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVSDivImpl(const SMTExprRef &LHS,
                                   const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSDiv, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSDiv, &Context, LHS->Sort,
                              toZ3Expr(LHS) / toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkBVUDivImpl(const SMTExprRef &LHS,
                                   const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVUDiv, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVUDiv, &Context, LHS->Sort,
                              z3::udiv(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVShlImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVShl, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVShl, &Context, LHS->Sort,
                              z3::shl(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVAshrImpl(const SMTExprRef &LHS,
                                   const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVAshr, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVAshr, &Context, LHS->Sort,
                              z3::ashr(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVLshrImpl(const SMTExprRef &LHS,
                                   const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVLshr, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVLshr, &Context, LHS->Sort,
                              z3::lshr(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVXorImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVXor, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVXor, &Context, LHS->Sort,
                              toZ3Expr(LHS) ^ toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkBVOrImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVOr, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVOr, &Context, LHS->Sort,
                              toZ3Expr(LHS) | toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkBVAndImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVAnd, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVAnd, &Context, LHS->Sort,
                              toZ3Expr(LHS) & toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkBVXnorImpl(const SMTExprRef &LHS,
                                   const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVXnor, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVXnor, &Context, LHS->Sort,
                              z3::xnor(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVNorImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVNor, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVNor, &Context, LHS->Sort,
                              z3::nor(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVNandImpl(const SMTExprRef &LHS,
                                   const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVNand, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVNand, &Context, LHS->Sort,
                              z3::nand(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVUltImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVUlt, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVUlt, &Context, mkBoolSort(),
                              z3::ult(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVSltImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSlt, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSlt, &Context, mkBoolSort(),
                              z3::slt(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVUgtImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVUgt, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVUgt, &Context, mkBoolSort(),
                              z3::ugt(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVSgtImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSgt, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSgt, &Context, mkBoolSort(),
                              toZ3Expr(LHS) > toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkBVUleImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVUle, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVUle, &Context, mkBoolSort(),
                              z3::ule(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVSleImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSle, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSle, &Context, mkBoolSort(),
                              z3::sle(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVUgeImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVUge, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVUge, &Context, mkBoolSort(),
                              z3::uge(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkBVSgeImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSge, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSge, &Context, mkBoolSort(),
                              toZ3Expr(LHS) >= toZ3Expr(RHS));
 }
 
@@ -488,164 +483,164 @@ SMTExprRef Z3Solver::mkBVNegOverflowImpl(const SMTExprRef &Exp) {
 
 SMTExprRef Z3Solver::mkImpliesImpl(const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::Implies, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::Implies, &Context, mkBoolSort(),
                              z3::implies(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkAndImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::And, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::And, &Context, mkBoolSort(),
                              toZ3Expr(LHS) && toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkOrImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::Or, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::Or, &Context, mkBoolSort(),
                              toZ3Expr(LHS) || toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkXorImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::Xor, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::Xor, &Context, LHS->Sort,
                              toZ3Expr(LHS) ^ toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkArithAddImpl(const SMTExprRef &LHS,
                                     const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithAdd, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithAdd, &Context, LHS->Sort,
                              toZ3Expr(LHS) + toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkArithSubImpl(const SMTExprRef &LHS,
                                     const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithSub, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithSub, &Context, LHS->Sort,
                              toZ3Expr(LHS) - toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkArithMulImpl(const SMTExprRef &LHS,
                                     const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithMul, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithMul, &Context, LHS->Sort,
                              toZ3Expr(LHS) * toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkArithDivImpl(const SMTExprRef &LHS,
                                     const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithDiv, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithDiv, &Context, LHS->Sort,
                              toZ3Expr(LHS) / toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkArithModImpl(const SMTExprRef &LHS,
                                     const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithMod, Context, mkIntSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithMod, &Context, mkIntSort(),
                              z3::mod(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkArithShlImpl(const SMTExprRef &LHS,
                                     const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithShl, Context, mkIntSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithShl, &Context, mkIntSort(),
                              toZ3Expr(LHS) *
                                  z3::pw(toZ3Expr(mkInt("2")), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkArithLtImpl(const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithLt, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithLt, &Context, mkBoolSort(),
                              toZ3Expr(LHS) < toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkArithGtImpl(const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithGt, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithGt, &Context, mkBoolSort(),
                              toZ3Expr(LHS) > toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkArithLeImpl(const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithLe, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithLe, &Context, mkBoolSort(),
                              toZ3Expr(LHS) <= toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkArithGeImpl(const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArithGe, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::ArithGe, &Context, mkBoolSort(),
                              toZ3Expr(LHS) >= toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkEqualImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::Equal, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::Equal, &Context, mkBoolSort(),
                              toZ3Expr(LHS) == toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkBVConcatImpl(const SMTExprRef &LHS,
                                     const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVConcat, Context,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVConcat, &Context,
                              mkBVSort(LHS->getWidth() + RHS->getWidth()),
                              z3::concat(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkArraySelectImpl(const SMTExprRef &LHS,
                                        const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::ArraySelect, Context,
+  return makeExprRef<Z3Expr>(SMTExprKind::ArraySelect, &Context,
                              LHS->Sort->getElementSort(),
                              z3::select(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkFPRemImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPRem, Context, LHS->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::FPRem, &Context, LHS->Sort,
                              z3::rem(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkFPLtImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPLt, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPLt, &Context, mkBoolSort(),
                              toZ3Expr(LHS) < toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkFPGtImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPGt, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPGt, &Context, mkBoolSort(),
                              toZ3Expr(LHS) > toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkFPLeImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPLe, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPLe, &Context, mkBoolSort(),
                              toZ3Expr(LHS) <= toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkFPGeImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPGe, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPGe, &Context, mkBoolSort(),
                              toZ3Expr(LHS) >= toZ3Expr(RHS));
 }
 
 SMTExprRef Z3Solver::mkFPEqualImpl(const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPEqual, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::FPEqual, &Context, mkBoolSort(),
                              z3::fp_eq(toZ3Expr(LHS), toZ3Expr(RHS)));
 }
 
 SMTExprRef Z3Solver::mkReal2IntImpl(const SMTExprRef &Exp) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::Real2Int, Context, mkIntSort(),
-      z3::to_expr(*Context, Z3_mk_real2int(*Context, toZ3Expr(Exp))));
+      SMTExprKind::Real2Int, &Context, mkIntSort(),
+      z3::to_expr(Context, Z3_mk_real2int(Context, toZ3Expr(Exp))));
 }
 
 SMTExprRef Z3Solver::mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVSignExt, Context,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVSignExt, &Context,
                              mkBVSort(i + Exp->getWidth()),
                              z3::sext(toZ3Expr(Exp), i));
 }
 
 SMTExprRef Z3Solver::mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVZeroExt, Context,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVZeroExt, &Context,
                              mkBVSort(i + Exp->getWidth()),
                              z3::zext(toZ3Expr(Exp), i));
 }
 
 SMTExprRef Z3Solver::mkBVExtractImpl(unsigned High, unsigned Low,
                                      const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVExtract, Context,
+  return makeExprRef<Z3Expr>(SMTExprKind::BVExtract, &Context,
                              mkBVSort(High - Low + 1),
                              toZ3Expr(Exp).extract(High, Low));
 }
 
 SMTExprRef Z3Solver::mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                                const SMTExprRef &F) {
-  return makeExprRef<Z3Expr>(SMTExprKind::Ite, Context, T->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::Ite, &Context, T->Sort,
                              z3::ite(toZ3Expr(Cond), toZ3Expr(T), toZ3Expr(F)));
 }
 
@@ -653,7 +648,7 @@ SMTExprRef Z3Solver::mkArrayStoreImpl(const SMTExprRef &Array,
                                       const SMTExprRef &Index,
                                       const SMTExprRef &Element) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::ArrayStore, Context, Array->Sort,
+      SMTExprKind::ArrayStore, &Context, Array->Sort,
       z3::store(toZ3Expr(Array), toZ3Expr(Index), toZ3Expr(Element)));
 }
 
@@ -664,28 +659,27 @@ SMTExprRef Z3Solver::mkTupleImpl(const std::vector<SMTExprRef> &Elements) {
     ElementSorts.push_back(Element->Sort);
   SMTSortRef TupleSort = mkTupleSort(ElementSorts);
 
-  z3::func_decl Ctor(*Context,
+  z3::func_decl Ctor(Context,
                      Z3_get_tuple_sort_mk_decl(
-                         *Context, toSolverSort<Z3Sort>(*TupleSort).Sort));
+                         Context, toSolverSort<Z3Sort>(*TupleSort).Sort));
   std::vector<Z3_ast> Args;
   Args.reserve(Elements.size());
   for (const auto &Element : Elements)
     Args.push_back(toZ3Expr(Element));
   return makeExprRef<Z3Expr>(
-      SMTExprKind::TupleConst, Context, TupleSort,
-      z3::to_expr(*Context,
-                  Z3_mk_app(*Context, Ctor, Args.size(), Args.data())));
+      SMTExprKind::TupleConst, &Context, TupleSort,
+      z3::to_expr(Context, Z3_mk_app(Context, Ctor, Args.size(), Args.data())));
 }
 
 SMTExprRef Z3Solver::mkTupleSelectImpl(const SMTExprRef &Tuple,
                                        unsigned Index) {
   Z3_func_decl FieldDecl = Z3_get_tuple_sort_field_decl(
-      *Context, toSolverSort<Z3Sort>(*Tuple->Sort).Sort, Index);
+      Context, toSolverSort<Z3Sort>(*Tuple->Sort).Sort, Index);
   Z3_ast Arg = toZ3Ast(Tuple);
   return makeExprRef<Z3Expr>(
-      SMTExprKind::TupleSelect, Context,
+      SMTExprKind::TupleSelect, &Context,
       Tuple->Sort->getTupleElementSorts()[Index],
-      z3::to_expr(*Context, Z3_mk_app(*Context, FieldDecl, 1, &Arg)));
+      z3::to_expr(Context, Z3_mk_app(Context, FieldDecl, 1, &Arg)));
 }
 
 SMTExprRef Z3Solver::mkApplyImpl(const SMTExprRef &Function,
@@ -695,104 +689,104 @@ SMTExprRef Z3Solver::mkApplyImpl(const SMTExprRef &Function,
   for (const auto &Arg : Args)
     AppArgs.push_back(toZ3Expr(Arg));
   return makeExprRef<Z3Expr>(
-      SMTExprKind::Apply, Context, Function->Sort->getCodomainSort(),
-      z3::to_expr(*Context, Z3_mk_app(*Context, toZ3FuncDecl(Function),
-                                      AppArgs.size(), AppArgs.data())));
+      SMTExprKind::Apply, &Context, Function->Sort->getCodomainSort(),
+      z3::to_expr(Context, Z3_mk_app(Context, toZ3FuncDecl(Function),
+                                     AppArgs.size(), AppArgs.data())));
 }
 
 SMTExprRef Z3Solver::mkFPMulImpl(const SMTExprRef &LHS, const SMTExprRef &RHS,
                                  const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPMul, Context, LHS->Sort,
-      z3::to_expr(*Context, Z3_mk_fpa_mul(*Context, toZ3Expr(R), toZ3Expr(LHS),
-                                          toZ3Expr(RHS))));
+      SMTExprKind::FPMul, &Context, LHS->Sort,
+      z3::to_expr(Context, Z3_mk_fpa_mul(Context, toZ3Expr(R), toZ3Expr(LHS),
+                                         toZ3Expr(RHS))));
 }
 
 SMTExprRef Z3Solver::mkFPDivImpl(const SMTExprRef &LHS, const SMTExprRef &RHS,
                                  const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPDiv, Context, LHS->Sort,
-      z3::to_expr(*Context, Z3_mk_fpa_div(*Context, toZ3Expr(R), toZ3Expr(LHS),
-                                          toZ3Expr(RHS))));
+      SMTExprKind::FPDiv, &Context, LHS->Sort,
+      z3::to_expr(Context, Z3_mk_fpa_div(Context, toZ3Expr(R), toZ3Expr(LHS),
+                                         toZ3Expr(RHS))));
 }
 
 SMTExprRef Z3Solver::mkFPAddImpl(const SMTExprRef &LHS, const SMTExprRef &RHS,
                                  const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPAdd, Context, LHS->Sort,
-      z3::to_expr(*Context, Z3_mk_fpa_add(*Context, toZ3Expr(R), toZ3Expr(LHS),
-                                          toZ3Expr(RHS))));
+      SMTExprKind::FPAdd, &Context, LHS->Sort,
+      z3::to_expr(Context, Z3_mk_fpa_add(Context, toZ3Expr(R), toZ3Expr(LHS),
+                                         toZ3Expr(RHS))));
 }
 
 SMTExprRef Z3Solver::mkFPSubImpl(const SMTExprRef &LHS, const SMTExprRef &RHS,
                                  const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPSub, Context, LHS->Sort,
-      z3::to_expr(*Context, Z3_mk_fpa_sub(*Context, toZ3Expr(R), toZ3Expr(LHS),
-                                          toZ3Expr(RHS))));
+      SMTExprKind::FPSub, &Context, LHS->Sort,
+      z3::to_expr(Context, Z3_mk_fpa_sub(Context, toZ3Expr(R), toZ3Expr(LHS),
+                                         toZ3Expr(RHS))));
 }
 
 SMTExprRef Z3Solver::mkFPSqrtImpl(const SMTExprRef &Exp, const SMTExprRef &R) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPSqrt, Context, Exp->Sort,
+  return makeExprRef<Z3Expr>(SMTExprKind::FPSqrt, &Context, Exp->Sort,
                              z3::sqrt(toZ3Expr(Exp), toZ3Expr(R)));
 }
 
 SMTExprRef Z3Solver::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
                                  const SMTExprRef &Z, const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPFMA, Context, X->Sort,
+      SMTExprKind::FPFMA, &Context, X->Sort,
       z3::fma(toZ3Expr(X), toZ3Expr(Y), toZ3Expr(Z), toZ3Expr(R)));
 }
 
 SMTExprRef Z3Solver::mkFPtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                   const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPtoFP, Context, To,
-      z3::to_expr(*Context,
-                  Z3_mk_fpa_to_fp_float(*Context, toZ3Expr(R), toZ3Expr(From),
+      SMTExprKind::FPtoFP, &Context, To,
+      z3::to_expr(Context,
+                  Z3_mk_fpa_to_fp_float(Context, toZ3Expr(R), toZ3Expr(From),
                                         toSolverSort<Z3Sort>(*To).Sort)));
 }
 
 SMTExprRef Z3Solver::mkSBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                    const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::SBVtoFP, Context, To,
-      z3::to_expr(*Context,
-                  Z3_mk_fpa_to_fp_signed(*Context, toZ3Expr(R), toZ3Expr(From),
+      SMTExprKind::SBVtoFP, &Context, To,
+      z3::to_expr(Context,
+                  Z3_mk_fpa_to_fp_signed(Context, toZ3Expr(R), toZ3Expr(From),
                                          toSolverSort<Z3Sort>(*To).Sort)));
 }
 
 SMTExprRef Z3Solver::mkUBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                    const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::UBVtoFP, Context, To,
-      z3::to_expr(*Context, Z3_mk_fpa_to_fp_unsigned(
-                                *Context, toZ3Expr(R), toZ3Expr(From),
-                                toSolverSort<Z3Sort>(*To).Sort)));
+      SMTExprKind::UBVtoFP, &Context, To,
+      z3::to_expr(Context,
+                  Z3_mk_fpa_to_fp_unsigned(Context, toZ3Expr(R), toZ3Expr(From),
+                                           toSolverSort<Z3Sort>(*To).Sort)));
 }
 
 SMTExprRef Z3Solver::mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) {
   const SMTExprRef &roundingMode = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPtoSBV, Context, mkBVSort(ToWidth),
-      z3::to_expr(*Context, Z3_mk_fpa_to_sbv(*Context, toZ3Expr(roundingMode),
-                                             toZ3Expr(From), ToWidth)));
+      SMTExprKind::FPtoSBV, &Context, mkBVSort(ToWidth),
+      z3::to_expr(Context, Z3_mk_fpa_to_sbv(Context, toZ3Expr(roundingMode),
+                                            toZ3Expr(From), ToWidth)));
 }
 
 SMTExprRef Z3Solver::mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) {
   const SMTExprRef &roundingMode = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPtoUBV, Context, mkBVSort(ToWidth),
-      z3::to_expr(*Context, Z3_mk_fpa_to_ubv(*Context, toZ3Expr(roundingMode),
-                                             toZ3Expr(From), ToWidth)));
+      SMTExprKind::FPtoUBV, &Context, mkBVSort(ToWidth),
+      z3::to_expr(Context, Z3_mk_fpa_to_ubv(Context, toZ3Expr(roundingMode),
+                                            toZ3Expr(From), ToWidth)));
 }
 
 SMTExprRef Z3Solver::mkFPtoIntegralImpl(const SMTExprRef &From,
                                         const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPtoIntegral, Context, From->Sort,
-      z3::to_expr(*Context, Z3_mk_fpa_round_to_integral(*Context, toZ3Expr(R),
-                                                        toZ3Expr(From))));
+      SMTExprKind::FPtoIntegral, &Context, From->Sort,
+      z3::to_expr(Context, Z3_mk_fpa_round_to_integral(Context, toZ3Expr(R),
+                                                       toZ3Expr(From))));
 }
 
 SMTResult<bool> Z3Solver::getBoolImpl(const SMTExprRef &Exp) {
@@ -888,44 +882,44 @@ SMTResult<std::string> Z3Solver::getFPInBinImpl(const SMTExprRef &Exp) {
 SMTExprRef Z3Solver::getArrayElementImpl(const SMTExprRef &Array,
                                          const SMTExprRef &Index) {
   const SMTExprRef &sel = mkArraySelect(Array, Index);
-  return makeExprRef<Z3Expr>(sel->getKind(), Context, sel->Sort,
+  return makeExprRef<Z3Expr>(sel->getKind(), &Context, sel->Sort,
                              Solver.get_model().eval(toZ3Expr(sel), true));
 }
 
 SMTExprRef Z3Solver::mkBoolImpl(const bool b) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BoolConst, Context, mkBoolSort(),
-                             Context->bool_val(b));
+  return makeExprRef<Z3Expr>(SMTExprKind::BoolConst, &Context, mkBoolSort(),
+                             Context.bool_val(b));
 }
 
 SMTExprRef Z3Solver::mkIntImpl(int64_t v) {
-  return makeExprRef<Z3Expr>(SMTExprKind::IntConst, Context, mkIntSort(),
-                             Context->int_val(v));
+  return makeExprRef<Z3Expr>(SMTExprKind::IntConst, &Context, mkIntSort(),
+                             Context.int_val(v));
 }
 
 SMTExprRef Z3Solver::mkIntImpl(const std::string &v) {
-  return makeExprRef<Z3Expr>(SMTExprKind::IntConst, Context, mkIntSort(),
-                             Context->int_val(v.c_str()));
+  return makeExprRef<Z3Expr>(SMTExprKind::IntConst, &Context, mkIntSort(),
+                             Context.int_val(v.c_str()));
 }
 
 SMTExprRef Z3Solver::mkRealImpl(const std::string &v) {
-  return makeExprRef<Z3Expr>(SMTExprKind::RealConst, Context, mkRealSort(),
-                             Context->real_val(v.c_str()));
+  return makeExprRef<Z3Expr>(SMTExprKind::RealConst, &Context, mkRealSort(),
+                             Context.real_val(v.c_str()));
 }
 
 SMTExprRef Z3Solver::mkRealImpl(int64_t v) {
-  return makeExprRef<Z3Expr>(SMTExprKind::RealConst, Context, mkRealSort(),
-                             Context->real_val(v));
+  return makeExprRef<Z3Expr>(SMTExprKind::RealConst, &Context, mkRealSort(),
+                             Context.real_val(v));
 }
 
 SMTExprRef Z3Solver::mkRealImpl(int64_t num, int64_t den) {
-  return makeExprRef<Z3Expr>(SMTExprKind::RealConst, Context, mkRealSort(),
-                             Context->real_val(num, den));
+  return makeExprRef<Z3Expr>(SMTExprKind::RealConst, &Context, mkRealSort(),
+                             Context.real_val(num, den));
 }
 
 SMTExprRef Z3Solver::mkBVFromDecImpl(const int64_t Int,
                                      const SMTSortRef &Sort) {
-  return makeExprRef<Z3Expr>(SMTExprKind::BVConst, Context, Sort,
-                             Context->bv_val(Int, Sort->getWidth()));
+  return makeExprRef<Z3Expr>(SMTExprKind::BVConst, &Context, Sort,
+                             Context.bv_val(Int, Sort->getWidth()));
 }
 
 SMTExprRef Z3Solver::mkBVFromBinImpl(const std::string &Int,
@@ -935,8 +929,8 @@ SMTExprRef Z3Solver::mkBVFromBinImpl(const std::string &Int,
   for (unsigned int i = 0; i < s; ++i)
     newInt[s - i - 1] = (Int[i] == '1');
 
-  const SMTExprRef &bv = makeExprRef<Z3Expr>(SMTExprKind::BVConst, Context,
-                                             Sort, Context->bv_val(s, newInt));
+  const SMTExprRef &bv = makeExprRef<Z3Expr>(SMTExprKind::BVConst, &Context,
+                                             Sort, Context.bv_val(s, newInt));
   delete[] newInt;
   return bv;
 }
@@ -944,17 +938,17 @@ SMTExprRef Z3Solver::mkBVFromBinImpl(const std::string &Int,
 SMTExprRef Z3Solver::mkSymbolImpl(const std::string &Name,
                                   const SMTSortRef &Sort) {
   if (Sort->isFunctionSort()) {
-    z3::sort_vector Domain(*Context);
+    z3::sort_vector Domain(Context);
     for (const auto &DomainSort : Sort->getDomainSorts())
       Domain.push_back(toSolverSort<Z3Sort>(*DomainSort).Sort);
     return makeExprRef<Z3Expr>(
-        SMTExprKind::Symbol, Context, Sort,
-        Context->function(Name.c_str(), Domain,
-                          toSolverSort<Z3Sort>(*Sort->getCodomainSort()).Sort));
+        SMTExprKind::Symbol, &Context, Sort,
+        Context.function(Name.c_str(), Domain,
+                         toSolverSort<Z3Sort>(*Sort->getCodomainSort()).Sort));
   }
   return makeExprRef<Z3Expr>(
-      SMTExprKind::Symbol, Context, Sort,
-      Context->constant(Name.c_str(), toSolverSort<Z3Sort>(*Sort).Sort));
+      SMTExprKind::Symbol, &Context, Sort,
+      Context.constant(Name.c_str(), toSolverSort<Z3Sort>(*Sort).Sort));
 }
 
 SMTExprRef Z3Solver::mkFPFromBinImpl(const std::string &FP, unsigned EWidth) {
@@ -963,33 +957,33 @@ SMTExprRef Z3Solver::mkFPFromBinImpl(const std::string &FP, unsigned EWidth) {
   const SMTExprRef &sig = SMTSolverImpl::mkBVFromBin(FP.substr(1 + EWidth));
 
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPConst, Context,
+      SMTExprKind::FPConst, &Context,
       mkFPSort(EWidth, FP.length() - EWidth - 1, FPEncoding::Native),
       z3::fpa_fp(toZ3Expr(sgn), toZ3Expr(exp), toZ3Expr(sig)));
 }
 
 SMTExprRef Z3Solver::mkRMImpl(const RM &R) {
-  z3::expr e(*Context);
+  z3::expr e(Context);
   switch (R) {
   default:
     fatalError("Unsupported floating-point semantics.");
   case RM::ROUND_TO_EVEN:
-    e = z3::to_expr(*Context, Z3_mk_fpa_rne(*Context));
+    e = z3::to_expr(Context, Z3_mk_fpa_rne(Context));
     break;
   case RM::ROUND_TO_AWAY:
-    e = z3::to_expr(*Context, Z3_mk_fpa_rna(*Context));
+    e = z3::to_expr(Context, Z3_mk_fpa_rna(Context));
     break;
   case RM::ROUND_TO_PLUS_INF:
-    e = z3::to_expr(*Context, Z3_mk_fpa_rtp(*Context));
+    e = z3::to_expr(Context, Z3_mk_fpa_rtp(Context));
     break;
   case RM::ROUND_TO_MINUS_INF:
-    e = z3::to_expr(*Context, Z3_mk_fpa_rtn(*Context));
+    e = z3::to_expr(Context, Z3_mk_fpa_rtn(Context));
     break;
   case RM::ROUND_TO_ZERO:
-    e = z3::to_expr(*Context, Z3_mk_fpa_rtz(*Context));
+    e = z3::to_expr(Context, Z3_mk_fpa_rtz(Context));
     break;
   }
-  return makeExprRef<Z3Expr>(SMTExprKind::RMConst, Context,
+  return makeExprRef<Z3Expr>(SMTExprKind::RMConst, &Context,
                              mkRMSort(FPEncoding::Native), e);
 }
 
@@ -997,8 +991,8 @@ SMTExprRef Z3Solver::mkNaNImpl(const bool Sgn, const unsigned ExpWidth,
                                const unsigned SigWidth) {
   const SMTSortRef &sort = mkFPSort(ExpWidth, SigWidth - 1, FPEncoding::Native);
   const SMTExprRef &theNaN =
-      makeExprRef<Z3Expr>(SMTExprKind::FPConst, Context, sort,
-                          Context->fpa_nan(toSolverSort<Z3Sort>(*sort).Sort));
+      makeExprRef<Z3Expr>(SMTExprKind::FPConst, &Context, sort,
+                          Context.fpa_nan(toSolverSort<Z3Sort>(*sort).Sort));
 
   return Sgn ? mkFPNeg(theNaN) : theNaN;
 }
@@ -1007,14 +1001,14 @@ SMTExprRef Z3Solver::mkInfImpl(const bool Sgn, const unsigned ExpWidth,
                                const unsigned SigWidth) {
   const SMTSortRef &sort = mkFPSort(ExpWidth, SigWidth - 1, FPEncoding::Native);
   return makeExprRef<Z3Expr>(
-      SMTExprKind::FPConst, Context, sort,
-      Context->fpa_inf(toSolverSort<Z3Sort>(*sort).Sort, Sgn));
+      SMTExprKind::FPConst, &Context, sort,
+      Context.fpa_inf(toSolverSort<Z3Sort>(*sort).Sort, Sgn));
 }
 
 SMTExprRef Z3Solver::mkBVToIEEEFPImpl(const SMTExprRef &Exp,
                                       const SMTSortRef &To) {
   return makeExprRef<Z3Expr>(
-      SMTExprKind::BVToIEEEFP, Context, To,
+      SMTExprKind::BVToIEEEFP, &Context, To,
       toZ3Expr(Exp).mk_from_ieee_bv(toSolverSort<Z3Sort>(*To).Sort));
 }
 
@@ -1022,7 +1016,7 @@ SMTExprRef Z3Solver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
   const SMTSortRef &to =
       mkFPSort(Exp->Sort->getFPExponentWidth(),
                Exp->Sort->getFPSignificandWidth(), FPEncoding::BV);
-  return makeExprRef<Z3Expr>(SMTExprKind::IEEEFPToBV, Context, to,
+  return makeExprRef<Z3Expr>(SMTExprKind::IEEEFPToBV, &Context, to,
                              toZ3Expr(Exp).mk_to_ieee_bv());
 }
 
@@ -1030,26 +1024,26 @@ SMTExprRef Z3Solver::mkArrayConstImpl(const SMTSortRef &IndexSort,
                                       const SMTExprRef &InitValue) {
   const SMTSortRef &sort = mkArraySort(IndexSort, InitValue->Sort);
   return makeExprRef<Z3Expr>(
-      SMTExprKind::ArrayConst, Context, sort,
+      SMTExprKind::ArrayConst, &Context, sort,
       z3::const_array(toSolverSort<Z3Sort>(*IndexSort).Sort,
                       toZ3Expr(InitValue)));
 }
 
 SMTExprRef Z3Solver::mkForallImpl(const std::vector<SMTExprRef> &Vars,
                                   const SMTExprRef &Body) {
-  z3::expr_vector bound_vars(*Context);
+  z3::expr_vector bound_vars(Context);
   for (auto const &Var : Vars)
     bound_vars.push_back(toZ3Expr(Var));
-  return makeExprRef<Z3Expr>(SMTExprKind::Forall, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::Forall, &Context, mkBoolSort(),
                              z3::forall(bound_vars, toZ3Expr(Body)));
 }
 
 SMTExprRef Z3Solver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
                                   const SMTExprRef &Body) {
-  z3::expr_vector bound_vars(*Context);
+  z3::expr_vector bound_vars(Context);
   for (auto const &Var : Vars)
     bound_vars.push_back(toZ3Expr(Var));
-  return makeExprRef<Z3Expr>(SMTExprKind::Exists, Context, mkBoolSort(),
+  return makeExprRef<Z3Expr>(SMTExprKind::Exists, &Context, mkBoolSort(),
                              z3::exists(bound_vars, toZ3Expr(Body)));
 }
 

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -891,7 +891,7 @@ SMTResult<ArrayModel> Z3Solver::getArrayValuesImpl(const SMTExprRef &Array) {
   const SMTSortRef &IndexSort = Array->Sort->getIndexSort();
   const SMTSortRef &ElemSort = Array->Sort->getElementSort();
   const auto wrap = [&](const z3::expr &Value, const SMTSortRef &Sort) {
-    return makeExprRef<Z3Expr>(valueKindForSort(Sort), Context, Sort, Value);
+    return makeExprRef<Z3Expr>(valueKindForSort(Sort), &Context, Sort, Value);
   };
 
   z3::model Model = Solver.get_model();
@@ -909,7 +909,7 @@ SMTResult<ArrayModel> Z3Solver::getArrayValuesImpl(const SMTExprRef &Array) {
   if (Val.is_app() && Val.decl().decl_kind() == Z3_OP_AS_ARRAY) {
     // The model chose a function-graph representation: read the entries
     // and the else-branch off the function interpretation.
-    z3::func_decl Decl(*Context, Z3_get_as_array_func_decl(*Context, Val));
+    z3::func_decl Decl(Context, Z3_get_as_array_func_decl(Context, Val));
     z3::func_interp Interp = Model.get_func_interp(Decl);
     for (unsigned I = 0; I < Interp.num_entries(); ++I) {
       z3::func_entry Entry = Interp.entry(I);
@@ -1125,7 +1125,7 @@ bool Z3Solver::setTimeoutImpl(uint64_t Milliseconds) {
   constexpr uint64_t NoLimit = std::numeric_limits<unsigned>::max();
   const uint64_t Value =
       Milliseconds == 0 ? NoLimit : std::min(Milliseconds, NoLimit);
-  z3::params params(*Context);
+  z3::params params(Context);
   params.set("timeout", static_cast<unsigned>(Value));
   Solver.set(params);
   return true;
@@ -1138,11 +1138,11 @@ Z3Solver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
   // smt solver tracks them regardless, so setting the parameter here is a
   // harmless no-op for it. Set per call because setSolver can swap the
   // solver instance at any time.
-  z3::params params(*Context);
+  z3::params params(Context);
   params.set("unsat_core", true);
   Solver.set(params);
 
-  z3::expr_vector assumptions(*Context);
+  z3::expr_vector assumptions(Context);
   for (const SMTExprRef &Assumption : Assumptions)
     assumptions.push_back(toZ3Expr(Assumption));
 

--- a/src/z3solver.h
+++ b/src/z3solver.h
@@ -23,7 +23,6 @@
 #define Z3SOLVER_H_
 
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <utility>
 #include <z3++.h>
@@ -69,13 +68,13 @@ public:
 class Z3Solver : public SMTSolverImpl {
 public:
   Z3Solver();
-  explicit Z3Solver(std::unique_ptr<z3::context> C);
-  explicit Z3Solver(std::unique_ptr<z3::context> C, z3::solver S);
+  explicit Z3Solver(z3::context C);
+  explicit Z3Solver(z3::context C, z3::solver S);
   ~Z3Solver() override;
 
 protected:
-  z3::context &context() { return *Context; }
-  const z3::context &context() const { return *Context; }
+  z3::context &context() { return Context; }
+  const z3::context &context() const { return Context; }
   z3::solver &solver() { return Solver; }
   const z3::solver &solver() const { return Solver; }
   void setSolver(z3::solver S) { Solver = std::move(S); }
@@ -377,12 +376,7 @@ protected:
   void dumpModelImpl(std::string &Out) override;
 
 private:
-  // Z3 < 4.16 makes z3::context non-copyable and non-movable, so a
-  // caller-provided context cannot be passed by value. Own it through a
-  // unique_ptr and hold a raw pointer (Z3ContextRef) that the sort/expr
-  // handles and mk*Sort impls reference.
-  std::unique_ptr<z3::context> OwnedContext;
-  Z3ContextRef Context = nullptr;
+  z3::context Context;
   z3::solver Solver;
   unsigned TupleCounter = 0;
 }; // end class Z3Solver


### PR DESCRIPTION
Brings the Z3 dependency back to 4.16.0, reverting the Z3 portion of b8b099d (the 4.15.4 downgrade) while keeping that commit's Bitwuzla 0.9.1 and CVC5 1.3.4 bumps.

- Re-pins all per-platform prebuilt URLs and the `config_solver` minimum to 4.16.0.
- Restores the pre-downgrade ownership model: `z3::context` held by value again (4.16 made it movable), the by-value custom-context constructors return, and the `OwnedContext` unique_ptr indirection is gone. The `myZ3Solver` regression test takes `z3::context` by value again.
- Adapts the two features that landed after the downgrade and were written against the pointer-style member — the overflow predicate API (#73) and the model-extraction hardening (#68) — to the by-value convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
