### PR TITLE
Fix three array-soundness defects (bitwuzla const arrays, lazy equality, STP equality)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ limitations still matter in day-to-day use.
   - integers and reals are not supported.
   - quantifiers are available, but the strongest coverage in Camada is still in
     the quantifier-free fragments.
+  - constant arrays use Camada's lazy lowering: Bitwuzla 0.9.x answers
+    UNKNOWN for formulas that equate a native constant array with another
+    array (it warns "Equality over constant arrays not fully supported
+    yet"), which breaks the common `symbol = array_of(v)` pattern.
 - `CVC5` and `Z3`
   - these are currently the most complete backends for the public Camada API.
 
@@ -394,7 +398,7 @@ Camada also smooths over backend quirks where practical. For example:
 
 - MathSAT and STP now lower `Array<Idx, Bool>` through backend `Array<Idx, BV1>`
   representations internally
-- STP and Yices constant arrays use Camada's lazy lowering (a fresh array
+- STP, Yices, and Bitwuzla constant arrays use Camada's lazy lowering (a fresh array
   symbol whose default-value axiom is instantiated at each observed index);
   `ConstArrayLowering::Lazy` forces the same lowering on any backend
 - MathSAT native FP still falls back for unsupported operations such as

--- a/regression/array.test.h
+++ b/regression/array.test.h
@@ -312,6 +312,151 @@ inline void const_array_model_values(
   REQUIRE(Probe.value() == 7);
 }
 
