### PR TITLE
Answer SMT-LIB supports(UnsatAssumptions) from the runtime probe

### DIFF
--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -363,7 +363,10 @@ TEST_CASE("SMTLIB feature capabilities", "[SMTLIB]") {
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
   REQUIRE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
-  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  // UnsatAssumptions reflects the runtime probe: in write-only mode there
+  // is no child to answer :produce-unsat-assumptions, so it is false here
+  // and true against children that accept the option.
+  REQUIRE_FALSE(solver->supports(SolverFeature::UnsatAssumptions));
   REQUIRE_FALSE(solver->supports(SolverFeature::Timeouts));
   REQUIRE_FALSE(solver->supports(SolverFeature::ArrayModels));
 

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -2175,8 +2175,13 @@ bool SMTLIBSolver::supportsImpl(SolverFeature Feature) const {
   case SolverFeature::Quantifiers:
   case SolverFeature::UninterpretedFunctions:
   case SolverFeature::NativeFloatingPoint:
-  case SolverFeature::UnsatAssumptions:
     return true;
+  // Unlike the wire-capability bits above, this one IS known: the
+  // preamble already learned whether the child accepted
+  // :produce-unsat-assumptions (false in write-only mode, where there is
+  // no model to query either).
+  case SolverFeature::UnsatAssumptions:
+    return UnsatAssumptionsSupported;
   case SolverFeature::Timeouts:
   case SolverFeature::ArrayModels:
     return false;
@@ -2187,27 +2192,28 @@ bool SMTLIBSolver::supportsImpl(SolverFeature Feature) const {
   return false;
 }
 
-checkResult SMTLIBSolver::checkImpl() {
-  // (check-sat) is a query — it does NOT produce a `success` ack even when
-  // :print-success is true. Bypass emitLine's resync logic; write the
-  // command directly and read the sat/unsat/unknown line ourselves.
-  const std::string Cmd = "(check-sat)\n";
+checkResult SMTLIBSolver::emitCheckCommand(const std::string &Cmd) {
+  // Check commands are queries — they do NOT produce a `success` ack even
+  // when :print-success is true. Bypass emitLine's resync logic; write the
+  // command directly and read the sat/unsat/unknown line ourselves. In
+  // write-only mode there is no response to read.
   if (File)
     File->emitRaw(Cmd);
   if (Proc) {
     Proc->emitRaw(Cmd);
     Proc->flush();
-    std::string Resp = Proc->readResponse();
-    if (Resp == "sat")
-      return checkResult::SAT;
-    if (Resp == "unsat")
-      return checkResult::UNSAT;
-    return checkResult::UNKNOWN;
+    const std::string Resp = Proc->readResponse();
+    return Resp == "sat"     ? checkResult::SAT
+           : Resp == "unsat" ? checkResult::UNSAT
+                             : checkResult::UNKNOWN;
   }
-  // Write-only mode: no response to read.
   if (File)
     File->flush();
   return checkResult::UNKNOWN;
+}
+
+checkResult SMTLIBSolver::checkImpl() {
+  return emitCheckCommand("(check-sat)\n");
 }
 
 checkResult
@@ -2231,24 +2237,7 @@ SMTLIBSolver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
     LastAssumptionLits.emplace_back(std::move(Lit), Assumption);
   }
   Cmd.append("))\n");
-
-  // Like (check-sat), this is a query — no `success` ack, so bypass
-  // emitLine and read the verdict directly.
-  if (File)
-    File->emitRaw(Cmd);
-  if (Proc) {
-    Proc->emitRaw(Cmd);
-    Proc->flush();
-    std::string Resp = Proc->readResponse();
-    if (Resp == "sat")
-      return checkResult::SAT;
-    if (Resp == "unsat")
-      return checkResult::UNSAT;
-    return checkResult::UNKNOWN;
-  }
-  if (File)
-    File->flush();
-  return checkResult::UNKNOWN;
+  return emitCheckCommand(Cmd);
 }
 
 SMTResult<std::vector<SMTExprRef>> SMTLIBSolver::getUnsatAssumptionsImpl() {

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -412,6 +412,10 @@ private:
   // Emit a single line (newline appended) to the active emitter(s).
   void emitLine(const std::string &Text) const;
 
+  // Emit a check command (a query: no `success` ack) and read the
+  // sat/unsat/unknown verdict; UNKNOWN in write-only mode.
+  checkResult emitCheckCommand(const std::string &Cmd);
+
   // Send (get-value (Exp)) to the child solver and extract the value text
   // from its response. Fails in write-only mode (no child process). Resp
   // receives the raw response for use in error messages.


### PR DESCRIPTION
Two pre-release sweep items, both in the SMT-LIB backend:

- **supports(UnsatAssumptions) now reflects reality.** The preamble already negotiates `:produce-unsat-assumptions` with the child and stores the answer, but `supportsImpl` reported a static `true` — so `if (supports(...)) getUnsatAssumptions()` over e.g. a yices-smt2 child got an error, which is exactly what `supports()` exists to avoid. The bit now answers from the probe (false in write-only mode, where there is no model to query either). The wire-capability framing in the comment stays for the bits that genuinely can't be probed.
- **Deduplicate the check-command protocol block**: `checkImpl` and `checkSatAssumingImpl` ended with a verbatim 16-line emit/flush/read/verdict sequence; it's now one `emitCheckCommand` helper, with the query-has-no-ack rationale documented once.

Full suite: 163/163 (write-only capability expectation updated for the probe semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)