### PR TITLE
Support constant arrays of tuples through per-leaf lowering

### DIFF
--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -183,3 +183,17 @@ TEST_CASE("Deep tuple/array nesting Bitwuzla test", "[Bitwuzla]") {
   auto solver = camada::createBitwuzlaSolver();
   tuple_array_deep_nesting(solver);
 }
+
+// Nested constant tuple arrays need every per-leaf constant array to
+// nest, and lazily lowered constant arrays cannot — pin the abort.
+TEST_CASE("Unsupported nested constant tuple arrays Bitwuzla test",
+          "[Bitwuzla]") {
+  auto solver = camada::createBitwuzlaSolver();
+  require_abort([&]() {
+    auto bv4 = solver->mkBVSort(4);
+    auto init =
+        solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(5, 8)});
+    auto innerConst = solver->mkArrayConst(bv4, init);
+    (void)solver->mkArrayConst(bv4, innerConst);
+  });
+}

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -162,3 +162,10 @@ TEST_CASE("Deep tuple/array nesting CVC5 test", "[CVC5]") {
   auto solver = camada::createCVC5Solver();
   tuple_array_deep_nesting(solver);
 }
+
+// Registered per backend: nested constant arrays require native constant
+// arrays (lazily lowered constant arrays cannot nest).
+TEST_CASE("Nested constant tuple arrays CVC5 test", "[CVC5]") {
+  auto solver = camada::createCVC5Solver();
+  tuple_array_const_nested(solver);
+}

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -240,3 +240,12 @@ TEST_CASE("Deep tuple/array nesting MathSAT test", "[MathSAT]") {
   auto solver = camada::createMathSATSolver();
   tuple_array_deep_nesting(solver);
 }
+
+// Registered per backend: nested constant arrays require native constant
+// arrays (lazily lowered constant arrays cannot nest). MathSAT is the
+// one decomposed-path backend where they do — the per-leaf constant
+// arrays lower natively, so nesting is just an array-sorted initializer.
+TEST_CASE("Nested constant tuple arrays MathSAT test", "[MathSAT]") {
+  auto solver = camada::createMathSATSolver();
+  tuple_array_const_nested(solver);
+}

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -50,3 +50,13 @@ TEST_CASE("Unsupported tuple-array UF/quantifier boundaries STP test",
     (void)stp->mkFunctionSort({tupArr}, bv4);
   });
 }
+
+TEST_CASE("Unsupported nested constant tuple arrays STP test", "[STP]") {
+  auto stp = camada::createSTPSolver();
+  require_abort([&]() {
+    auto bv4 = stp->mkBVSort(4);
+    auto init = stp->mkTuple({stp->mkBool(true), stp->mkBVFromDec(5, 8)});
+    auto innerConst = stp->mkArrayConst(bv4, init);
+    (void)stp->mkArrayConst(bv4, innerConst);
+  });
+}

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -82,6 +82,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(tuple_structural_equality);
   RESETANDTEST(tuple_array_semantics);
   RESETANDTEST(tuple_array_equality_ite);
+  RESETANDTEST(tuple_array_const);
+  RESETANDARGTEST(tuple_array_const, LazyArrays);
   RESETANDTEST(empty_tuple_semantics);
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -229,6 +229,93 @@ inline void tuple_array_equality_ite(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::checkResult::UNSAT);
 }
 