+// Plain array equality must be extensional in both polarities. The
+// asserted-positive direction is the regression: STP's old lowering
+// (select(A,w) == select(B,w) at one fresh index) only constrained one
+// cell, so `a == b` plus disagreeing selects was satisfiable.
+inline void array_equality_semantics(const camada::SMTSolverRef &solver) {
+  auto mk = [&](const char *NameA, const char *NameB) {
+    auto indexsort = solver->mkBVSort(8);
+    auto arrsort = solver->mkArraySort(indexsort, indexsort);
+    return std::make_pair(solver->mkSymbol(NameA, arrsort),
+                          solver->mkSymbol(NameB, arrsort));
+  };
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+
+  // Positive direction: equality forces agreement at observed indexes.
+  auto [a, b] = mk("a", "b");
+  solver->addConstraint(solver->mkEqual(a, b));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(a, idx(0)), idx(1)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(b, idx(0)), idx(2)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Same, with the selects observed BEFORE the equality is built — pins
+  // the replay of already-observed indexes.
+  solver->reset();
+  auto [c, d] = mk("c", "d");
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(c, idx(0)), idx(1)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(d, idx(0)), idx(2)));
+  solver->addConstraint(solver->mkEqual(c, d));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Negative direction stays satisfiable: a difference can be exhibited.
+  solver->reset();
+  auto [e, f] = mk("e", "f");
+  solver->addConstraint(solver->mkNot(solver->mkEqual(e, f)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // Agreeing constraints under asserted equality are satisfiable.
+  solver->reset();
+  auto [g, h] = mk("g", "h");
+  solver->addConstraint(solver->mkEqual(g, h));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(g, idx(0)), idx(5)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(h, idx(0)), idx(5)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // Equality must be visible through store-derived terms: reading
+  // store(a, j, v) at i != j reads a at i.
+  solver->reset();
+  auto [p, q] = mk("p", "q");
+  solver->addConstraint(solver->mkEqual(p, q));
+  auto ps = solver->mkArrayStore(p, idx(1), idx(42));
+  auto qs = solver->mkArrayStore(q, idx(1), idx(42));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(
+      solver->mkArraySelect(ps, idx(0)), solver->mkArraySelect(qs, idx(0)))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // ... and through ite-derived terms.
+  solver->reset();
+  auto [r, s] = mk("r", "s");
+  auto cond = solver->mkSymbol("cond", solver->mkBoolSort());
+  solver->addConstraint(solver->mkEqual(r, s));
+  auto i1 = solver->mkIte(cond, r, s);
+  auto i2 = solver->mkIte(cond, s, r);
+  solver->addConstraint(solver->mkNot(
+      solver->mkEqual(solver->mkArraySelect(i1, solver->mkBVFromDec(0, 8)),
+                      solver->mkArraySelect(i2, solver->mkBVFromDec(0, 8)))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Transitive chains close through observed-index congruence.
+  solver->reset();
+  auto [t, u] = mk("t", "u");
+  auto v = solver->mkSymbol("v", t->Sort);
+  solver->addConstraint(solver->mkEqual(t, u));
+  solver->addConstraint(solver->mkEqual(u, v));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(t, idx(0)), idx(1)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(v, idx(0)), idx(2)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Polarity safety: the equality literal used under boolean structure.
+  solver->reset();
+  auto [w, x] = mk("w", "x");
+  auto flag = solver->mkSymbol("flag", solver->mkBoolSort());
+  auto eq = solver->mkEqual(w, x);
+  solver->addConstraint(solver->mkIte(flag, eq, solver->mkNot(eq)));
+  solver->addConstraint(flag);
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(w, idx(0)), idx(1)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(x, idx(0)), idx(2)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Equality between an array symbol and a constant array — ESBMC's
+// `symbol = array_of(v)` pattern. Bitwuzla 0.9.x answers UNKNOWN on the
+// native ((as const ...)) form of this (with an "Equality over constant
+// arrays not fully supported yet" warning), which is why it lowers
+// constant arrays lazily; this fixture pins the pattern on every
+// backend and lowering.
+inline void const_array_equality_semantics(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto indexsort = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto arrsort = solver->mkArraySort(indexsort, indexsort);
+
+  auto a = solver->mkSymbol("a", arrsort);
+  solver->addConstraint(
+      solver->mkEqual(a, solver->mkArrayConst(indexsort, idx(7), Lowering)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(a, idx(3)), idx(7)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // reset() invalidates every handle; rebuild the sorts for the
+  // contradiction direction.
+  solver->reset();
+  indexsort = solver->mkBVSort(8);
+  arrsort = solver->mkArraySort(indexsort, indexsort);
+  auto b = solver->mkSymbol("b", arrsort);
+  solver->addConstraint(
+      solver->mkEqual(b, solver->mkArrayConst(indexsort, idx(7), Lowering)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(b, idx(3)), idx(9)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Derived-before-equality: a store built over the symbol BEFORE the
+  // constant-array equality exists must still see the default at indexes
+  // the store does not shadow.
+  solver->reset();
+  indexsort = solver->mkBVSort(8);
+  arrsort = solver->mkArraySort(indexsort, indexsort);
+  auto c = solver->mkSymbol("c", arrsort);
+  auto cs = solver->mkArrayStore(c, idx(1), idx(42));
+  solver->addConstraint(
+      solver->mkEqual(c, solver->mkArrayConst(indexsort, idx(7), Lowering)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(cs, idx(3)), idx(9)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
 inline void const_array_lowering_interop(const camada::SMTSolverRef &solver) {
   auto idx = solver->mkBVSort(8);
   auto elem = solver->mkBVSort(8);

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -171,7 +171,7 @@ TEST_CASE("Bitwuzla feature capabilities", "[Bitwuzla]") {
   REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
-  REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeConstantArrays));
   REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -63,6 +63,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(array_const_survives_push_pop);
   RESETANDTEST(wide_index_const_array_semantics);
   RESETANDTEST(const_array_select_survives_pop);
+  RESETANDTEST(array_equality_semantics);
+  RESETANDTEST(const_array_equality_semantics);
   constexpr auto LazyArrays = camada::ConstArrayLowering::Lazy;
   RESETANDARGTEST(array, LazyArrays);
   RESETANDARGTEST(array_const_store_semantics, LazyArrays);
@@ -70,6 +72,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDARGTEST(array_const_survives_push_pop, LazyArrays);
   RESETANDARGTEST(wide_index_const_array_semantics, LazyArrays);
   RESETANDARGTEST(const_array_select_survives_pop, LazyArrays);
+  RESETANDARGTEST(const_array_equality_semantics, LazyArrays);
   RESETANDTEST(array_model_values);
   RESETANDTEST(const_array_model_values);
   RESETANDARGTEST(const_array_model_values, LazyArrays);

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -925,13 +925,9 @@ SMTExprRef BitwuzlaSolver::mkSymbolImpl(const std::string &Name,
                         Name.c_str()));
 }
 
-SMTExprRef BitwuzlaSolver::mkArrayConstImpl(const SMTSortRef &IndexSort,
-                                            const SMTExprRef &InitValue) {
-  const SMTSortRef &sort = mkArraySort(IndexSort, InitValue->Sort);
-  return makeExprRef<BitwExpr>(
-      SMTExprKind::ArrayConst, Context, sort,
-      bitwuzla_mk_const_array(TermManager, toSolverSort<BitwSort>(*sort).Sort,
-                              toSolverExpr<BitwExpr>(*InitValue).Expr));
+SMTExprRef BitwuzlaSolver::mkArrayConstImpl(const SMTSortRef &,
+                                            const SMTExprRef &) {
+  fatalError("Bitwuzla constant arrays are lowered lazily by the common layer");
 }
 
 SMTExprRef BitwuzlaSolver::mkForallImpl(const std::vector<SMTExprRef> &Vars,

--- a/src/bitwuzlasolver.h
+++ b/src/bitwuzlasolver.h
@@ -233,8 +233,17 @@ protected:
                        const unsigned SigWidth) override;
   SMTExprRef mkSymbolImpl(const std::string &Name,
                           const SMTSortRef &Sort) override;
+
+  // Bitwuzla 0.9.x answers UNKNOWN (with an "Equality over constant
+  // arrays not fully supported yet" warning) for any formula that
+  // equates a constant array with another array — including the common
+  // `symbol = ((as const ...) v)` pattern — so the common layer lowers
+  // constant arrays lazily instead (nativeConstArraySupport() below) and
+  // this override is unreachable.
   SMTExprRef mkArrayConstImpl(const SMTSortRef &IndexSort,
                               const SMTExprRef &InitValue) override;
+
+  bool nativeConstArraySupport() const override { return false; }
   SMTExprRef mkBVToIEEEFPImpl(const SMTExprRef &Exp,
                               const SMTSortRef &To) override;
   SMTExprRef mkIEEEFPToBVImpl(const SMTExprRef &Exp) override;

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -231,6 +231,12 @@ void SMTSolverImpl::clearExprCaches() {
   LazyArrayItes.clear();
   LazyTouched.clear();
   LazyConstraintLevels.assign(1, {});
+  LazyRootsByIndexSort.clear();
+  ObservedIndexesBySort.clear();
+  ObservedIndexSeen.clear();
+  ArrayEqualLinks.clear();
+  ArrayEqualLinksByIndexSort.clear();
+  ArrayEqualCongruenceDone.clear();
   invalidateUnsatAssumptions();
 }
 
@@ -671,28 +677,39 @@ SMTExprRef SMTSolverImpl::mkEqual(const SMTExprRef &LHS,
   // equalities.
   if (LHS->Sort->isTupleSort() && !nativeTupleSupport())
     return mkCamadaTupleEqual(*this, LHS, RHS);
-  if (!LazyConstArrayRoots.empty() && LHS->Sort->isArraySort() &&
-      (reachesLazyArray(LHS) || reachesLazyArray(RHS))) {
-    // Extensionality witness for lazy constant arrays. The backend decides
-    // array equality natively, but a lazy root's default axiom is only
-    // instantiated at observed indexes, so a model could fake a difference
-    // (or agreement) at an unobserved index. The standard reduction plugs
-    // this: a fresh witness index per equality, the universally valid lemma
-    //   LHS = RHS  \/  select(LHS, K) != select(RHS, K)
-    // and default instantiation at K (done by mkArraySelect below). Any
-    // model claiming LHS != RHS must now exhibit the difference at K,
-    // where defaults are enforced.
-    SMTExprRef Witness = mkSymbolUnchecked(
-        "__CAMADA_lazyarr_ext" + std::to_string(LazyConstArrayCounter++),
-        LHS->Sort->getIndexSort());
-    SMTExprRef SelL = mkArraySelect(LHS, Witness);
-    SMTExprRef SelR = mkArraySelect(RHS, Witness);
-    SMTExprRef theEq = mkEqualImpl(LHS, RHS);
-    assert(theEq->isBoolSort());
-    SMTExprRef Lemma = mkOr(theEq, mkNot(mkEqual(SelL, SelR)));
-    addConstraint(Lemma);
-    LazyConstraintLevels.back().push_back(std::move(Lemma));
-    return theEq;
+  if (LHS->Sort->isArraySort()) {
+    const bool LazyInvolved = !LazyConstArrayRoots.empty() &&
+                              (reachesLazyArray(LHS) || reachesLazyArray(RHS));
+    // Backends without native array extensionality (STP) cannot decide
+    // array equality at all — their only array predicate is select — so
+    // every array equality is lowered to the witness + observed-index
+    // congruence encoding. Its witness selects also instantiate any lazy
+    // defaults, so this subsumes the lazy lemma below.
+    if (!nativeArrayExtensionality())
+      return mkEncodedArrayEqual(LHS, RHS);
+    if (LazyInvolved) {
+      // Extensionality witness for lazy constant arrays. The backend
+      // decides array equality natively, but a lazy root's default axiom
+      // is only instantiated at observed indexes, so a model could fake a
+      // difference (or agreement) at an unobserved index. The standard
+      // reduction plugs this: a fresh witness index per equality, the
+      // universally valid lemma
+      //   LHS = RHS  \/  select(LHS, K) != select(RHS, K)
+      // and default instantiation at K (done by mkArraySelect below). Any
+      // model claiming LHS != RHS must now exhibit the difference at K,
+      // where defaults are enforced.
+      SMTExprRef Witness = mkSymbolUnchecked(
+          "__CAMADA_lazyarr_ext" + std::to_string(LazyConstArrayCounter++),
+          LHS->Sort->getIndexSort());
+      SMTExprRef SelL = mkArraySelect(LHS, Witness);
+      SMTExprRef SelR = mkArraySelect(RHS, Witness);
+      SMTExprRef theEq = mkEqualImpl(LHS, RHS);
+      assert(theEq->isBoolSort());
+      SMTExprRef Lemma = mkOr(theEq, mkNot(mkEqual(SelL, SelR)));
+      addConstraint(Lemma);
+      LazyConstraintLevels.back().push_back(std::move(Lemma));
+      return theEq;
+    }
   }
   SMTExprRef theExp = mkEqualImpl(LHS, RHS);
   assert(theExp->isBoolSort());
@@ -1165,8 +1182,8 @@ SMTExprRef SMTSolverImpl::mkArraySelect(const SMTExprRef &Array,
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
   fatalErrorIf(Array->Sort->getIndexSort() != Index->Sort,
                "Expected array index with matching sort");
-  if (!LazyConstArrayRoots.empty())
-    instantiateLazyDefaults(Array, Index);
+  if (!InLazyModelQuery)
+    observeArrayIndex(Index);
   SMTExprRef theExp = mkArraySelectImpl(Array, Index);
   assert(theExp->Sort == Array->Sort->getElementSort());
   return theExp;
@@ -1220,21 +1237,31 @@ SMTExprRef SMTSolverImpl::mkLazyConstArray(const SMTSortRef &IndexSort,
       "__CAMADA_lazyarr" + std::to_string(LazyConstArrayCounter++), ArraySort);
   Root = rewrapExprImpl(*Root, Root->Sort, SMTExprKind::ArrayConst);
   LazyConstArrayRoots.emplace(&*Root, LazyConstArrayRoot{Root, InitValue});
+  const SMTSort *IndexSortKey = &*IndexSort;
+  LazyRootsByIndexSort[IndexSortKey].push_back(&*Root);
+  // Replay the default axiom at every index already observed at this
+  // sort: reads may reach this root through terms built before it (e.g.
+  // a store over an array later equated with it).
+  if (auto It = ObservedIndexesBySort.find(IndexSortKey);
+      It != ObservedIndexesBySort.end()) {
+    const std::vector<SMTExprRef> Observed = It->second;
+    for (const SMTExprRef &Index : Observed)
+      instantiateLazyDefaultAt(&*Root, Index);
+  }
   return Root;
 }
 
-void SMTSolverImpl::instantiateLazyDefaults(const SMTExprRef &Array,
-                                            const SMTExprRef &Index) {
-  for (const SMTExpr *RootKey : lazyArrayRootsOf(Array)) {
-    // Memo-first: the select built below re-enters mkArraySelect on the
-    // root with this same index and must find the pair already recorded.
-    if (!LazyTouched.insert({RootKey, &*Index}).second)
-      continue;
-    const LazyConstArrayRoot &Root = LazyConstArrayRoots.at(RootKey);
-    SMTExprRef Constraint = mkEqual(mkArraySelect(Root.Root, Index), Root.Init);
-    addConstraint(Constraint);
-    LazyConstraintLevels.back().push_back(std::move(Constraint));
-  }
+void SMTSolverImpl::instantiateLazyDefaultAt(const SMTExpr *RootKey,
+                                             const SMTExprRef &Index) {
+  // Memo-first: the select built below re-enters mkArraySelect (and
+  // observeArrayIndex) and must find the pair already recorded.
+  if (!LazyTouched.insert({RootKey, &*Index}).second)
+    return;
+  // Copy: the maps may rehash while the constraint is built.
+  const LazyConstArrayRoot Root = LazyConstArrayRoots.at(RootKey);
+  SMTExprRef Constraint = mkEqual(mkArraySelect(Root.Root, Index), Root.Init);
+  addConstraint(Constraint);
+  LazyConstraintLevels.back().push_back(std::move(Constraint));
 }
 
 std::string SMTSolverImpl::lazyIndexModelBits(const SMTExprRef &Exp) {
@@ -1246,6 +1273,75 @@ std::string SMTSolverImpl::lazyIndexModelBits(const SMTExprRef &Exp) {
     return std::string(); // unsupported index sort: backend fallback
   SMTResult<std::string> Value = getBVInBin(Exp);
   return Value ? Value.value() : std::string();
+}
+
+void SMTSolverImpl::observeArrayIndex(const SMTExprRef &Index) {
+  const SMTSort *SortKey = &*Index->Sort;
+  if (!ObservedIndexSeen.insert({SortKey, &*Index}).second)
+    return;
+  ObservedIndexesBySort[SortKey].push_back(Index);
+  // Copies throughout: instantiation builds selects that re-enter this
+  // function and may register new roots/links/indexes.
+  if (auto It = LazyRootsByIndexSort.find(SortKey);
+      It != LazyRootsByIndexSort.end()) {
+    const std::vector<const SMTExpr *> Roots = It->second;
+    for (const SMTExpr *RootKey : Roots)
+      instantiateLazyDefaultAt(RootKey, Index);
+  }
+  if (auto It = ArrayEqualLinksByIndexSort.find(SortKey);
+      It != ArrayEqualLinksByIndexSort.end()) {
+    const std::vector<std::size_t> Links = It->second;
+    for (std::size_t LinkId : Links)
+      assertArrayEqualCongruence(LinkId, Index);
+  }
+}
+
+SMTExprRef SMTSolverImpl::mkEncodedArrayEqual(const SMTExprRef &LHS,
+                                              const SMTExprRef &RHS) {
+  const std::size_t LinkId = ArrayEqualLinks.size();
+  SMTExprRef EqVar = mkSymbolUnchecked(
+      "__CAMADA_arreq" + std::to_string(ArrayEqualCounter++), mkBoolSort());
+  // Present the lowering as an Equal node, like the other common-layer
+  // lowerings do.
+  EqVar = rewrapExprImpl(*EqVar, EqVar->Sort, SMTExprKind::Equal);
+  ArrayEqualLinks.push_back(ArrayEqualLink{EqVar, LHS, RHS});
+  const SMTSort *IndexSortKey = &*LHS->Sort->getIndexSort();
+  ArrayEqualLinksByIndexSort[IndexSortKey].push_back(LinkId);
+
+  // Positive direction at every index already observed at this sort —
+  // reads may reach these arrays through derived terms or terms built
+  // before this equality. (Future indexes fire through observeArrayIndex.)
+  if (auto It = ObservedIndexesBySort.find(IndexSortKey);
+      It != ObservedIndexesBySort.end()) {
+    const std::vector<SMTExprRef> Observed = It->second;
+    for (const SMTExprRef &Index : Observed)
+      assertArrayEqualCongruence(LinkId, Index);
+  }
+
+  // Negative direction: a claimed difference must be exhibitable at the
+  // witness. The selects below also flow through mkArraySelect, which
+  // asserts this link's congruence at W and instantiates lazy defaults,
+  // so EqVar is fully tied to the arrays' contents at W.
+  SMTExprRef Witness = mkSymbolUnchecked(
+      "__CAMADA_arreq_wit" + std::to_string(ArrayEqualCounter++),
+      LHS->Sort->getIndexSort());
+  SMTExprRef Lemma = mkOr(EqVar, mkNot(mkEqual(mkArraySelect(LHS, Witness),
+                                               mkArraySelect(RHS, Witness))));
+  addConstraint(Lemma);
+  LazyConstraintLevels.back().push_back(std::move(Lemma));
+  return EqVar;
+}
+
+void SMTSolverImpl::assertArrayEqualCongruence(std::size_t LinkId,
+                                               const SMTExprRef &Index) {
+  if (!ArrayEqualCongruenceDone.insert({LinkId, &*Index}).second)
+    return;
+  const ArrayEqualLink Link = ArrayEqualLinks[LinkId];
+  SMTExprRef Constraint =
+      mkImplies(Link.EqVar, mkEqual(mkArraySelect(Link.LHS, Index),
+                                    mkArraySelect(Link.RHS, Index)));
+  addConstraint(Constraint);
+  LazyConstraintLevels.back().push_back(std::move(Constraint));
 }
 
 SMTExprRef SMTSolverImpl::resolveLazyArrayElement(const SMTExprRef &Array,
@@ -1467,6 +1563,15 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
   if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
     if (SMTExprRef Resolved = resolveLazyArrayElement(Array, Index))
       return Resolved;
+  // RAII: backend model queries can throw (z3::exception,
+  // CVC5ApiException); the flag must not stay latched or every later
+  // select would silently skip instantiation.
+  struct ModelQueryGuard {
+    bool &Flag;
+    bool Saved;
+    explicit ModelQueryGuard(bool &F) : Flag(F), Saved(F) { F = true; }
+    ~ModelQueryGuard() { Flag = Saved; }
+  } Guard(InLazyModelQuery);
   SMTExprRef theExp = getArrayElementImpl(Array, Index);
   assert(theExp->Sort == Array->Sort->getElementSort());
   return theExp;

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -155,6 +155,8 @@ protected:
     const SMTExpr *FalseArr;
   };
   std::unordered_map<const SMTExpr *, LazyConstArrayRoot> LazyConstArrayRoots;
+  std::unordered_map<const SMTSort *, std::vector<const SMTExpr *>>
+      LazyRootsByIndexSort;
   std::unordered_map<const SMTExpr *, std::vector<const SMTExpr *>>
       LazyConstArrayReach;
   std::unordered_map<const SMTExpr *, LazyArrayStoreStep> LazyArrayStores;
@@ -166,10 +168,56 @@ protected:
   std::set<std::pair<const SMTExpr *, const SMTExpr *>> LazyTouched;
   std::vector<std::vector<SMTExprRef>> LazyConstraintLevels{1};
   uint64_t LazyConstArrayCounter = 0;
+  // Every distinct index term ever selected with, grouped by index sort.
+  // Lazy default axioms and encoded-equality congruence are instantiated
+  // at EVERY observed index of the matching sort — not just indexes seen
+  // on the syntactic array operands — because reads can reach an array
+  // through store/ite-derived terms and through terms built before an
+  // equality existed. Sort-global instantiation is a superset of any
+  // equivalence-class walk, so it is unconditionally sound, and complete
+  // for quantifier-free formulas (only finitely many index terms exist).
+  std::unordered_map<const SMTSort *, std::vector<SMTExprRef>>
+      ObservedIndexesBySort;
+  std::set<std::pair<const SMTSort *, const SMTExpr *>> ObservedIndexSeen;
+  void observeArrayIndex(const SMTExprRef &Index);
+  // True while a model query (getArrayElement) is evaluating: selects
+  // built for evaluation must not instantiate default axioms or count as
+  // formula observations — asserting after check() invalidates the
+  // backend's model.
+  bool InLazyModelQuery = false;
 
   /// True when the backend can express `((as const ...) v)` natively.
   /// Backends without it get constant arrays through mkLazyConstArray().
   virtual bool nativeConstArraySupport() const { return true; }
+
+  /// True when the backend decides array equality natively (extensional
+  /// array theory). STP cannot: its only array predicate is select, so
+  /// the common layer lowers array equality through mkEncodedArrayEqual()
+  /// instead of mkEqualImpl().
+  virtual bool nativeArrayExtensionality() const { return true; }
+
+  // --- Encoded array equality (backends without native extensionality) ---
+  // Each lowered equality is a fresh boolean EqVar tied to its arrays by:
+  //   * the negative direction: EqVar \/ select(L,W) != select(R,W) for a
+  //     fresh witness index W (a difference must be exhibitable), and
+  //   * the positive direction: EqVar => select(L,i) = select(R,i) at
+  //     every index i either array is observed at — replayed for past
+  //     selects and hooked into mkArraySelect for future ones.
+  // Sound and complete for quantifier-free formulas: only finitely many
+  // index terms are ever observed.
+  struct ArrayEqualLink {
+    SMTExprRef EqVar;
+    SMTExprRef LHS;
+    SMTExprRef RHS;
+  };
+  std::vector<ArrayEqualLink> ArrayEqualLinks;
+  std::unordered_map<const SMTSort *, std::vector<std::size_t>>
+      ArrayEqualLinksByIndexSort;
+  std::set<std::pair<std::size_t, const SMTExpr *>> ArrayEqualCongruenceDone;
+  uint64_t ArrayEqualCounter = 0;
+
+  SMTExprRef mkEncodedArrayEqual(const SMTExprRef &LHS, const SMTExprRef &RHS);
+  void assertArrayEqualCongruence(std::size_t LinkId, const SMTExprRef &Index);
 
   /// Lower a constant array as a fresh backend array symbol whose
   /// "every element equals InitValue" semantics are enforced lazily: the
@@ -185,8 +233,8 @@ protected:
 
   std::vector<const SMTExpr *> lazyArrayRootsOf(const SMTExprRef &Exp) const;
   bool reachesLazyArray(const SMTExprRef &Exp) const;
-  void instantiateLazyDefaults(const SMTExprRef &Array,
-                               const SMTExprRef &Index);
+  void instantiateLazyDefaultAt(const SMTExpr *RootKey,
+                                const SMTExprRef &Index);
   SMTExprRef resolveLazyArrayElement(const SMTExprRef &Array,
                                      const SMTExprRef &Index);
 

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -366,17 +366,12 @@ SMTExprRef STPSolver::mkXorImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) {
 
 SMTExprRef STPSolver::mkEqualImpl(const SMTExprRef &LHS,
                                   const SMTExprRef &RHS) {
-  if (LHS->isArraySort()) {
-    // STP does not support array extensionality, so let's create a free
-    // variable
-    const std::string name =
-        "__CAMADA_index" + std::to_string(ConstArrayCounter++);
-    const SMTExprRef &index =
-        mkSymbolUnchecked(name, LHS->Sort->getIndexSort());
-
-    // and do select(A,i) == select(B,i)
-    return mkEqual(mkArraySelect(LHS, index), mkArraySelect(RHS, index));
-  }
+  // Array-sorted operands are lowered by the common layer
+  // (nativeArrayExtensionality() is false): the old single-witness
+  // select(A,i) == select(B,i) reduction here was only sound for asserted
+  // disequality.
+  fatalErrorIf(LHS->isArraySort(),
+               "STP array equality is lowered by the common layer");
 
   if (LHS->isBoolSort())
     return makeExprRef<STPExpr>(

--- a/src/stpsolver.h
+++ b/src/stpsolver.h
@@ -204,6 +204,11 @@ protected:
 
   bool nativeConstArraySupport() const override { return false; }
 
+  // STP's only array predicate is select; array equality is lowered by
+  // the common layer (mkEncodedArrayEqual), so mkEqualImpl never sees
+  // array-sorted operands.
+  bool nativeArrayExtensionality() const override { return false; }
+
   checkResult checkImpl() override;
 
   void resetImpl() override;

--- a/src/stpsolver.h
+++ b/src/stpsolver.h
@@ -223,7 +223,6 @@ protected:
 
 private:
   STP::VC Context = nullptr;
-  unsigned int ConstArrayCounter = 0;
 }; // end class STPSolver
 
 } // namespace camada

--- a/src/yicessolver.cpp
+++ b/src/yicessolver.cpp
@@ -123,7 +123,12 @@ static inline term_t yicesCheckTerm(term_t Term, const char *Message) {
 // per-element query loops a first-class path.
 class YicesModel {
 public:
-  explicit YicesModel(context_t *Ctx) : Model(yices_get_model(Ctx, 1)) {}
+  explicit YicesModel(context_t *Ctx) : Model(yices_get_model(Ctx, 1)) {
+    // yices_get_model returns NULL when the context is not in a SAT
+    // state; passing that to the yices_val_*/yices_get_* APIs segfaults.
+    fatalErrorIf(Model == nullptr,
+                 "Yices has no model available (last check was not SAT?)");
+  }
   ~YicesModel() {
     if (Model)
       yices_free_model(Model);


### PR DESCRIPTION
A user report ("Bitwuzla inherits `nativeConstArraySupport() = true` and breaks") unraveled into **three distinct array-soundness defects**, all fixed here and all pinned by new fixtures. Verified end to end with adversarial review repros; full suite 164/164.

## 1. Bitwuzla constant arrays → lazy lowering

Bitwuzla 0.9.x answers UNKNOWN (warning: "Equality over constant arrays not fully supported yet") for any formula equating a native constant array with another array — including ESBMC's bread-and-butter `symbol = array_of(v)`. Same class of deficiency that disqualified Yices' lambda encoding, same fix: `nativeConstArraySupport()` is now false, constant arrays lower lazily, `supports(NativeConstantArrays)` flips, README documents it.

## 2. Lazy-array equality hole (shipped in v0.11)

`b == lazy-const(7) ∧ select(b, 3) == 9` was SAT: the equality's witness lemma covered only the disequality direction, and default axioms were instantiated per-operand, so reads on the aliased side (or through store/ite-derived terms, or terms built before the equality) escaped them.

Fix: **sort-global index observation**. Every distinct index term selected with is recorded per index sort, and lazy default axioms are instantiated at every observed index of the matching sort — past indexes replayed when a root is created, future ones fired from the select wrapper. Sort-global instantiation is a superset of any equivalence-class walk (instantiating a valid axiom is always sound) and complete for QF formulas.

## 3. STP positive array equality was unsound (shipped since the backend existed)

STP's `mkEqualImpl` lowered array equality to select-equality at **one fresh index** — sound only for asserted disequality. `a == b ∧ select(a,0) ≠ select(b,0)` was satisfiable on STP.

Fix: a new `nativeArrayExtensionality()` capability hook (false only on STP) routes array equality through a common-layer encoding: a fresh equality literal `EqVar` with the difference-witness lemma `EqVar ∨ select(L,W) ≠ select(R,W)` for the negative direction, and congruence `EqVar ⇒ select(L,i) = select(R,i)` at every observed index of the sort for the positive direction (replayed at link creation, hooked for future selects, memoized). Polarity-safe; transitive chains close through the congruence re-entrancy.

## Hardening found along the way

- Model queries (`getArrayElement` backend fallback) are now side-effect-free under an RAII guard — instantiating axioms post-check invalidated backend models (z3 threw "there is no current model"; Yices returned a NULL model and segfaulted).
- The Yices model RAII wrapper now aborts with a diagnostic on a NULL model instead of passing it to `yices_val_*`.

## Fixtures

`array_equality_semantics` (positive/negative directions, select-before-equality ordering, store-wrapped and ite-wrapped reads, transitive chains, polarity-under-ite) and `const_array_equality_semantics` (the ESBMC `symbol = array_of(v)` pattern + derived-before-equality, parameterized over `ConstArrayLowering`), registered on all backends. The adversarial review's confirmed-SAT-for-UNSAT repros all answer UNSAT now, on every backend.

`array_store_chain` bench is unaffected (the observation hook is one set-insert per select).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
