### PR TITLE
Add decomposed tuple-array core for solvers without datatypes

### DIFF
--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -176,3 +176,10 @@ TEST_CASE("Bitwuzla feature capabilities", "[Bitwuzla]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting Bitwuzla test", "[Bitwuzla]") {
+  auto solver = camada::createBitwuzlaSolver();
+  tuple_array_deep_nesting(solver);
+}

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -155,3 +155,10 @@ TEST_CASE("CVC5 feature capabilities", "[CVC5]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting CVC5 test", "[CVC5]") {
+  auto solver = camada::createCVC5Solver();
+  tuple_array_deep_nesting(solver);
+}

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -233,3 +233,10 @@ TEST_CASE("MathSAT feature capabilities", "[MathSAT]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting MathSAT test", "[MathSAT]") {
+  auto solver = camada::createMathSATSolver();
+  tuple_array_deep_nesting(solver);
+}

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -32,3 +32,21 @@ TEST_CASE("STP feature capabilities", "[STP]") {
   REQUIRE_FALSE(solver->supports(SolverFeature::Timeouts));
   REQUIRE_FALSE(solver->supports(SolverFeature::ArrayModels));
 }
+
+TEST_CASE("Unsupported nested arrays STP test", "[STP]") {
+  auto stp = camada::createSTPSolver();
+  require_abort([&]() {
+    auto bv4 = stp->mkBVSort(4);
+    (void)stp->mkArraySort(bv4, stp->mkArraySort(bv4, bv4));
+  });
+}
+
+TEST_CASE("Unsupported tuple-array UF/quantifier boundaries STP test",
+          "[STP]") {
+  auto stp = camada::createSTPSolver();
+  require_abort([&]() {
+    auto bv4 = stp->mkBVSort(4);
+    auto tupArr = stp->mkArraySort(bv4, stp->mkTupleSort({bv4}));
+    (void)stp->mkFunctionSort({tupArr}, bv4);
+  });
+}

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -80,6 +80,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(tuple_semantics);
   RESETANDTEST(tuple_with_array_field);
   RESETANDTEST(tuple_structural_equality);
+  RESETANDTEST(tuple_array_semantics);
+  RESETANDTEST(tuple_array_equality_ite);
   RESETANDTEST(empty_tuple_semantics);
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -130,6 +130,161 @@ inline void tuple_structural_equality(const camada::SMTSolverRef &solver) {
   REQUIRE_FALSE(*sym_a == *sym_b);
 }
 