+// Constant arrays of tuples: on backends without native datatypes the
+// initializer decomposes into one constant array per scalar leaf (each
+// lowered natively or lazily per the backend); native backends lower
+// the whole thing directly. Checks are solver-side only — model
+// extraction on decomposed arrays is a later tuple-plan phase.
+inline void tuple_array_const(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+
+  // The default value is visible at an arbitrary symbolic index.
+  auto init = solver->mkTuple({solver->mkBool(true), idx(170)});
+  auto arr = solver->mkArrayConst(bv8, init, Lowering);
+  auto i = solver->mkSymbol("i", bv8);
+  solver->addConstraint(
+      solver->mkNot(solver->mkEqual(solver->mkArraySelect(arr, i), init)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Store over the constant array: the stored tuple at the written
+  // index, the default elsewhere.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  init = solver->mkTuple({solver->mkBool(false), idx(7)});
+  auto stored = solver->mkTuple({solver->mkBool(true), idx(99)});
+  auto upd = solver->mkArrayStore(solver->mkArrayConst(bv8, init, Lowering),
+                                  idx(3), stored);
+  auto ok =
+      solver->mkAnd(solver->mkEqual(solver->mkArraySelect(upd, idx(3)), stored),
+                    solver->mkEqual(solver->mkArraySelect(upd, idx(5)), init));
+  solver->addConstraint(solver->mkNot(ok));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // The default survives a store made inside a pushed scope: after pop,
+  // reads at the previously written index see the default again.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  init = solver->mkTuple({solver->mkBool(true), idx(21)});
+  auto arr3 = solver->mkArrayConst(bv8, init, Lowering);
+  solver->push();
+  auto scratch = solver->mkTuple({solver->mkBool(false), idx(1)});
+  auto inPush = solver->mkArrayStore(arr3, idx(2), scratch);
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(inPush, idx(2)), scratch));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  solver->pop();
+  solver->addConstraint(solver->mkNot(
+      solver->mkEqual(solver->mkArraySelect(arr3, idx(2)), init)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Homogeneous fields pin per-leaf default order semantically: a leaf
+  // transposition would hand 22 to field 0 with no sort mismatch.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  auto homoInit = solver->mkTuple({idx(11), idx(22)});
+  auto homoArr = solver->mkArrayConst(bv8, homoInit, Lowering);
+  auto k = solver->mkSymbol("k", bv8);
+  auto homoRd = solver->mkArraySelect(homoArr, k);
+  auto fieldsOk =
+      solver->mkAnd(solver->mkEqual(solver->mkTupleSelect(homoRd, 0), idx(11)),
+                    solver->mkEqual(solver->mkTupleSelect(homoRd, 1), idx(22)));
+  solver->addConstraint(solver->mkNot(fieldsOk));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Nested constant arrays of tuples: array_of(array_of(tuple)). On the
+// decomposed path the inner constant array's leaves become the per-leaf
+// initializers of the outer one. Registered per backend: lazily lowered
+// constant arrays cannot nest (bitwuzla/yices/stp abort), so this runs
+// only where constant arrays are native.
+inline void tuple_array_const_nested(const camada::SMTSolverRef &solver) {
+  auto bv4 = solver->mkBVSort(4);
+  auto init =
+      solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(5, 8)});
+  auto innerConst = solver->mkArrayConst(bv4, init);
+  auto outerConst = solver->mkArrayConst(bv4, innerConst);
+
+  auto i = solver->mkSymbol("i", bv4);
+  auto j = solver->mkSymbol("j", bv4);
+  auto rd = solver->mkArraySelect(solver->mkArraySelect(outerConst, i), j);
+  // Guard against a vacuously UNSAT context (e.g. contradictory default
+  // axioms) before pinning the property itself.
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(rd, init)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
 // Deep nesting: tuple { array of tuple { bv, array of tuple { bool, bv } } }
 // — five levels of alternation; everything must flatten to native
 // nested-arrays-of-scalars and recurse leaf-wise.

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -238,3 +238,16 @@ TEST_CASE("Deep tuple/array nesting Yices test", "[Yices]") {
   auto solver = camada::createYicesSolver();
   tuple_array_deep_nesting(solver);
 }
+
+// Nested constant tuple arrays need every per-leaf constant array to
+// nest, and lazily lowered constant arrays cannot — pin the abort.
+TEST_CASE("Unsupported nested constant tuple arrays Yices test", "[Yices]") {
+  auto solver = camada::createYicesSolver();
+  require_abort([&]() {
+    auto bv4 = solver->mkBVSort(4);
+    auto init =
+        solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(5, 8)});
+    auto innerConst = solver->mkArrayConst(bv4, init);
+    (void)solver->mkArrayConst(bv4, innerConst);
+  });
+}

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -193,3 +193,10 @@ TEST_CASE("Deep tuple/array nesting Z3 test", "[Z3]") {
   auto solver = camada::createZ3Solver();
   tuple_array_deep_nesting(solver);
 }
+
+// Registered per backend: nested constant arrays require native constant
+// arrays (lazily lowered constant arrays cannot nest).
+TEST_CASE("Nested constant tuple arrays Z3 test", "[Z3]") {
+  auto solver = camada::createZ3Solver();
+  tuple_array_const_nested(solver);
+}

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -1933,11 +1933,6 @@ SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
 SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
                                        const SMTExprRef &InitValue,
                                        ConstArrayLowering Lowering) {
-  // Tuple-involving initializers decompose into per-leaf constant arrays;
-  // tracked as the next tuple-plan phase.
-  fatalErrorIf(!nativeTupleSupport() && sortContainsTuple(InitValue->Sort),
-               "Constant arrays of tuples are not yet supported on this "
-               "backend; see tuple-plan.md");
   fatalErrorIf(!nativeTupleSupport() && sortContainsTuple(IndexSort),
                "Arrays whose index sort involves a tuple are not supported "
                "on this backend; see issue #17");
@@ -1947,6 +1942,11 @@ SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
   fatalErrorIf(Lowering == ConstArrayLowering::Native &&
                    !nativeConstArraySupport(),
                "Native constant arrays are not supported by this backend");
+  // Tuple-involving initializers decompose into one constant array per
+  // scalar leaf; the per-leaf calls re-enter this wrapper, so the resolved
+  // lowering (and its lazy machinery) applies per leaf.
+  if (!nativeTupleSupport() && sortContainsTuple(InitValue->Sort))
+    return mkCamadaTupleArrayConst(*this, IndexSort, InitValue, Lowering);
   SMTExprRef theExp = Lowering == ConstArrayLowering::Native
                           ? mkArrayConstImpl(IndexSort, InitValue)
                           : mkLazyConstArray(IndexSort, InitValue);

--- a/src/camadatuple.cpp
+++ b/src/camadatuple.cpp
@@ -495,6 +495,23 @@ SMTExprRef mkCamadaTupleArrayStore(SMTSolverImpl &Solver,
       std::move(StoredLeaves));
 }
 
