### PR TITLE
Remove the unusable Z3Solver(context, solver) constructor

### DIFF
--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -114,13 +114,6 @@ Z3Solver::Z3Solver(z3::context C) : Context(std::move(C)), Solver(Context) {
   initializeCommonSingletons();
 }
 
-Z3Solver::Z3Solver(z3::context C, z3::solver S)
-    : Context(std::move(C)), Solver(std::move(S)) {
-  // Needs to be set in order to convert NaN to bitvector
-  z3::set_param("rewriter.hi_fp_unspecified", true);
-  initializeCommonSingletons();
-}
-
 // Context (z3::context) and Solver (z3::solver) are RAII value members; their
 // destructors release the underlying Z3 resources after this body returns, so
 // only invalidateGeneratedObjects() is needed here to honor the SMTSolverImpl

--- a/src/z3solver.h
+++ b/src/z3solver.h
@@ -69,7 +69,12 @@ class Z3Solver : public SMTSolverImpl {
 public:
   Z3Solver();
   explicit Z3Solver(z3::context C);
-  explicit Z3Solver(z3::context C, z3::solver S);
+  // There is deliberately no (context, solver) constructor: z3::solver
+  // holds a pointer to the context *object* it was built against, and
+  // z3::context is move-only, so any solver a caller could pass would
+  // reference the moved-from (nulled) context and crash on the first
+  // refcount operation. Subclass and call setSolver() against context()
+  // to install a custom solver (see the Override Z3 regression).
   ~Z3Solver() override;
 
 protected:


### PR DESCRIPTION
Pre-release sweep finding, verified with a repro: every possible call to `Z3Solver(z3::context, z3::solver)` segfaults. `z3::context` is move-only in 4.16, so the caller must move their context into the parameter — but `z3::solver` has no move constructor, and its copy constructor calls `Z3_solver_inc_ref` through the pointer it still holds to the caller's now-nulled context object. The crash happens in the member-init list, before the body could repair anything.

Nothing in or out of tree can have working calls, so remove it before the release freezes it. The custom-solver use case is served by subclassing and `setSolver()` against `context()` — exactly what the Override Z3 regression exercises (tactic-built solver). A comment in the header documents why the constructor is deliberately absent.

Full suite: 163/163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)