### PR TITLE
Split overflow predicates into mkBVS*/mkBVU* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,9 @@ Camada currently provides public APIs for:
   extraction (`getUnsatAssumptions`)
 - per-check wall-clock timeouts (`setTimeout`; checks that hit the limit
   return `UNKNOWN`)
-- bit-vector overflow predicates (`mkBVAddOverflow`, `mkBVSubOverflow`,
-  `mkBVMulOverflow`, `mkBVSDivOverflow`, `mkBVNegOverflow`)
+- bit-vector overflow predicates (`mkBVSAddOverflow`/`mkBVUAddOverflow`,
+  `mkBVSSubOverflow`/`mkBVUSubOverflow`, `mkBVSMulOverflow`/`mkBVUMulOverflow`,
+  `mkBVSDivOverflow`, `mkBVNegOverflow`)
 - model queries for supported value kinds, including sparse array models
   (`getArrayValues`)
 - a queryable capability API (`supports(SolverFeature)`) so callers can

--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -222,21 +222,21 @@ inline void bv_overflow_semantics(const camada::SMTSolverRef &solver) {
       auto [x, y] = symbols();
       auto Exact =
           solver->mkBVAdd(solver->mkBVSignExt(1, x), solver->mkBVSignExt(1, y));
-      requireEquiv("saddo", solver->mkBVAddOverflow(x, y, true),
+      requireEquiv("saddo", solver->mkBVSAddOverflow(x, y),
                    signedOutOfRange(Exact, W + 1));
     }
     {
       auto [x, y] = symbols();
       auto Exact =
           solver->mkBVAdd(solver->mkBVZeroExt(1, x), solver->mkBVZeroExt(1, y));
-      requireEquiv("uaddo", solver->mkBVAddOverflow(x, y, false),
+      requireEquiv("uaddo", solver->mkBVUAddOverflow(x, y),
                    unsignedOutOfRange(Exact, W + 1));
     }
     {
       auto [x, y] = symbols();
       auto Exact =
           solver->mkBVSub(solver->mkBVSignExt(1, x), solver->mkBVSignExt(1, y));
-      requireEquiv("ssubo", solver->mkBVSubOverflow(x, y, true),
+      requireEquiv("ssubo", solver->mkBVSSubOverflow(x, y),
                    signedOutOfRange(Exact, W + 1));
     }
     {
@@ -245,7 +245,7 @@ inline void bv_overflow_semantics(const camada::SMTSolverRef &solver) {
       auto [x, y] = symbols();
       auto Exact =
           solver->mkBVSub(solver->mkBVZeroExt(1, x), solver->mkBVZeroExt(1, y));
-      requireEquiv("usubo", solver->mkBVSubOverflow(x, y, false),
+      requireEquiv("usubo", solver->mkBVUSubOverflow(x, y),
                    solver->mkEqual(solver->mkBVExtract(W, W, Exact),
                                    solver->mkBVFromDec(1, 1)));
     }
@@ -253,14 +253,14 @@ inline void bv_overflow_semantics(const camada::SMTSolverRef &solver) {
       auto [x, y] = symbols();
       auto Exact =
           solver->mkBVMul(solver->mkBVSignExt(W, x), solver->mkBVSignExt(W, y));
-      requireEquiv("smulo", solver->mkBVMulOverflow(x, y, true),
+      requireEquiv("smulo", solver->mkBVSMulOverflow(x, y),
                    signedOutOfRange(Exact, 2 * W));
     }
     {
       auto [x, y] = symbols();
       auto Exact =
           solver->mkBVMul(solver->mkBVZeroExt(W, x), solver->mkBVZeroExt(W, y));
-      requireEquiv("umulo", solver->mkBVMulOverflow(x, y, false),
+      requireEquiv("umulo", solver->mkBVUMulOverflow(x, y),
                    unsignedOutOfRange(Exact, 2 * W));
     }
     {

--- a/src/camada.h
+++ b/src/camada.h
@@ -381,25 +381,40 @@ public:
   virtual SMTExprRef mkBVSge(const SMTExprRef &LHS, const SMTExprRef &RHS) = 0;
 
   /// Creates a boolean predicate that is true iff the infinitely-precise
-  /// sum of LHS and RHS (interpreted as signed or unsigned per IsSigned) is
-  /// not representable at the operands' bit-width. Equivalent to SMT-LIB's
-  /// bvsaddo/bvuaddo.
-  virtual SMTExprRef mkBVAddOverflow(const SMTExprRef &LHS,
-                                     const SMTExprRef &RHS, bool IsSigned) = 0;
+  /// signed sum of LHS and RHS is not representable at the operands'
+  /// bit-width. Equivalent to SMT-LIB's bvsaddo.
+  virtual SMTExprRef mkBVSAddOverflow(const SMTExprRef &LHS,
+                                      const SMTExprRef &RHS) = 0;
 
   /// Creates a boolean predicate that is true iff the infinitely-precise
-  /// difference LHS - RHS (signed or unsigned per IsSigned) is not
-  /// representable at the operands' bit-width. Equivalent to SMT-LIB's
-  /// bvssubo/bvusubo.
-  virtual SMTExprRef mkBVSubOverflow(const SMTExprRef &LHS,
-                                     const SMTExprRef &RHS, bool IsSigned) = 0;
+  /// unsigned sum of LHS and RHS is not representable at the operands'
+  /// bit-width. Equivalent to SMT-LIB's bvuaddo.
+  virtual SMTExprRef mkBVUAddOverflow(const SMTExprRef &LHS,
+                                      const SMTExprRef &RHS) = 0;
 
   /// Creates a boolean predicate that is true iff the infinitely-precise
-  /// product of LHS and RHS (signed or unsigned per IsSigned) is not
-  /// representable at the operands' bit-width. Equivalent to SMT-LIB's
-  /// bvsmulo/bvumulo.
-  virtual SMTExprRef mkBVMulOverflow(const SMTExprRef &LHS,
-                                     const SMTExprRef &RHS, bool IsSigned) = 0;
+  /// signed difference LHS - RHS is not representable at the operands'
+  /// bit-width. Equivalent to SMT-LIB's bvssubo.
+  virtual SMTExprRef mkBVSSubOverflow(const SMTExprRef &LHS,
+                                      const SMTExprRef &RHS) = 0;
+
+  /// Creates a boolean predicate that is true iff the infinitely-precise
+  /// unsigned difference LHS - RHS is not representable at the operands'
+  /// bit-width. Equivalent to SMT-LIB's bvusubo.
+  virtual SMTExprRef mkBVUSubOverflow(const SMTExprRef &LHS,
+                                      const SMTExprRef &RHS) = 0;
+
+  /// Creates a boolean predicate that is true iff the infinitely-precise
+  /// signed product of LHS and RHS is not representable at the operands'
+  /// bit-width. Equivalent to SMT-LIB's bvsmulo.
+  virtual SMTExprRef mkBVSMulOverflow(const SMTExprRef &LHS,
+                                      const SMTExprRef &RHS) = 0;
+
+  /// Creates a boolean predicate that is true iff the infinitely-precise
+  /// unsigned product of LHS and RHS is not representable at the operands'
+  /// bit-width. Equivalent to SMT-LIB's bvumulo.
+  virtual SMTExprRef mkBVUMulOverflow(const SMTExprRef &LHS,
+                                      const SMTExprRef &RHS) = 0;
 
   /// Creates a boolean predicate that is true iff signed division LHS / RHS
   /// overflows, i.e. LHS is the minimal signed value and RHS is -1.

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -596,29 +596,54 @@ CAMADA_DEFINE_SIMPLE_BINARY_WRAPPER(SMTExprRef, mkBVSge,
                                     mkBVSgeImpl(LHS, RHS),
                                     assert(theExp->Sort->isBoolSort()))
 
-SMTExprRef SMTSolverImpl::mkBVAddOverflow(const SMTExprRef &LHS,
-                                          const SMTExprRef &RHS,
-                                          bool IsSigned) {
+// The public surface follows the mkBVS*/mkBVU* naming convention of the
+// other signed/unsigned BV pairs; the protected *Impl hooks keep a single
+// IsSigned-parameterized entry point per operation, since every backend
+// implements both signednesses in one place.
+SMTExprRef SMTSolverImpl::mkBVSAddOverflow(const SMTExprRef &LHS,
+                                           const SMTExprRef &RHS) {
   requireBVSameSort(LHS, RHS);
-  SMTExprRef theExp = mkBVAddOverflowImpl(LHS, RHS, IsSigned);
+  SMTExprRef theExp = mkBVAddOverflowImpl(LHS, RHS, /*IsSigned=*/true);
   assert(theExp->Sort->isBoolSort());
   return theExp;
 }
 
-SMTExprRef SMTSolverImpl::mkBVSubOverflow(const SMTExprRef &LHS,
-                                          const SMTExprRef &RHS,
-                                          bool IsSigned) {
+SMTExprRef SMTSolverImpl::mkBVUAddOverflow(const SMTExprRef &LHS,
+                                           const SMTExprRef &RHS) {
   requireBVSameSort(LHS, RHS);
-  SMTExprRef theExp = mkBVSubOverflowImpl(LHS, RHS, IsSigned);
+  SMTExprRef theExp = mkBVAddOverflowImpl(LHS, RHS, /*IsSigned=*/false);
   assert(theExp->Sort->isBoolSort());
   return theExp;
 }
 
-SMTExprRef SMTSolverImpl::mkBVMulOverflow(const SMTExprRef &LHS,
-                                          const SMTExprRef &RHS,
-                                          bool IsSigned) {
+SMTExprRef SMTSolverImpl::mkBVSSubOverflow(const SMTExprRef &LHS,
+                                           const SMTExprRef &RHS) {
   requireBVSameSort(LHS, RHS);
-  SMTExprRef theExp = mkBVMulOverflowImpl(LHS, RHS, IsSigned);
+  SMTExprRef theExp = mkBVSubOverflowImpl(LHS, RHS, /*IsSigned=*/true);
+  assert(theExp->Sort->isBoolSort());
+  return theExp;
+}
+
+SMTExprRef SMTSolverImpl::mkBVUSubOverflow(const SMTExprRef &LHS,
+                                           const SMTExprRef &RHS) {
+  requireBVSameSort(LHS, RHS);
+  SMTExprRef theExp = mkBVSubOverflowImpl(LHS, RHS, /*IsSigned=*/false);
+  assert(theExp->Sort->isBoolSort());
+  return theExp;
+}
+
+SMTExprRef SMTSolverImpl::mkBVSMulOverflow(const SMTExprRef &LHS,
+                                           const SMTExprRef &RHS) {
+  requireBVSameSort(LHS, RHS);
+  SMTExprRef theExp = mkBVMulOverflowImpl(LHS, RHS, /*IsSigned=*/true);
+  assert(theExp->Sort->isBoolSort());
+  return theExp;
+}
+
+SMTExprRef SMTSolverImpl::mkBVUMulOverflow(const SMTExprRef &LHS,
+                                           const SMTExprRef &RHS) {
+  requireBVSameSort(LHS, RHS);
+  SMTExprRef theExp = mkBVMulOverflowImpl(LHS, RHS, /*IsSigned=*/false);
   assert(theExp->Sort->isBoolSort());
   return theExp;
 }

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -298,12 +298,18 @@ public:
                      const SMTExprRef &RHS) override final;
   SMTExprRef mkBVSge(const SMTExprRef &LHS,
                      const SMTExprRef &RHS) override final;
-  SMTExprRef mkBVAddOverflow(const SMTExprRef &LHS, const SMTExprRef &RHS,
-                             bool IsSigned) override final;
-  SMTExprRef mkBVSubOverflow(const SMTExprRef &LHS, const SMTExprRef &RHS,
-                             bool IsSigned) override final;
-  SMTExprRef mkBVMulOverflow(const SMTExprRef &LHS, const SMTExprRef &RHS,
-                             bool IsSigned) override final;
+  SMTExprRef mkBVSAddOverflow(const SMTExprRef &LHS,
+                              const SMTExprRef &RHS) override final;
+  SMTExprRef mkBVUAddOverflow(const SMTExprRef &LHS,
+                              const SMTExprRef &RHS) override final;
+  SMTExprRef mkBVSSubOverflow(const SMTExprRef &LHS,
+                              const SMTExprRef &RHS) override final;
+  SMTExprRef mkBVUSubOverflow(const SMTExprRef &LHS,
+                              const SMTExprRef &RHS) override final;
+  SMTExprRef mkBVSMulOverflow(const SMTExprRef &LHS,
+                              const SMTExprRef &RHS) override final;
+  SMTExprRef mkBVUMulOverflow(const SMTExprRef &LHS,
+                              const SMTExprRef &RHS) override final;
   SMTExprRef mkBVSDivOverflow(const SMTExprRef &LHS,
                               const SMTExprRef &RHS) override final;
   SMTExprRef mkBVNegOverflow(const SMTExprRef &Exp) override final;


### PR DESCRIPTION
Pre-release naming decision: `mkBVAddOverflow(a, b, /*IsSigned=*/true)` broke the `mkBVS*`/`mkBVU*` convention every other signed/unsigned BV pair follows (`mkBVSlt`/`mkBVUlt`, `mkBVSDiv`/`mkBVUDiv`, ...), and the same five-method family then reverted to the S-prefix for `mkBVSDivOverflow`/`mkBVNegOverflow`. Renaming after the release would be source-breaking, so now:

- Public API: `mkBVSAddOverflow`/`mkBVUAddOverflow`, `mkBVSSubOverflow`/`mkBVUSubOverflow`, `mkBVSMulOverflow`/`mkBVUMulOverflow` (sdiv/neg overflow keep their names — no unsigned counterpart exists).
- The protected `*Impl` hooks keep one `IsSigned`-parameterized entry point per operation, since every backend implements both signednesses in one switch — zero backend churn.
- Equivalence-proof regression and README updated to the new names.

Full suite: 163/163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)