+SMTExprRef mkCamadaTupleArrayConst(SMTSolverImpl &Solver,
+                                   const SMTSortRef &IndexSort,
+                                   const SMTExprRef &InitValue,
+                                   ConstArrayLowering Lowering) {
+  fatalErrorIf(!sortContainsTuple(InitValue->Sort),
+               "mkCamadaTupleArrayConst on a tuple-free initializer");
+  SMTSortRef Sort = Solver.mkArraySort(IndexSort, InitValue->Sort);
+  std::vector<SMTExprRef> InitLeaves;
+  collectLeafExprsOf(Solver, InitValue, InitLeaves);
+  std::vector<SMTExprRef> Leaves;
+  Leaves.reserve(InitLeaves.size());
+  for (const auto &Init : InitLeaves)
+    Leaves.push_back(Solver.mkArrayConst(IndexSort, Init, Lowering));
+  return Solver.makeExprRef<CamadaTupleArrayExpr>(
+      SMTExprKind::ArrayConst, Sort->getBackendKind(), Sort, std::move(Leaves));
+}
+
 SMTExprRef mkCamadaTupleArrayEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
   const CamadaTupleArrayExpr *LE = toCamadaTupleArrayExpr(LHS);

--- a/src/camadatuple.h
+++ b/src/camadatuple.h
@@ -89,6 +89,11 @@ SMTExprRef mkCamadaTupleArrayStore(SMTSolverImpl &Solver,
                                    const SMTExprRef &Index,
                                    const SMTExprRef &Element);
 
+SMTExprRef mkCamadaTupleArrayConst(SMTSolverImpl &Solver,
+                                   const SMTSortRef &IndexSort,
+                                   const SMTExprRef &InitValue,
+                                   ConstArrayLowering Lowering);
+
 SMTExprRef mkCamadaTupleArrayEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
                                    const SMTExprRef &RHS);
 


### PR DESCRIPTION
Phase 4 of the tuple plan (`tuple-plan.md`): constant arrays of tuples. **Stacked on #100** (phase 3, the decomposed tuple-array core) — merge that first; this PR's own diff is the last commit.

## What

`mkArrayConst` with a tuple-involving initializer now decomposes into one constant array per scalar leaf instead of failing loudly:

- `mkCamadaTupleArrayConst` flattens the initializer with the phase-3 leaf algebra and calls the public `mkArrayConst` per leaf, bundling the results into a `CamadaTupleArrayExpr`. Because each leaf re-enters the public wrapper, the resolved `ConstArrayLowering` (`Native` or `Lazy`) and all of the v0.12 lazy machinery (default axioms, sort-global index observation, pop-time re-assertion) apply per leaf unchanged.
- In `SMTSolverImpl::mkArrayConst`, `Auto` is resolved and the `Native`-vs-capability check fires *before* decomposition, so an impossible lowering request aborts identically on tuple and non-tuple paths. Non-tuple callers see no behavioral change.
- Nested constant arrays of tuples (`array_of(array_of(tuple))`) work where constant arrays are native — MathSAT is the interesting case: the one decomposed-path backend where the per-leaf constant arrays lower natively, so nesting is just an array-sorted initializer. On lazy-lowering backends (Bitwuzla, Yices, STP) the existing lazily-lowered-arrays-cannot-nest guard aborts with a clear message; no new restriction was added.

This covers ESBMC's `pointer_array_of` scenario (constant arrays of 2-field pointer tuples) named in the plan.

## Tests

- `tuple_array_const` (shared suite, run under both `Auto` and explicit `Lazy` lowering on all 7 backends): default visible at a symbolic index; store-over-const reads the stored tuple at the written index and the default elsewhere; the default survives a store made inside a pushed scope after pop; a homogeneous-field case pins per-leaf default order semantically.
- `tuple_array_const_nested` (per backend): success pinned on Z3, CVC5, and MathSAT with a SAT guard against a vacuously inconsistent context; `require_abort` pins on Bitwuzla, Yices, and STP.

Code-reviewer findings (vacuous-UNSAT guard, homogeneous-field ordering case, missing STP abort pin) are applied. Full suite: 177/177 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
