### PR TITLE
Document the new capability rows in the README parity table

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ shared fixtures from `tests.h`):
 The Camada preamble unconditionally sends `(set-option :print-success true)`,
 `(set-option :produce-models true)`,
 `(set-option :produce-unsat-assumptions true)` (a child answering
-`unsupported` still solves normally; only `getUnsatAssumptions` degrades),
+`unsupported` still solves normally; only `getUnsatAssumptions` degrades,
+and `supports(SolverFeature::UnsatAssumptions)` reflects the child's
+answer),
 `(set-option :global-declarations true)`, `(set-info :status unknown)`, and
 `(set-logic ALL)` at startup, so any solver that honors the SMT-LIB option
 contract should work. Other solvers should be
@@ -251,6 +253,10 @@ even if it lacks native floating-point support.
 | Uninterpreted functions | ✔️ | ✔️ | ✔️ |   | ✔️ | ✔️ |
 | Tuples | ✔️<sup>2</sup> | ✔️ | ✔️<sup>2</sup> | ✔️<sup>2</sup> | ✔️<sup>2</sup> | ✔️ |
 | Quantifiers | ✔️ | ✔️ |   |   |   | ✔️ |
+| Overflow predicates | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Unsat assumptions | ✔️ | ✔️ | ✔️ |   | ✔️ | ✔️ |
+| Timeouts (`setTimeout`) | ✔️ | ✔️ | ✔️ |   | ✔️<sup>3</sup> | ✔️ |
+| Array models (`getArrayValues`) | ✔️ | ✔️ | ✔️ |   | ✔️ | ✔️ |
 
 <sup>1</sup> On `MathSAT`, `fp.fma` and `fp.rem` are lowered through the
 common BV path, and native `ROUND_TO_AWAY` is unsupported.
@@ -258,6 +264,15 @@ common BV path, and native `ROUND_TO_AWAY` is unsupported.
 <sup>2</sup> Via Camada's per-field tuple lowering rather than native
 datatypes; some gaps remain (e.g. arrays of tuples). Query
 `supports(SolverFeature::NativeTuples)` to tell the two apart.
+
+<sup>3</sup> POSIX only, enforced through a process-global SIGALRM timer —
+at most one timed Yices check may run at a time process-wide.
+
+The last four rows (and any platform splits) are queryable at runtime via
+`supports(SolverFeature)`; `checkSatAssuming` itself works on every
+backend through a push/assert/check/pop fallback — the unsat-assumptions
+row covers `getUnsatAssumptions`. On STP, `getArrayValues` still answers
+for lazily lowered constant arrays, which the common layer handles.
 
 ## Backend Caveats
 
@@ -290,6 +305,9 @@ limitations still matter in day-to-day use.
   - global Yices initialization/teardown is hardened for multiple wrappers, but
     simultaneously live Yices solver instances can still collide on shared
     symbol names.
+  - `setTimeout` is enforced with a process-global SIGALRM timer plus
+    `yices_stop_search` (Yices has no native time limit), so it is POSIX-only
+    and at most one timed Yices check may run at a time process-wide.
 - `Bitwuzla`
   - integers and reals are not supported.
   - quantifiers are available, but the strongest coverage in Camada is still in


### PR DESCRIPTION
Follow-up README pass after the seven pre-release PRs landed. The overflow predicates were already documented with their new `mkBVS*`/`mkBVU*` names (#95 updated the README in the same PR); the remaining gaps were:

- The backend parity table predated the per-backend-divergent features — added rows for overflow predicates (all backends, common-layer fallback), unsat assumptions, timeouts (with the Yices POSIX footnote), and array models, plus a note that these rows are queryable at runtime via `supports(SolverFeature)` and that `checkSatAssuming` itself works everywhere through the fallback.
- The SMT-LIB preamble paragraph now mentions that `supports(UnsatAssumptions)` reflects the child's `:produce-unsat-assumptions` answer (#93).
- Yices backend caveats now record the SIGALRM mechanism's process-global, one-timed-check-at-a-time constraint, which was previously documented only in the code.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)