### PR TITLE
Recover the Yices context after interrupted (timed-out) checks

### DIFF
--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -115,9 +115,20 @@ inline void solver_timeout_semantics(const camada::SMTSolverRef &solver) {
   auto t = solver->mkSymbol("t", solver->mkBoolSort());
   REQUIRE(solver->checkSatAssuming({t}) == camada::checkResult::UNKNOWN);
 
-  // Clearing the limit restores normal solving.
-  solver->reset();
+  // Clearing the limit must work from the just-timed-out state.
   REQUIRE(solver->setTimeout(0));
+
+  // A timed-out check must leave the solver fully usable WITHOUT a reset:
+  // new constraints must take effect and incremental scopes must work. A
+  // backend whose interrupted context goes stale would drop the assert
+  // and answer instantly from the poisoned state instead of UNSAT.
+  solver->push();
+  solver->addConstraint(solver->mkBool(false));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  solver->pop();
+
+  // Normal solving works again after the limit is cleared.
+  solver->reset();
   auto y = solver->mkSymbol("y", solver->mkBVSort(8));
   solver->addConstraint(solver->mkEqual(y, solver->mkBVFromDec(9, 8)));
   REQUIRE(solver->check() == camada::checkResult::SAT);

--- a/src/yicessolver.cpp
+++ b/src/yicessolver.cpp
@@ -200,6 +200,15 @@ void YicesSolver::recreateContextWithConfig(const char *Logic,
   yices_default_config_for_logic(config, Logic);
   if (Configure)
     Configure(config);
+  // The context mode is owned by Camada, deliberately after the Configure
+  // callback: push()/pop() need at least push-pop mode, and "interactive"
+  // additionally restores the context automatically when a search is
+  // interrupted (yices_stop_search) — how setTimeout() is enforced here.
+  // Any weaker mode leaves an interrupted context in
+  // YICES_STATUS_INTERRUPTED permanently: later checks return STATUS_ERROR
+  // (mapped to instant UNKNOWN), asserts fail, and push aborts.
+  yicesCheckError(yices_set_config(config, "mode", "interactive"),
+                  "Could not configure Yices interactive mode");
 
   Context = yicesCheckContext(yices_new_context(config),
                               "Could not create Yices context");
@@ -208,7 +217,10 @@ void YicesSolver::recreateContextWithConfig(const char *Logic,
 
 void YicesSolver::addConstraintImpl(const SMTExprRef &Exp) {
   Assertions.push_back(Exp);
-  yices_assert_formula(Context, toSolverExpr<YicesExpr>(*Exp).Expr);
+  // Checked so a bad context state can never silently drop a constraint.
+  yicesCheckError(
+      yices_assert_formula(Context, toSolverExpr<YicesExpr>(*Exp).Expr),
+      "Could not assert formula in Yices context");
 }
 
 SMTExprRef YicesSolver::rewrapExprImpl(const SMTExpr &Exp,


### PR DESCRIPTION
Release blocker found in the pre-release sweep: on Yices, a check that hit the `setTimeout` limit left the context in `YICES_STATUS_INTERRUPTED` forever. Every later check returned instant UNKNOWN without solving, `addConstraint` silently dropped constraints (unchecked return), and `push()` aborted the process. The regression suite missed it because the timeout test reset the solver right after the timed-out check.

- Configure the Yices context in `interactive` mode — push-pop plus automatic context cleanup when a search is interrupted, which is exactly how `setTimeout` is enforced (SIGALRM + `yices_stop_search`). The mode is set after the `Configure` callback and is deliberately not overridable: camada's `push()`/`pop()` and timeouts all require it (the Override-Yices regression, which sets `mode=push-pop` in its callback, reproduced the poisoning end to end).
- Check the `yices_assert_formula` return so a bad context state can never silently drop a constraint again.
- Harden `solver_timeout_semantics`: after the timed-out checks, clear the limit and verify push/assert/check/pop works **without** a reset — a stale context fails this on any backend.

Full suite: 163/163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)