### PR TITLE
Bump version to 0.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 set(CAMADA_VER_MAJOR 0)
-set(CAMADA_VER_MINOR 11)
+set(CAMADA_VER_MINOR 12)
 
 project(
   camada

--- a/regression/main.cpp
+++ b/regression/main.cpp
@@ -13,5 +13,5 @@ int main(int argc, char *argv[]) {
 // a quoting mistake there once shipped the literal macro names as the
 // version string, and nothing noticed.
 TEST_CASE("Camada version string", "[Camada]") {
-  REQUIRE(camada::getCamadaVersion() == "0.11");
+  REQUIRE(camada::getCamadaVersion() == "0.12");
 }


### PR DESCRIPTION
Version bump for the release carrying the array-soundness fixes (#97): bitwuzla lazy constant arrays, sort-global lazy default instantiation, and the encoded STP array equality. `getCamadaVersion()` regression updated; library builds as `libcamada.so.0.12`. Full suite: 164/164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)