+// Arrays of tuples: on native-datatype backends these are native
+// (Array Idx (Tuple ...)) sorts; elsewhere they decompose into one
+// backend array per scalar leaf field, so all array reasoning stays in
+// the solver's native theory (no software array encoding).
+inline void tuple_array_semantics(const camada::SMTSolverRef &solver) {
+  auto bv8 = solver->mkBVSort(8);
+  auto tupleSort = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  auto arrSort = solver->mkArraySort(bv8, tupleSort);
+  REQUIRE(arrSort->isArraySort());
+  REQUIRE(arrSort->getElementSort()->isTupleSort());
+
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto a = solver->mkSymbol("a", arrSort);
+
+  // Store a tuple value, read it back at the same index.
+  auto t = solver->mkTuple({solver->mkBool(true), idx(42)});
+  auto a1 = solver->mkArrayStore(a, idx(3), t);
+  auto rd = solver->mkArraySelect(a1, idx(3));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(rd, t)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Reads at other indexes stay tied to the original array.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  tupleSort = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  arrSort = solver->mkArraySort(bv8, tupleSort);
+  auto b = solver->mkSymbol("b", arrSort);
+  auto t2 = solver->mkTuple({solver->mkBool(false), idx(1)});
+  auto b1 = solver->mkArrayStore(b, idx(3), t2);
+  auto preserved = solver->mkEqual(solver->mkArraySelect(b1, idx(5)),
+                                   solver->mkArraySelect(b, idx(5)));
+  solver->addConstraint(solver->mkNot(preserved));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Homogeneous fields pin leaf-order identity solver-side: a leaf
+  // transposition between flatten and assemble would swap 1 and 2
+  // without any sort mismatch to catch it.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  auto homoSort = solver->mkTupleSort({bv8, bv8});
+  auto homoArr = solver->mkArraySort(bv8, homoSort);
+  auto h = solver->mkSymbol("h", homoArr);
+  auto hv = solver->mkTuple({idx(1), idx(2)});
+  auto h1 = solver->mkArrayStore(h, idx(0), hv);
+  auto hRead = solver->mkArraySelect(h1, idx(0));
+  auto fieldsOk =
+      solver->mkAnd(solver->mkEqual(solver->mkTupleSelect(hRead, 0), idx(1)),
+                    solver->mkEqual(solver->mkTupleSelect(hRead, 1), idx(2)));
+  solver->addConstraint(solver->mkNot(fieldsOk));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Read-over-write at a distinct symbolic index.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  tupleSort = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  arrSort = solver->mkArraySort(bv8, tupleSort);
+  auto c = solver->mkSymbol("c", arrSort);
+  auto i = solver->mkSymbol("i", bv8);
+  auto j = solver->mkSymbol("j", bv8);
+  auto t3 = solver->mkTuple({solver->mkBool(true), idx(9)});
+  auto c1 = solver->mkArrayStore(c, i, t3);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(i, j)));
+  auto rd2 = solver->mkArraySelect(c1, j);
+  solver->addConstraint(
+      solver->mkNot(solver->mkEqual(rd2, solver->mkArraySelect(c, j))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+inline void tuple_array_equality_ite(const camada::SMTSolverRef &solver) {
+  auto bv8 = solver->mkBVSort(8);
+  auto tupleSort = solver->mkTupleSort({bv8, bv8});
+  auto arrSort = solver->mkArraySort(bv8, tupleSort);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+
+  // Equality forces agreement at observed indexes.
+  auto a = solver->mkSymbol("a", arrSort);
+  auto b = solver->mkSymbol("b", arrSort);
+  solver->addConstraint(solver->mkEqual(a, b));
+  auto fa = solver->mkTupleSelect(solver->mkArraySelect(a, idx(0)), 1);
+  auto fb = solver->mkTupleSelect(solver->mkArraySelect(b, idx(0)), 1);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(fa, fb)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Ite distributes; selecting from the chosen branch agrees.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  tupleSort = solver->mkTupleSort({bv8, bv8});
+  arrSort = solver->mkArraySort(bv8, tupleSort);
+  auto c = solver->mkSymbol("c", arrSort);
+  auto d = solver->mkSymbol("d", arrSort);
+  auto cond = solver->mkSymbol("cond", solver->mkBoolSort());
+  auto picked = solver->mkIte(cond, c, d);
+  auto sel = solver->mkArraySelect(picked, idx(2));
+  auto expected = solver->mkIte(cond, solver->mkArraySelect(c, idx(2)),
+                                solver->mkArraySelect(d, idx(2)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(sel, expected)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Deep nesting: tuple { array of tuple { bv, array of tuple { bool, bv } } }
+// — five levels of alternation; everything must flatten to native
+// nested-arrays-of-scalars and recurse leaf-wise.
+inline void tuple_array_deep_nesting(const camada::SMTSolverRef &solver) {
+  auto bv4 = solver->mkBVSort(4);
+  auto bv8 = solver->mkBVSort(8);
+  auto idx4 = [&](int64_t V) { return solver->mkBVFromDec(V, 4); };
+  auto idx8 = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+
+  auto inner = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  auto innerArr = solver->mkArraySort(bv4, inner);
+  auto mid = solver->mkTupleSort({bv8, innerArr});
+  auto midArr = solver->mkArraySort(bv4, mid);
+  auto outer = solver->mkTupleSort({solver->mkBoolSort(), midArr});
+
+  auto o = solver->mkSymbol("o", outer);
+  // Walk down: outer.1 is an array of mid; select one, take its inner
+  // array, store an inner tuple, walk back up through stores/updates.
+  auto midArrV = solver->mkTupleSelect(o, 1);
+  auto midV = solver->mkArraySelect(midArrV, idx4(2));
+  auto innerArrV = solver->mkTupleSelect(midV, 1);
+  auto innerT = solver->mkTuple({solver->mkBool(true), idx8(7)});
+  auto innerArr1 = solver->mkArrayStore(innerArrV, idx4(1), innerT);
+  // Rebuild the enclosing tuples field-wise (mkTupleUpdate lands in a
+  // separate PR; select-and-rebuild is its definition anyway).
+  auto midV1 = solver->mkTuple({solver->mkTupleSelect(midV, 0), innerArr1});
+  auto midArr1 = solver->mkArrayStore(midArrV, idx4(2), midV1);
+  auto o1 = solver->mkTuple({solver->mkTupleSelect(o, 0), midArr1});
+
+  // Reading the stored inner tuple back through the whole chain.
+  auto back = solver->mkArraySelect(
+      solver->mkTupleSelect(
+          solver->mkArraySelect(solver->mkTupleSelect(o1, 1), idx4(2)), 1),
+      idx4(1));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(back, innerT)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // An untouched path stays tied to the original.
+  solver->reset();
+  bv4 = solver->mkBVSort(4);
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  innerArr = solver->mkArraySort(bv4, inner);
+  mid = solver->mkTupleSort({bv8, innerArr});
+  midArr = solver->mkArraySort(bv4, mid);
+  auto p = solver->mkSymbol("p", midArr);
+  auto q = solver->mkSymbol("q", midArr);
+  solver->addConstraint(solver->mkEqual(p, q));
+  auto deepP = solver->mkArraySelect(
+      solver->mkTupleSelect(solver->mkArraySelect(p, idx4(0)), 1), idx4(3));
+  auto deepQ = solver->mkArraySelect(
+      solver->mkTupleSelect(solver->mkArraySelect(q, idx4(0)), 1), idx4(3));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(deepP, deepQ)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
 inline void empty_tuple_semantics(const camada::SMTSolverRef &solver) {
   auto tupleSort = solver->mkTupleSort({});
   auto tupleValue = solver->mkTuple({});

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -231,3 +231,10 @@ TEST_CASE("Yices feature capabilities", "[Yices]") {
 #endif
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting Yices test", "[Yices]") {
+  auto solver = camada::createYicesSolver();
+  tuple_array_deep_nesting(solver);
+}

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -186,3 +186,10 @@ TEST_CASE("Z3 feature capabilities", "[Z3]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting Z3 test", "[Z3]") {
+  auto solver = camada::createZ3Solver();
+  tuple_array_deep_nesting(solver);
+}

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -369,17 +369,23 @@ SMTSortRef SMTSolverImpl::mkArraySort(const SMTSortRef &IndexSort,
   // no backend sort handle) through mkArraySortImpl, where the backend
   // would static_cast it as one of its own sorts. Reject up front. The
   // per-field array decomposition is tracked in issue #17.
-  fatalErrorIf(IndexSort->isTupleSort() && !nativeTupleSupport(),
-               "Arrays whose index sort is a tuple are not yet supported "
+  fatalErrorIf(sortContainsTuple(IndexSort) && !nativeTupleSupport(),
+               "Arrays whose index sort involves a tuple are not supported "
                "on this backend; see issue #17");
-  fatalErrorIf(ElemSort->isTupleSort() && !nativeTupleSupport(),
-               "Arrays whose element sort is a tuple are not yet supported "
-               "on this backend; see issue #17");
-
   ArraySortCacheKey Key{IndexSort.get(), ElemSort.get()};
   auto It = ArraySortCache.find(Key);
   if (It != ArraySortCache.end())
     return It->second;
+
+  // Element sorts involving tuples have no backend representation on
+  // backends without native datatype support: the array decomposes into
+  // a bundle of per-leaf-field backend arrays (see camadatuple.cpp).
+  if (!nativeTupleSupport() && sortContainsTuple(ElemSort)) {
+    SMTSortRef theSort = mkCamadaTupleArraySort(*this, IndexSort, ElemSort);
+    assert(theSort->isArraySort());
+    ArraySortCache.emplace(Key, theSort);
+    return theSort;
+  }
 
   SMTSortRef theSort = mkArraySortImpl(IndexSort, ElemSort);
   assert(theSort->isArraySort());
@@ -398,13 +404,14 @@ SMTSolverImpl::mkFunctionSort(const std::vector<SMTSortRef> &DomainSorts,
   // support would static_cast a CamadaTupleSort as a backend sort.
   // Reject up front; structural lowering is part of the issue #17 work.
   if (!nativeTupleSupport()) {
-    fatalErrorIf(CodomainSort->isTupleSort(),
-                 "Functions returning tuples are not yet supported on this "
-                 "backend; see issue #17");
+    fatalErrorIf(sortContainsTuple(CodomainSort),
+                 "Functions returning tuples (or tuple-involving arrays) "
+                 "are not yet supported on this backend; see issue #17");
     for (const auto &D : DomainSorts)
-      fatalErrorIf(D->isTupleSort(),
-                   "Functions taking tuple arguments are not yet supported "
-                   "on this backend; see issue #17");
+      fatalErrorIf(sortContainsTuple(D),
+                   "Functions taking tuple (or tuple-involving array) "
+                   "arguments are not yet supported on this backend; see "
+                   "issue #17");
   }
   if (DomainSorts.size() <= 4) {
     SmallFunctionSortCacheKey SmallKey{};
@@ -678,6 +685,11 @@ SMTExprRef SMTSolverImpl::mkEqual(const SMTExprRef &LHS,
   if (LHS->Sort->isTupleSort() && !nativeTupleSupport())
     return mkCamadaTupleEqual(*this, LHS, RHS);
   if (LHS->Sort->isArraySort()) {
+    // Decomposed tuple arrays compare as the conjunction of their leaf
+    // equalities; each leaf re-enters this wrapper and engages the
+    // normal array-equality machinery (lazy witness, STP encoding).
+    if (!nativeTupleSupport() && sortContainsTuple(LHS->Sort->getElementSort()))
+      return mkCamadaTupleArrayEqual(*this, LHS, RHS);
     const bool LazyInvolved = !LazyConstArrayRoots.empty() &&
                               (reachesLazyArray(LHS) || reachesLazyArray(RHS));
     // Backends without native array extensionality (STP) cannot decide
@@ -894,6 +906,11 @@ SMTExprRef SMTSolverImpl::mkIte(const SMTExprRef &Cond, const SMTExprRef &T,
   // node that distributes selection over its fields lazily.
   if (T->Sort->isTupleSort() && !nativeTupleSupport())
     return mkCamadaTupleIte(*this, Cond, T, F);
+  // Decomposed tuple arrays ite leaf-wise; the per-leaf ites re-enter
+  // this wrapper, so the lazy-root union tracking below applies per leaf.
+  if (!nativeTupleSupport() && T->Sort->isArraySort() &&
+      sortContainsTuple(T->Sort->getElementSort()))
+    return mkCamadaTupleArrayIte(*this, Cond, T, F);
   SMTExprRef theExp = mkIteImpl(Cond, T, F);
   assert(theExp->Sort == F->Sort);
   if (!LazyConstArrayRoots.empty() && T->Sort->isArraySort()) {
@@ -1182,6 +1199,11 @@ SMTExprRef SMTSolverImpl::mkArraySelect(const SMTExprRef &Array,
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
   fatalErrorIf(Array->Sort->getIndexSort() != Index->Sort,
                "Expected array index with matching sort");
+  // Decomposed tuple arrays select leaf-wise; the per-leaf selects below
+  // re-enter this wrapper, so observation/lazy instantiation happens per
+  // leaf.
+  if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
+    return mkCamadaTupleArraySelect(*this, Array, Index);
   if (!InLazyModelQuery)
     observeArrayIndex(Index);
   SMTExprRef theExp = mkArraySelectImpl(Array, Index);
@@ -1197,6 +1219,10 @@ SMTExprRef SMTSolverImpl::mkArrayStore(const SMTExprRef &Array,
                "Expected array index with matching sort");
   fatalErrorIf(Array->Sort->getElementSort() != Element->Sort,
                "Expected array element with matching sort");
+  // Decomposed tuple arrays store leaf-wise; the per-leaf stores re-enter
+  // this wrapper, so the lazy guards/tracking below apply per leaf.
+  if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
+    return mkCamadaTupleArrayStore(*this, Array, Index, Element);
   fatalErrorIf(!LazyConstArrayRoots.empty() && reachesLazyArray(Element),
                "Storing a lazily lowered constant array inside another array "
                "is not supported");
@@ -1451,9 +1477,10 @@ SMTExprRef SMTSolverImpl::mkForall(const std::vector<SMTExprRef> &Vars,
   // then static_cast as one of its own expressions. Reject up front.
   if (!nativeTupleSupport())
     for (const auto &V : Vars)
-      fatalErrorIf(V->Sort->isTupleSort(),
-                   "Quantifiers over tuple-typed variables are not yet "
-                   "supported on this backend; see issue #17");
+      fatalErrorIf(sortContainsTuple(V->Sort),
+                   "Quantifiers over tuple-typed (or tuple-involving-array) "
+                   "variables are not yet supported on this backend; see "
+                   "issue #17");
   SMTExprRef theExp = mkForallImpl(Vars, Body);
   assert(theExp->isBoolSort());
   return theExp;
@@ -1469,9 +1496,10 @@ SMTExprRef SMTSolverImpl::mkExists(const std::vector<SMTExprRef> &Vars,
   requireBoolSort(Body, "Expected boolean quantifier body");
   if (!nativeTupleSupport())
     for (const auto &V : Vars)
-      fatalErrorIf(V->Sort->isTupleSort(),
-                   "Quantifiers over tuple-typed variables are not yet "
-                   "supported on this backend; see issue #17");
+      fatalErrorIf(sortContainsTuple(V->Sort),
+                   "Quantifiers over tuple-typed (or tuple-involving-array) "
+                   "variables are not yet supported on this backend; see "
+                   "issue #17");
   SMTExprRef theExp = mkExistsImpl(Vars, Body);
   assert(theExp->isBoolSort());
   return theExp;
@@ -1560,6 +1588,12 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
   fatalErrorIf(Array->Sort->getIndexSort() != Index->Sort,
                "Expected array index with matching sort");
+  // Tuple-array model extraction is the model-extraction tuple-plan
+  // phase; the bundle has no backend representation to evaluate yet.
+  fatalErrorIf(!nativeTupleSupport() &&
+                   sortContainsTuple(Array->Sort->getElementSort()),
+               "Model extraction for arrays of tuples is not yet supported "
+               "on this backend; see tuple-plan.md");
   if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
     if (SMTExprRef Resolved = resolveLazyArrayElement(Array, Index))
       return Resolved;
@@ -1579,6 +1613,10 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
 
 SMTResult<ArrayModel> SMTSolverImpl::getArrayValues(const SMTExprRef &Array) {
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
+  if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
+    return SMTError{SMTErrorCode::UnsupportedOperation, Array->getBackendKind(),
+                    "Sparse models for arrays of tuples are not yet "
+                    "supported on this backend; see tuple-plan.md"};
   if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
     return lazyArrayModel(Array);
   return getArrayValuesImpl(Array);
@@ -1782,6 +1820,12 @@ SMTExprRef SMTSolverImpl::mkSymbolUnchecked(const std::string &Name,
     SymbolExprCache.emplace(Key, theExp);
     return theExp;
   }
+  if (!nativeTupleSupport() && Sort->isArraySort() &&
+      sortContainsTuple(Sort->getElementSort())) {
+    SMTExprRef theExp = mkCamadaTupleArraySymbol(*this, Name, Sort);
+    SymbolExprCache.emplace(Key, theExp);
+    return theExp;
+  }
 
   SMTExprRef theExp = mkSymbolImpl(Name, Sort);
   assert(theExp->Sort == Sort);
@@ -1889,6 +1933,14 @@ SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
 SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
                                        const SMTExprRef &InitValue,
                                        ConstArrayLowering Lowering) {
+  // Tuple-involving initializers decompose into per-leaf constant arrays;
+  // tracked as the next tuple-plan phase.
+  fatalErrorIf(!nativeTupleSupport() && sortContainsTuple(InitValue->Sort),
+               "Constant arrays of tuples are not yet supported on this "
+               "backend; see tuple-plan.md");
+  fatalErrorIf(!nativeTupleSupport() && sortContainsTuple(IndexSort),
+               "Arrays whose index sort involves a tuple are not supported "
+               "on this backend; see issue #17");
   if (Lowering == ConstArrayLowering::Auto)
     Lowering = nativeConstArraySupport() ? ConstArrayLowering::Native
                                          : ConstArrayLowering::Lazy;

--- a/src/camadatuple.cpp
+++ b/src/camadatuple.cpp
@@ -167,6 +167,176 @@ const CamadaTupleExpr *toCamadaTupleExpr(const SMTExprRef &Exp) {
   return dynamic_cast<const CamadaTupleExpr *>(Exp.get());
 }
 
+/// Array sort whose element involves a tuple, owned by the Camada layer.
+/// Behaves as a normal array sort through the generic accessors
+/// (getIndexSort/getElementSort); additionally carries the flattened
+/// per-leaf array sorts the bundle representation aligns with.
+class CamadaTupleArraySort : public SMTSort {
+public:
+  CamadaTupleArraySort(SMTBackendKind BackendKind, const SMTSortRef &IndexSort,
+                       const SMTSortRef &ElemSort,
+                       std::vector<SMTSortRef> LeafSorts)
+      : SMTSort(SMTSortKind::Array, ArraySortData{IndexSort, ElemSort}),
+        LeafSorts(std::move(LeafSorts)), BackendKind(BackendKind) {}
+
+  SMTBackendKind getBackendKind() const override { return BackendKind; }
+
+  unsigned getWidthFromSolver() const override {
+    fatalError("Width query on Camada-managed tuple-array sort");
+  }
+
+  void dump(std::string &Out) const override {
+    Out = "(CamadaTupleArray";
+    for (const auto &L : LeafSorts) {
+      Out += " ";
+      std::string LeafOut;
+      L->dump(LeafOut);
+      if (!LeafOut.empty() && LeafOut.back() == '\n')
+        LeafOut.pop_back();
+      Out += LeafOut;
+    }
+    Out += ")\n";
+  }
+
+  std::vector<SMTSortRef> LeafSorts;
+
+private:
+  SMTBackendKind BackendKind;
+};
+
+/// Bundle of per-leaf backend arrays representing an array of tuples.
+/// LeafArrays aligns positionally with the sort's LeafSorts; every leaf
+/// is an ordinary backend array expression, so the existing lazy
+/// constant-array, encoded-equality, and model machinery applies per
+/// leaf with no new backend code.
+class CamadaTupleArrayExpr : public SMTExpr {
+public:
+  CamadaTupleArrayExpr(SMTExprKind ExprKind, SMTBackendKind BackendKind,
+                       const SMTSortRef &Sort, std::vector<SMTExprRef> Leaves)
+      : SMTExpr(ExprKind, Sort), LeafArrays(std::move(Leaves)),
+        BackendKind(BackendKind) {}
+
+  SMTBackendKind getBackendKind() const override { return BackendKind; }
+
+  void dump(std::string &Out) const override {
+    Out = "(CamadaTupleArray";
+    for (const auto &L : LeafArrays) {
+      Out += " ";
+      std::string LeafOut;
+      L->dump(LeafOut);
+      if (!LeafOut.empty() && LeafOut.back() == '\n')
+        LeafOut.pop_back();
+      Out += LeafOut;
+    }
+    Out += ")\n";
+  }
+
+  std::vector<SMTExprRef> LeafArrays;
+
+protected:
+  bool equal_to(SMTExpr const &Other) const override {
+    if (Sort != Other.Sort || Other.getBackendKind() != getBackendKind() ||
+        getKind() != Other.getKind())
+      return false;
+    auto const &Rhs = static_cast<const CamadaTupleArrayExpr &>(Other);
+    if (LeafArrays.size() != Rhs.LeafArrays.size())
+      return false;
+    for (std::size_t I = 0; I < LeafArrays.size(); ++I)
+      if (!(*LeafArrays[I] == *Rhs.LeafArrays[I]))
+        return false;
+    return true;
+  }
+
+private:
+  SMTBackendKind BackendKind;
+};
+
+const CamadaTupleArrayExpr *toCamadaTupleArrayExpr(const SMTExprRef &Exp) {
+  if (!Exp || !Exp->Sort->isArraySort())
+    return nullptr;
+  return dynamic_cast<const CamadaTupleArrayExpr *>(Exp.get());
+}
+
+/// Flattened per-leaf array sorts of `Array<Index, Elem>` where Elem
+/// involves a tuple: one `Array<Index, L>` per scalar leaf path L
+/// through Elem, built through the public mkArraySort (leaves contain no
+/// tuples, so these are native sorts — possibly nested arrays).
+void collectLeafSortsOf(SMTSolverImpl &Solver, const SMTSortRef &Sort,
+                        std::vector<SMTSortRef> &Out) {
+  if (Sort->isTupleSort()) {
+    for (const auto &Elem : Sort->getTupleElementSorts())
+      collectLeafSortsOf(Solver, Elem, Out);
+    return;
+  }
+  if (Sort->isArraySort() && sortContainsTuple(Sort->getElementSort())) {
+    std::vector<SMTSortRef> ElemLeaves;
+    collectLeafSortsOf(Solver, Sort->getElementSort(), ElemLeaves);
+    for (const auto &L : ElemLeaves)
+      Out.push_back(Solver.mkArraySort(Sort->getIndexSort(), L));
+    return;
+  }
+  Out.push_back(Sort);
+}
+
+const std::vector<SMTSortRef> &leafSortsOf(const SMTSortRef &Sort) {
+  const auto *AS = dynamic_cast<const CamadaTupleArraySort *>(Sort.get());
+  fatalErrorIf(AS == nullptr, "Expected a Camada-managed tuple-array sort");
+  return AS->LeafSorts;
+}
+
+/// Flatten a value of a tuple-involving sort into its leaf expressions,
+/// in leaf-sort order. Tuple values decompose through the public
+/// mkTupleSelect (which handles symbol/value/ite shapes); tuple-array
+/// values contribute their bundles; scalars and native arrays are leaves.
+void collectLeafExprsOf(SMTSolverImpl &Solver, const SMTExprRef &Value,
+                        std::vector<SMTExprRef> &Out) {
+  if (Value->Sort->isTupleSort()) {
+    const std::size_t Fields = Value->Sort->getTupleElementSorts().size();
+    for (unsigned I = 0; I < Fields; ++I)
+      collectLeafExprsOf(Solver, Solver.mkTupleSelect(Value, I), Out);
+    return;
+  }
+  if (Value->Sort->isArraySort() &&
+      sortContainsTuple(Value->Sort->getElementSort())) {
+    const CamadaTupleArrayExpr *AE = toCamadaTupleArrayExpr(Value);
+    fatalErrorIf(AE == nullptr,
+                 "Tuple-array-sorted expression is not a Camada bundle");
+    Out.insert(Out.end(), AE->LeafArrays.begin(), AE->LeafArrays.end());
+    return;
+  }
+  Out.push_back(Value);
+}
+
+/// Rebuild a value of the given sort from leaf expressions (consumed in
+/// order) — the inverse of collectLeafExprsOf.
+SMTExprRef assembleFromLeaves(SMTSolverImpl &Solver, const SMTSortRef &Sort,
+                              const std::vector<SMTExprRef> &Leaves,
+                              std::size_t &Pos) {
+  if (Sort->isTupleSort()) {
+    std::vector<SMTExprRef> Fields;
+    const auto &ElemSorts = Sort->getTupleElementSorts();
+    Fields.reserve(ElemSorts.size());
+    for (const auto &Elem : ElemSorts)
+      Fields.push_back(assembleFromLeaves(Solver, Elem, Leaves, Pos));
+    return Solver.mkTuple(Fields);
+  }
+  if (Sort->isArraySort() && sortContainsTuple(Sort->getElementSort())) {
+    std::vector<SMTSortRef> SubLeafSorts;
+    collectLeafSortsOf(Solver, Sort, SubLeafSorts);
+    std::vector<SMTExprRef> SubLeaves;
+    SubLeaves.reserve(SubLeafSorts.size());
+    for (std::size_t I = 0; I < SubLeafSorts.size(); ++I) {
+      fatalErrorIf(Pos >= Leaves.size(), "Tuple-array leaf underflow");
+      SubLeaves.push_back(Leaves[Pos++]);
+    }
+    return Solver.makeExprRef<CamadaTupleArrayExpr>(SMTExprKind::ArrayConst,
+                                                    Sort->getBackendKind(),
+                                                    Sort, std::move(SubLeaves));
+  }
+  fatalErrorIf(Pos >= Leaves.size(), "Tuple-array leaf underflow");
+  return Leaves[Pos++];
+}
+
 } // namespace
 
 SMTSortRef mkCamadaTupleSort(SMTSolverImpl &Solver,
@@ -251,6 +421,111 @@ SMTExprRef mkCamadaTupleIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
                "mkCamadaTupleIte on non-tuple branches");
   return Solver.makeExprRef<CamadaTupleExpr>(
       SMTExprKind::Ite, T->getBackendKind(), T->Sort, Cond, T, F);
+}
+
+bool sortContainsTuple(const SMTSortRef &Sort) {
+  if (Sort->isTupleSort())
+    return true;
+  if (Sort->isArraySort())
+    return sortContainsTuple(Sort->getElementSort());
+  return false;
+}
+
+SMTSortRef mkCamadaTupleArraySort(SMTSolverImpl &Solver,
+                                  const SMTSortRef &IndexSort,
+                                  const SMTSortRef &ElemSort) {
+  fatalErrorIf(!sortContainsTuple(ElemSort),
+               "mkCamadaTupleArraySort on a tuple-free element sort");
+  std::vector<SMTSortRef> LeafSorts;
+  collectLeafSortsOf(Solver, ElemSort, LeafSorts);
+  for (auto &Leaf : LeafSorts)
+    Leaf = Solver.mkArraySort(IndexSort, Leaf);
+  return Solver.makeSortRef(CamadaTupleArraySort(
+      IndexSort->getBackendKind(), IndexSort, ElemSort, std::move(LeafSorts)));
+}
+
+SMTExprRef mkCamadaTupleArraySymbol(SMTSolverImpl &Solver,
+                                    const std::string &Name,
+                                    const SMTSortRef &Sort) {
+  const std::vector<SMTSortRef> &LeafSorts = leafSortsOf(Sort);
+  std::vector<SMTExprRef> Leaves;
+  Leaves.reserve(LeafSorts.size());
+  for (std::size_t I = 0; I < LeafSorts.size(); ++I)
+    Leaves.push_back(Solver.mkSymbolUnchecked(
+        "__CAMADA_tuparr_" + Name + "_" + std::to_string(I), LeafSorts[I]));
+  return Solver.makeExprRef<CamadaTupleArrayExpr>(
+      SMTExprKind::Symbol, Sort->getBackendKind(), Sort, std::move(Leaves));
+}
+
+SMTExprRef mkCamadaTupleArraySelect(SMTSolverImpl &Solver,
+                                    const SMTExprRef &Array,
+                                    const SMTExprRef &Index) {
+  const CamadaTupleArrayExpr *AE = toCamadaTupleArrayExpr(Array);
+  fatalErrorIf(AE == nullptr,
+               "mkCamadaTupleArraySelect on a non-bundle expression");
+  std::vector<SMTExprRef> SelectedLeaves;
+  SelectedLeaves.reserve(AE->LeafArrays.size());
+  for (const auto &Leaf : AE->LeafArrays)
+    SelectedLeaves.push_back(Solver.mkArraySelect(Leaf, Index));
+  std::size_t Pos = 0;
+  SMTExprRef Element = assembleFromLeaves(Solver, Array->Sort->getElementSort(),
+                                          SelectedLeaves, Pos);
+  fatalErrorIf(Pos != SelectedLeaves.size(), "Tuple-array leaf overflow");
+  return Element;
+}
+
+SMTExprRef mkCamadaTupleArrayStore(SMTSolverImpl &Solver,
+                                   const SMTExprRef &Array,
+                                   const SMTExprRef &Index,
+                                   const SMTExprRef &Element) {
+  const CamadaTupleArrayExpr *AE = toCamadaTupleArrayExpr(Array);
+  fatalErrorIf(AE == nullptr,
+               "mkCamadaTupleArrayStore on a non-bundle expression");
+  std::vector<SMTExprRef> ElementLeaves;
+  collectLeafExprsOf(Solver, Element, ElementLeaves);
+  fatalErrorIf(ElementLeaves.size() != AE->LeafArrays.size(),
+               "Tuple-array store leaf count mismatch");
+  std::vector<SMTExprRef> StoredLeaves;
+  StoredLeaves.reserve(AE->LeafArrays.size());
+  for (std::size_t I = 0; I < AE->LeafArrays.size(); ++I)
+    StoredLeaves.push_back(
+        Solver.mkArrayStore(AE->LeafArrays[I], Index, ElementLeaves[I]));
+  return Solver.makeExprRef<CamadaTupleArrayExpr>(
+      SMTExprKind::ArrayStore, Array->getBackendKind(), Array->Sort,
+      std::move(StoredLeaves));
+}
+
+SMTExprRef mkCamadaTupleArrayEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
+                                   const SMTExprRef &RHS) {
+  const CamadaTupleArrayExpr *LE = toCamadaTupleArrayExpr(LHS);
+  const CamadaTupleArrayExpr *RE = toCamadaTupleArrayExpr(RHS);
+  fatalErrorIf(LE == nullptr || RE == nullptr,
+               "mkCamadaTupleArrayEqual on a non-bundle expression");
+  fatalErrorIf(LE->LeafArrays.size() != RE->LeafArrays.size(),
+               "Tuple-array equality leaf count mismatch");
+  if (LE->LeafArrays.empty())
+    return Solver.mkBool(true);
+  SMTExprRef Acc = Solver.mkEqual(LE->LeafArrays[0], RE->LeafArrays[0]);
+  for (std::size_t I = 1; I < LE->LeafArrays.size(); ++I)
+    Acc =
+        Solver.mkAnd(Acc, Solver.mkEqual(LE->LeafArrays[I], RE->LeafArrays[I]));
+  return Acc;
+}
+
+SMTExprRef mkCamadaTupleArrayIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
+                                 const SMTExprRef &T, const SMTExprRef &F) {
+  const CamadaTupleArrayExpr *TE = toCamadaTupleArrayExpr(T);
+  const CamadaTupleArrayExpr *FE = toCamadaTupleArrayExpr(F);
+  fatalErrorIf(TE == nullptr || FE == nullptr,
+               "mkCamadaTupleArrayIte on a non-bundle expression");
+  fatalErrorIf(TE->LeafArrays.size() != FE->LeafArrays.size(),
+               "Tuple-array ite leaf count mismatch");
+  std::vector<SMTExprRef> Leaves;
+  Leaves.reserve(TE->LeafArrays.size());
+  for (std::size_t I = 0; I < TE->LeafArrays.size(); ++I)
+    Leaves.push_back(Solver.mkIte(Cond, TE->LeafArrays[I], FE->LeafArrays[I]));
+  return Solver.makeExprRef<CamadaTupleArrayExpr>(
+      SMTExprKind::Ite, T->getBackendKind(), T->Sort, std::move(Leaves));
 }
 
 } // namespace camada

--- a/src/camadatuple.h
+++ b/src/camadatuple.h
@@ -58,6 +58,43 @@ SMTExprRef mkCamadaTupleEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
 SMTExprRef mkCamadaTupleIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
                             const SMTExprRef &T, const SMTExprRef &F);
 
+/// True when Sort is a tuple sort or an array sort whose element sort
+/// (recursively) involves a tuple. Drives the decomposed tuple-array
+/// dispatch: such sorts have no backend representation on backends
+/// without native datatype support.
+bool sortContainsTuple(const SMTSortRef &Sort);
+
+/// Camada-managed arrays of tuples: an `Array<Idx, T>` where T involves a
+/// tuple is represented as a bundle of per-leaf-field backend arrays —
+/// `Array<Idx, Tuple{BV32, Tuple{Bool}}>` becomes `{Array<Idx, BV32>,
+/// Array<Idx, Bool>}`. The tuple structure is dissolved at the Camada
+/// layer; all array reasoning stays in the backend's native theory.
+/// Operations recurse leaf-wise, so arbitrary tuple/array nesting
+/// flattens to native nested-arrays-of-scalars.
+
+SMTSortRef mkCamadaTupleArraySort(SMTSolverImpl &Solver,
+                                  const SMTSortRef &IndexSort,
+                                  const SMTSortRef &ElemSort);
+
+SMTExprRef mkCamadaTupleArraySymbol(SMTSolverImpl &Solver,
+                                    const std::string &Name,
+                                    const SMTSortRef &Sort);
+
+SMTExprRef mkCamadaTupleArraySelect(SMTSolverImpl &Solver,
+                                    const SMTExprRef &Array,
+                                    const SMTExprRef &Index);
+
+SMTExprRef mkCamadaTupleArrayStore(SMTSolverImpl &Solver,
+                                   const SMTExprRef &Array,
+                                   const SMTExprRef &Index,
+                                   const SMTExprRef &Element);
+
+SMTExprRef mkCamadaTupleArrayEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
+                                   const SMTExprRef &RHS);
+
+SMTExprRef mkCamadaTupleArrayIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
+                                 const SMTExprRef &T, const SMTExprRef &F);
+
 } // namespace camada
 
 #endif

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -131,6 +131,11 @@ SMTSortRef STPSolver::mkBVRMSortImpl() {
 
 SMTSortRef STPSolver::mkArraySortImpl(const SMTSortRef &IndexSort,
                                       const SMTSortRef &ElemSort) {
+  // STP's array theory is strictly BV-indexed, BV-valued (bools are
+  // adapted below); arrays of arrays do not exist in it, and passing one
+  // through would trip STP's own fatal handler with a cryptic message.
+  fatalErrorIf(IndexSort->isArraySort() || ElemSort->isArraySort(),
+               "Nested arrays are not supported by STP");
   const SMTSortRef &backend_elem_sort =
       ElemSort->isBoolSort() ? mkBVSort(1) : ElemSort;
   return makeSortRef<STPSort>(


### PR DESCRIPTION
Phase 3 of the tuple plan (`tuple-plan.md`): the decomposed tuple-array core for backends without datatype support.

## What

Arrays whose element sort involves tuples are decomposed into one native array per scalar leaf, using the isomorphism `Array<I, Tuple{...}> ≅ Tuple{Array<I, ...>}` applied recursively. Leaves of arbitrarily nested tuple/array combinations become native nested-arrays-of-scalars, so the backend's array theory keeps handling each leaf — no software array encoding.

- `CamadaTupleArraySort` carries the flattened leaf sorts; `CamadaTupleArrayExpr` carries the leaf array expressions (structural equality).
- `collectLeafSortsOf` / `collectLeafExprsOf` / `assembleFromLeaves` implement the recursive flatten/assemble algebra.
- `mkArraySort`, `mkSymbolUnchecked`, `mkArraySelect`, `mkArrayStore`, `mkEqual`, and `mkIte` dispatch to the decomposed path when `sortContainsTuple(ElementSort)` and the backend lacks native tuple support. Leaf operations re-enter the public wrappers, so the v0.12 machinery (lazy const-array defaults, encoded array equality, index observation) applies per leaf unchanged.
- Dispatch boundaries hardened: tuple-involving sorts are rejected in `mkFunctionSort` domains/codomains, quantifier bound variables, array index sorts, and `mkArrayConst` index sorts (previously only plain tuple sorts were caught).
- Constant arrays of tuples (`mkArrayConst`) and model extraction (`getArrayElement` / `getArrayValues`) fail loudly — they are phases 4 and 5.
- STP: `mkArraySortImpl` now reports "Nested arrays are not supported by STP" instead of silently misbehaving (decomposition can produce nested-array leaves, which STP's array theory lacks).

## Tests

- `tuple_array_semantics`: store/select roundtrip, untouched-index preservation, read-over-write at symbolic indexes, and a homogeneous-field leaf-order identity pin.
- `tuple_array_equality_ite`: equality congruence through tuple-field reads, ite distribution over leaves.
- `tuple_array_deep_nesting` (per backend with nested-array support: Z3, CVC5, Bitwuzla, MathSAT, Yices): 5-level `Tuple{Bool, Array<BV4, Tuple{BV8, Array<BV4, Tuple{Bool, BV8}}>}>` walk-down/store/rebuild/read-back, plus untouched-path preservation under equality.
- STP: `require_abort` pins for nested arrays and the tuple-array UF boundary.

Full suite: 171/171 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
