### PR TITLE
Polish public API docs before the 0.11 release

### DIFF
--- a/src/bitwuzlasolver.h
+++ b/src/bitwuzlasolver.h
@@ -263,7 +263,7 @@ private:
   // Per-check wall-clock deadline enforced through bitwuzla's termination
   // callback (registered in initializeContext, which passes this member's
   // address as the callback state). The epoch value means "no deadline";
-  // checkImpl arms it from TimeoutMs before each query.
+  // the check paths arm it from TimeoutMs before each query.
   std::chrono::steady_clock::time_point CheckDeadline{};
 };
 

--- a/src/camada.h
+++ b/src/camada.h
@@ -167,6 +167,10 @@ enum class SMTErrorCode {
   BackendError,
   InvalidModelValue,
   UnsupportedOperation,
+  /// The call sequence violated an API contract (e.g. querying unsat
+  /// assumptions after the solver state changed), as opposed to a
+  /// backend-originated failure.
+  InvalidUsage,
 };
 
 /// Structured error payload carried by `SMTResult<T>` on failure.
@@ -533,7 +537,7 @@ public:
   /// Creates a floating-point isNaN operation
   virtual SMTExprRef mkFPIsNaN(const SMTExprRef &Exp) = 0;
 
-  /// Creates a floating-point isNormal operation
+  /// Creates a floating-point isSubnormal operation
   virtual SMTExprRef mkFPIsDenormal(const SMTExprRef &Exp) = 0;
 
   /// Creates a floating-point isNormal operation
@@ -809,18 +813,19 @@ public:
   virtual checkResult check() = 0;
 
   /// Set a wall-clock time limit, in milliseconds, applied to each
-  /// subsequent check() or checkSatAssuming() individually; 0 removes
-  /// the limit. A check that
-  /// hits the limit returns checkResult::UNKNOWN; reset() afterwards
-  /// restores the solver to a known-good state. The limit persists across
-  /// reset(). Returns false when the backend cannot enforce time limits
-  /// (STP; the SMT-LIB pipeline, where interrupting the child mid-query
-  /// would desynchronize the pipe protocol) — the limit is then ignored.
+  /// subsequent check() or checkSatAssuming() individually; 0 removes the
+  /// limit. A check that hits the limit returns checkResult::UNKNOWN and
+  /// leaves the solver usable. The limit persists across reset(). Returns
+  /// false when the backend cannot enforce time limits — the limit is
+  /// then ignored. Equivalently queryable up front as
+  /// supports(SolverFeature::Timeouts).
   virtual bool setTimeout(uint64_t Milliseconds) = 0;
 
   /// Check if the constraints conjoined with the given boolean assumptions
-  /// are satisfiable. The assumptions are only active for this query; they
-  /// are not asserted and do not persist into later checks.
+  /// are satisfiable. The assumptions are only active for this query: they
+  /// have no effect on the satisfiability of later checks. (Backends whose
+  /// native API only accepts literals lower compound assumptions through
+  /// fresh activation literals, which is observable in dump() output.)
   virtual checkResult
   checkSatAssuming(const std::vector<SMTExprRef> &Assumptions) = 0;
 
@@ -828,8 +833,9 @@ public:
   /// unsatisfiability. Only valid right after a checkSatAssuming() call
   /// that returned UNSAT: any solver mutation (addConstraint, push, pop,
   /// reset) or later check invalidates the result, and querying it then is
-  /// an error. Backends without native unsat-assumption support (STP)
-  /// return an UnsupportedOperation error.
+  /// an error. Backends reporting
+  /// supports(SolverFeature::UnsatAssumptions) == false return an
+  /// UnsupportedOperation error.
   virtual SMTResult<std::vector<SMTExprRef>> getUnsatAssumptions() = 0;
 
   /// Reset the solver and remove all constraints.

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -1831,7 +1831,7 @@ checkResult SMTSolverImpl::checkSatAssumingImpl(
 
 SMTResult<std::vector<SMTExprRef>> SMTSolverImpl::getUnsatAssumptions() {
   if (!UnsatAssumptionsValid)
-    return SMTError{SMTErrorCode::BackendError,
+    return SMTError{SMTErrorCode::InvalidUsage,
                     CachedBoolExprs[0]->getBackendKind(),
                     "getUnsatAssumptions is only valid right after a "
                     "checkSatAssuming call that returned UNSAT, before the "

--- a/src/mathsatsolver.h
+++ b/src/mathsatsolver.h
@@ -365,7 +365,7 @@ private:
   // Per-check wall-clock deadline enforced through MathSAT's termination
   // test (registered in initializeContext, which passes this member's
   // address as the callback state). The epoch value means "no deadline";
-  // checkImpl arms it from TimeoutMs before each query.
+  // the check paths arm it from TimeoutMs before each query.
   std::chrono::steady_clock::time_point CheckDeadline{};
 
   // msat_solve_with_assumptions accepts only (negated) Boolean constants,


### PR DESCRIPTION
The pre-release API review's small findings, fixed before the doc comments freeze:

- `mkFPIsDenormal` was documented as "isNormal" (copy-paste from its neighbor).
- `setTimeout` doc: re-flowed the merge-mangled paragraph and replaced the hardcoded backend enumeration (which was already missing Yices-on-Windows) with `supports(SolverFeature::Timeouts)` so the doc can't drift from per-platform behavior.
- `checkSatAssuming` doc no longer claims assumptions "are not asserted" — on MathSAT and the SMT-LIB pipe the activation-literal lowering asserts implications that are observable in `dump()`; the real promise is that later checks are unaffected.
- `getUnsatAssumptions` doc states the error contract via `supports()` instead of naming STP only.
- New `SMTErrorCode::InvalidUsage` (appended, existing enumerator values unchanged) and the stale-query guard in `getUnsatAssumptions` now uses it — API misuse was previously indistinguishable from a genuine `BackendError`.
- Two stale "checkImpl arms it" comments on the `CheckDeadline` members (both check paths arm it since the assumption-solving merge).

Full suite: 163/163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)