### PR TITLE
Implement the custom tuple subsystem (tuple updates, tuple arrays, const arrays, models)

### DIFF
--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -176,3 +176,10 @@ TEST_CASE("Bitwuzla feature capabilities", "[Bitwuzla]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting Bitwuzla test", "[Bitwuzla]") {
+  auto solver = camada::createBitwuzlaSolver();
+  tuple_array_deep_nesting(solver);
+}

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -183,3 +183,17 @@ TEST_CASE("Deep tuple/array nesting Bitwuzla test", "[Bitwuzla]") {
   auto solver = camada::createBitwuzlaSolver();
   tuple_array_deep_nesting(solver);
 }
+
+// Nested constant tuple arrays need every per-leaf constant array to
+// nest, and lazily lowered constant arrays cannot — pin the abort.
+TEST_CASE("Unsupported nested constant tuple arrays Bitwuzla test",
+          "[Bitwuzla]") {
+  auto solver = camada::createBitwuzlaSolver();
+  require_abort([&]() {
+    auto bv4 = solver->mkBVSort(4);
+    auto init =
+        solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(5, 8)});
+    auto innerConst = solver->mkArrayConst(bv4, init);
+    (void)solver->mkArrayConst(bv4, innerConst);
+  });
+}

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -155,3 +155,10 @@ TEST_CASE("CVC5 feature capabilities", "[CVC5]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting CVC5 test", "[CVC5]") {
+  auto solver = camada::createCVC5Solver();
+  tuple_array_deep_nesting(solver);
+}

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -162,3 +162,10 @@ TEST_CASE("Deep tuple/array nesting CVC5 test", "[CVC5]") {
   auto solver = camada::createCVC5Solver();
   tuple_array_deep_nesting(solver);
 }
+
+// Registered per backend: nested constant arrays require native constant
+// arrays (lazily lowered constant arrays cannot nest).
+TEST_CASE("Nested constant tuple arrays CVC5 test", "[CVC5]") {
+  auto solver = camada::createCVC5Solver();
+  tuple_array_const_nested(solver);
+}

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -240,3 +240,12 @@ TEST_CASE("Deep tuple/array nesting MathSAT test", "[MathSAT]") {
   auto solver = camada::createMathSATSolver();
   tuple_array_deep_nesting(solver);
 }
+
+// Registered per backend: nested constant arrays require native constant
+// arrays (lazily lowered constant arrays cannot nest). MathSAT is the
+// one decomposed-path backend where they do — the per-leaf constant
+// arrays lower natively, so nesting is just an array-sorted initializer.
+TEST_CASE("Nested constant tuple arrays MathSAT test", "[MathSAT]") {
+  auto solver = camada::createMathSATSolver();
+  tuple_array_const_nested(solver);
+}

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -233,3 +233,10 @@ TEST_CASE("MathSAT feature capabilities", "[MathSAT]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting MathSAT test", "[MathSAT]") {
+  auto solver = camada::createMathSATSolver();
+  tuple_array_deep_nesting(solver);
+}

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -50,3 +50,13 @@ TEST_CASE("Unsupported tuple-array UF/quantifier boundaries STP test",
     (void)stp->mkFunctionSort({tupArr}, bv4);
   });
 }
+
+TEST_CASE("Unsupported nested constant tuple arrays STP test", "[STP]") {
+  auto stp = camada::createSTPSolver();
+  require_abort([&]() {
+    auto bv4 = stp->mkBVSort(4);
+    auto init = stp->mkTuple({stp->mkBool(true), stp->mkBVFromDec(5, 8)});
+    auto innerConst = stp->mkArrayConst(bv4, init);
+    (void)stp->mkArrayConst(bv4, innerConst);
+  });
+}

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -32,3 +32,21 @@ TEST_CASE("STP feature capabilities", "[STP]") {
   REQUIRE_FALSE(solver->supports(SolverFeature::Timeouts));
   REQUIRE_FALSE(solver->supports(SolverFeature::ArrayModels));
 }
+
+TEST_CASE("Unsupported nested arrays STP test", "[STP]") {
+  auto stp = camada::createSTPSolver();
+  require_abort([&]() {
+    auto bv4 = stp->mkBVSort(4);
+    (void)stp->mkArraySort(bv4, stp->mkArraySort(bv4, bv4));
+  });
+}
+
+TEST_CASE("Unsupported tuple-array UF/quantifier boundaries STP test",
+          "[STP]") {
+  auto stp = camada::createSTPSolver();
+  require_abort([&]() {
+    auto bv4 = stp->mkBVSort(4);
+    auto tupArr = stp->mkArraySort(bv4, stp->mkTupleSort({bv4}));
+    (void)stp->mkFunctionSort({tupArr}, bv4);
+  });
+}

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -83,6 +83,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(tuple_structural_equality);
   RESETANDTEST(tuple_array_semantics);
   RESETANDTEST(tuple_array_equality_ite);
+  RESETANDTEST(tuple_array_const);
+  RESETANDARGTEST(tuple_array_const, LazyArrays);
   RESETANDTEST(empty_tuple_semantics);
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -79,6 +79,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(const_array_lowering_interop);
   RESETANDTEST(tuple_semantics);
   RESETANDTEST(tuple_with_array_field);
+  RESETANDTEST(tuple_update_semantics);
   RESETANDTEST(tuple_structural_equality);
   RESETANDTEST(empty_tuple_semantics);
   RESETANDTEST(dump_string_semantics);

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -85,6 +85,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(tuple_array_equality_ite);
   RESETANDTEST(tuple_array_const);
   RESETANDARGTEST(tuple_array_const, LazyArrays);
+  RESETANDTEST(tuple_array_model_values);
+  RESETANDARGTEST(tuple_array_model_values, LazyArrays);
   RESETANDTEST(empty_tuple_semantics);
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -81,6 +81,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(tuple_with_array_field);
   RESETANDTEST(tuple_update_semantics);
   RESETANDTEST(tuple_structural_equality);
+  RESETANDTEST(tuple_array_semantics);
+  RESETANDTEST(tuple_array_equality_ite);
   RESETANDTEST(empty_tuple_semantics);
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -105,6 +105,138 @@ inline void tuple_with_array_field(const camada::SMTSolverRef &solver) {
 // compare unequal. Native-tuple backends already get this for free via
 // their backend term; the encoded path needs to implement it on
 // CamadaTupleExpr explicitly.
+// mkTupleUpdate is ESBMC's `with`-on-struct choke point: a tuple equal
+// to the original except at one field. Bool + BV only, like
+// tuple_semantics, so every backend (native datatypes and the Camada
+// per-field lowering) runs it.
+inline void tuple_update_semantics(const camada::SMTSolverRef &solver) {
+  auto boolSort = solver->mkBoolSort();
+  auto bv8Sort = solver->mkBVSort(8);
+  auto tupleSort = solver->mkTupleSort({boolSort, bv8Sort, bv8Sort});
+
+  // Value tuple: the updated field changes, the others are preserved.
+  auto t = solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(1, 8),
+                            solver->mkBVFromDec(2, 8)});
+  auto u = solver->mkTupleUpdate(t, 1, solver->mkBVFromDec(9, 8));
+  REQUIRE(u->Sort == t->Sort);
+  auto expected =
+      solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(9, 8),
+                       solver->mkBVFromDec(2, 8)});
+  solver->addConstraint(solver->mkNot(solver->mkEqual(u, expected)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Symbol tuple: non-updated fields stay tied to the original symbol's
+  // fields, and the updated field equals the new value.
+  solver->reset();
+  boolSort = solver->mkBoolSort();
+  bv8Sort = solver->mkBVSort(8);
+  tupleSort = solver->mkTupleSort({boolSort, bv8Sort, bv8Sort});
+  auto s = solver->mkSymbol("st", tupleSort);
+  auto v = solver->mkTupleUpdate(s, 2, solver->mkBVFromDec(7, 8));
+  auto preserved = solver->mkAnd(
+      solver->mkEqual(solver->mkTupleSelect(v, 0), solver->mkTupleSelect(s, 0)),
+      solver->mkEqual(solver->mkTupleSelect(v, 1),
+                      solver->mkTupleSelect(s, 1)));
+  auto updated =
+      solver->mkEqual(solver->mkTupleSelect(v, 2), solver->mkBVFromDec(7, 8));
+  solver->addConstraint(solver->mkNot(solver->mkAnd(preserved, updated)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Chained updates of the same field — ESBMC's pointer-arithmetic hot
+  // pattern — collapse to the last value with the other fields preserved.
+  solver->reset();
+  boolSort = solver->mkBoolSort();
+  bv8Sort = solver->mkBVSort(8);
+  tupleSort = solver->mkTupleSort({boolSort, bv8Sort, bv8Sort});
+  auto base = solver->mkSymbol("base", tupleSort);
+  auto twice = solver->mkTupleUpdate(
+      solver->mkTupleUpdate(base, 1, solver->mkBVFromDec(1, 8)), 1,
+      solver->mkBVFromDec(2, 8));
+  auto chainOk = solver->mkAnd(solver->mkEqual(solver->mkTupleSelect(twice, 1),
+                                               solver->mkBVFromDec(2, 8)),
+                               solver->mkEqual(solver->mkTupleSelect(twice, 2),
+                                               solver->mkTupleSelect(base, 2)));
+  solver->addConstraint(solver->mkNot(chainOk));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Update of an ite-shaped tuple distributes through both branches.
+  solver->reset();
+  boolSort = solver->mkBoolSort();
+  bv8Sort = solver->mkBVSort(8);
+  tupleSort = solver->mkTupleSort({boolSort, bv8Sort, bv8Sort});
+  auto ta = solver->mkSymbol("ta", tupleSort);
+  auto tb = solver->mkSymbol("tb", tupleSort);
+  auto cond = solver->mkSymbol("cond", solver->mkBoolSort());
+  auto picked = solver->mkIte(cond, ta, tb);
+  auto pickedUpd = solver->mkTupleUpdate(picked, 1, solver->mkBVFromDec(4, 8));
+  auto iteOk = solver->mkAnd(
+      solver->mkEqual(solver->mkTupleSelect(pickedUpd, 1),
+                      solver->mkBVFromDec(4, 8)),
+      solver->mkEqual(solver->mkTupleSelect(pickedUpd, 2),
+                      solver->mkIte(cond, solver->mkTupleSelect(ta, 2),
+                                    solver->mkTupleSelect(tb, 2))));
+  solver->addConstraint(solver->mkNot(iteOk));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Updating the scalar field of a tuple that carries an array field
+  // composes with the verbatim array storage in the Camada lowering.
+  solver->reset();
+  bv8Sort = solver->mkBVSort(8);
+  auto arrSort = solver->mkArraySort(bv8Sort, bv8Sort);
+  auto mixSort = solver->mkTupleSort({bv8Sort, arrSort});
+  auto mix = solver->mkSymbol("mix", mixSort);
+  auto mixUpd = solver->mkTupleUpdate(mix, 0, solver->mkBVFromDec(6, 8));
+  auto arrPreserved =
+      solver->mkEqual(solver->mkArraySelect(solver->mkTupleSelect(mixUpd, 1),
+                                            solver->mkBVFromDec(0, 8)),
+                      solver->mkArraySelect(solver->mkTupleSelect(mix, 1),
+                                            solver->mkBVFromDec(0, 8)));
+  auto scalarUpdated = solver->mkEqual(solver->mkTupleSelect(mixUpd, 0),
+                                       solver->mkBVFromDec(6, 8));
+  solver->addConstraint(
+      solver->mkNot(solver->mkAnd(arrPreserved, scalarUpdated)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Nested tuples: updating an inner tuple through an outer update.
+  solver->reset();
+  boolSort = solver->mkBoolSort();
+  bv8Sort = solver->mkBVSort(8);
+  auto innerSort = solver->mkTupleSort({bv8Sort, bv8Sort});
+  auto outerSort = solver->mkTupleSort({boolSort, innerSort});
+  auto outer = solver->mkSymbol("outer", outerSort);
+  auto newInner = solver->mkTupleUpdate(solver->mkTupleSelect(outer, 1), 0,
+                                        solver->mkBVFromDec(3, 8));
+  auto newOuter = solver->mkTupleUpdate(outer, 1, newInner);
+  // inner[0] is 3, inner[1] is preserved, outer[0] is preserved
+  auto innerOfNew = solver->mkTupleSelect(newOuter, 1);
+  auto ok = solver->mkAnd(
+      solver->mkAnd(solver->mkEqual(solver->mkTupleSelect(innerOfNew, 0),
+                                    solver->mkBVFromDec(3, 8)),
+                    solver->mkEqual(solver->mkTupleSelect(innerOfNew, 1),
+                                    solver->mkTupleSelect(
+                                        solver->mkTupleSelect(outer, 1), 1))),
+      solver->mkEqual(solver->mkTupleSelect(newOuter, 0),
+                      solver->mkTupleSelect(outer, 0)));
+  solver->addConstraint(solver->mkNot(ok));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Model extraction through an update.
+  solver->reset();
+  bv8Sort = solver->mkBVSort(8);
+  auto pairSort = solver->mkTupleSort({bv8Sort, bv8Sort});
+  auto p = solver->mkSymbol("p", pairSort);
+  auto q = solver->mkTupleUpdate(p, 0, solver->mkBVFromDec(11, 8));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkTupleSelect(p, 1), solver->mkBVFromDec(5, 8)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  auto f0 = solver->getBV(solver->mkTupleSelect(q, 0));
+  REQUIRE(f0);
+  REQUIRE(f0.value() == 11);
+  auto f1 = solver->getBV(solver->mkTupleSelect(q, 1));
+  REQUIRE(f1);
+  REQUIRE(f1.value() == 5);
+}
+
 inline void tuple_structural_equality(const camada::SMTSolverRef &solver) {
   auto boolSort = solver->mkBoolSort();
   auto bv8Sort = solver->mkBVSort(8);

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -262,6 +262,161 @@ inline void tuple_structural_equality(const camada::SMTSolverRef &solver) {
   REQUIRE_FALSE(*sym_a == *sym_b);
 }
 
+// Arrays of tuples: on native-datatype backends these are native
+// (Array Idx (Tuple ...)) sorts; elsewhere they decompose into one
+// backend array per scalar leaf field, so all array reasoning stays in
+// the solver's native theory (no software array encoding).
+inline void tuple_array_semantics(const camada::SMTSolverRef &solver) {
+  auto bv8 = solver->mkBVSort(8);
+  auto tupleSort = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  auto arrSort = solver->mkArraySort(bv8, tupleSort);
+  REQUIRE(arrSort->isArraySort());
+  REQUIRE(arrSort->getElementSort()->isTupleSort());
+
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto a = solver->mkSymbol("a", arrSort);
+
+  // Store a tuple value, read it back at the same index.
+  auto t = solver->mkTuple({solver->mkBool(true), idx(42)});
+  auto a1 = solver->mkArrayStore(a, idx(3), t);
+  auto rd = solver->mkArraySelect(a1, idx(3));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(rd, t)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Reads at other indexes stay tied to the original array.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  tupleSort = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  arrSort = solver->mkArraySort(bv8, tupleSort);
+  auto b = solver->mkSymbol("b", arrSort);
+  auto t2 = solver->mkTuple({solver->mkBool(false), idx(1)});
+  auto b1 = solver->mkArrayStore(b, idx(3), t2);
+  auto preserved = solver->mkEqual(solver->mkArraySelect(b1, idx(5)),
+                                   solver->mkArraySelect(b, idx(5)));
+  solver->addConstraint(solver->mkNot(preserved));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Homogeneous fields pin leaf-order identity solver-side: a leaf
+  // transposition between flatten and assemble would swap 1 and 2
+  // without any sort mismatch to catch it.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  auto homoSort = solver->mkTupleSort({bv8, bv8});
+  auto homoArr = solver->mkArraySort(bv8, homoSort);
+  auto h = solver->mkSymbol("h", homoArr);
+  auto hv = solver->mkTuple({idx(1), idx(2)});
+  auto h1 = solver->mkArrayStore(h, idx(0), hv);
+  auto hRead = solver->mkArraySelect(h1, idx(0));
+  auto fieldsOk =
+      solver->mkAnd(solver->mkEqual(solver->mkTupleSelect(hRead, 0), idx(1)),
+                    solver->mkEqual(solver->mkTupleSelect(hRead, 1), idx(2)));
+  solver->addConstraint(solver->mkNot(fieldsOk));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Read-over-write at a distinct symbolic index.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  tupleSort = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  arrSort = solver->mkArraySort(bv8, tupleSort);
+  auto c = solver->mkSymbol("c", arrSort);
+  auto i = solver->mkSymbol("i", bv8);
+  auto j = solver->mkSymbol("j", bv8);
+  auto t3 = solver->mkTuple({solver->mkBool(true), idx(9)});
+  auto c1 = solver->mkArrayStore(c, i, t3);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(i, j)));
+  auto rd2 = solver->mkArraySelect(c1, j);
+  solver->addConstraint(
+      solver->mkNot(solver->mkEqual(rd2, solver->mkArraySelect(c, j))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+inline void tuple_array_equality_ite(const camada::SMTSolverRef &solver) {
+  auto bv8 = solver->mkBVSort(8);
+  auto tupleSort = solver->mkTupleSort({bv8, bv8});
+  auto arrSort = solver->mkArraySort(bv8, tupleSort);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+
+  // Equality forces agreement at observed indexes.
+  auto a = solver->mkSymbol("a", arrSort);
+  auto b = solver->mkSymbol("b", arrSort);
+  solver->addConstraint(solver->mkEqual(a, b));
+  auto fa = solver->mkTupleSelect(solver->mkArraySelect(a, idx(0)), 1);
+  auto fb = solver->mkTupleSelect(solver->mkArraySelect(b, idx(0)), 1);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(fa, fb)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Ite distributes; selecting from the chosen branch agrees.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  tupleSort = solver->mkTupleSort({bv8, bv8});
+  arrSort = solver->mkArraySort(bv8, tupleSort);
+  auto c = solver->mkSymbol("c", arrSort);
+  auto d = solver->mkSymbol("d", arrSort);
+  auto cond = solver->mkSymbol("cond", solver->mkBoolSort());
+  auto picked = solver->mkIte(cond, c, d);
+  auto sel = solver->mkArraySelect(picked, idx(2));
+  auto expected = solver->mkIte(cond, solver->mkArraySelect(c, idx(2)),
+                                solver->mkArraySelect(d, idx(2)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(sel, expected)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Deep nesting: tuple { array of tuple { bv, array of tuple { bool, bv } } }
+// — five levels of alternation; everything must flatten to native
+// nested-arrays-of-scalars and recurse leaf-wise.
+inline void tuple_array_deep_nesting(const camada::SMTSolverRef &solver) {
+  auto bv4 = solver->mkBVSort(4);
+  auto bv8 = solver->mkBVSort(8);
+  auto idx4 = [&](int64_t V) { return solver->mkBVFromDec(V, 4); };
+  auto idx8 = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+
+  auto inner = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  auto innerArr = solver->mkArraySort(bv4, inner);
+  auto mid = solver->mkTupleSort({bv8, innerArr});
+  auto midArr = solver->mkArraySort(bv4, mid);
+  auto outer = solver->mkTupleSort({solver->mkBoolSort(), midArr});
+
+  auto o = solver->mkSymbol("o", outer);
+  // Walk down: outer.1 is an array of mid; select one, take its inner
+  // array, store an inner tuple, walk back up through stores/updates.
+  auto midArrV = solver->mkTupleSelect(o, 1);
+  auto midV = solver->mkArraySelect(midArrV, idx4(2));
+  auto innerArrV = solver->mkTupleSelect(midV, 1);
+  auto innerT = solver->mkTuple({solver->mkBool(true), idx8(7)});
+  auto innerArr1 = solver->mkArrayStore(innerArrV, idx4(1), innerT);
+  // Rebuild the enclosing tuples field-wise (mkTupleUpdate lands in a
+  // separate PR; select-and-rebuild is its definition anyway).
+  auto midV1 = solver->mkTuple({solver->mkTupleSelect(midV, 0), innerArr1});
+  auto midArr1 = solver->mkArrayStore(midArrV, idx4(2), midV1);
+  auto o1 = solver->mkTuple({solver->mkTupleSelect(o, 0), midArr1});
+
+  // Reading the stored inner tuple back through the whole chain.
+  auto back = solver->mkArraySelect(
+      solver->mkTupleSelect(
+          solver->mkArraySelect(solver->mkTupleSelect(o1, 1), idx4(2)), 1),
+      idx4(1));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(back, innerT)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // An untouched path stays tied to the original.
+  solver->reset();
+  bv4 = solver->mkBVSort(4);
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  innerArr = solver->mkArraySort(bv4, inner);
+  mid = solver->mkTupleSort({bv8, innerArr});
+  midArr = solver->mkArraySort(bv4, mid);
+  auto p = solver->mkSymbol("p", midArr);
+  auto q = solver->mkSymbol("q", midArr);
+  solver->addConstraint(solver->mkEqual(p, q));
+  auto deepP = solver->mkArraySelect(
+      solver->mkTupleSelect(solver->mkArraySelect(p, idx4(0)), 1), idx4(3));
+  auto deepQ = solver->mkArraySelect(
+      solver->mkTupleSelect(solver->mkArraySelect(q, idx4(0)), 1), idx4(3));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(deepP, deepQ)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
 inline void empty_tuple_semantics(const camada::SMTSolverRef &solver) {
   auto tupleSort = solver->mkTupleSort({});
   auto tupleValue = solver->mkTuple({});

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -361,6 +361,93 @@ inline void tuple_array_equality_ite(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::checkResult::UNSAT);
 }
 
+// Constant arrays of tuples: on backends without native datatypes the
+// initializer decomposes into one constant array per scalar leaf (each
+// lowered natively or lazily per the backend); native backends lower
+// the whole thing directly. Checks are solver-side only — model
+// extraction on decomposed arrays is a later tuple-plan phase.
+inline void tuple_array_const(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+
+  // The default value is visible at an arbitrary symbolic index.
+  auto init = solver->mkTuple({solver->mkBool(true), idx(170)});
+  auto arr = solver->mkArrayConst(bv8, init, Lowering);
+  auto i = solver->mkSymbol("i", bv8);
+  solver->addConstraint(
+      solver->mkNot(solver->mkEqual(solver->mkArraySelect(arr, i), init)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Store over the constant array: the stored tuple at the written
+  // index, the default elsewhere.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  init = solver->mkTuple({solver->mkBool(false), idx(7)});
+  auto stored = solver->mkTuple({solver->mkBool(true), idx(99)});
+  auto upd = solver->mkArrayStore(solver->mkArrayConst(bv8, init, Lowering),
+                                  idx(3), stored);
+  auto ok =
+      solver->mkAnd(solver->mkEqual(solver->mkArraySelect(upd, idx(3)), stored),
+                    solver->mkEqual(solver->mkArraySelect(upd, idx(5)), init));
+  solver->addConstraint(solver->mkNot(ok));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // The default survives a store made inside a pushed scope: after pop,
+  // reads at the previously written index see the default again.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  init = solver->mkTuple({solver->mkBool(true), idx(21)});
+  auto arr3 = solver->mkArrayConst(bv8, init, Lowering);
+  solver->push();
+  auto scratch = solver->mkTuple({solver->mkBool(false), idx(1)});
+  auto inPush = solver->mkArrayStore(arr3, idx(2), scratch);
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(inPush, idx(2)), scratch));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  solver->pop();
+  solver->addConstraint(solver->mkNot(
+      solver->mkEqual(solver->mkArraySelect(arr3, idx(2)), init)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Homogeneous fields pin per-leaf default order semantically: a leaf
+  // transposition would hand 22 to field 0 with no sort mismatch.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  auto homoInit = solver->mkTuple({idx(11), idx(22)});
+  auto homoArr = solver->mkArrayConst(bv8, homoInit, Lowering);
+  auto k = solver->mkSymbol("k", bv8);
+  auto homoRd = solver->mkArraySelect(homoArr, k);
+  auto fieldsOk =
+      solver->mkAnd(solver->mkEqual(solver->mkTupleSelect(homoRd, 0), idx(11)),
+                    solver->mkEqual(solver->mkTupleSelect(homoRd, 1), idx(22)));
+  solver->addConstraint(solver->mkNot(fieldsOk));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Nested constant arrays of tuples: array_of(array_of(tuple)). On the
+// decomposed path the inner constant array's leaves become the per-leaf
+// initializers of the outer one. Registered per backend: lazily lowered
+// constant arrays cannot nest (bitwuzla/yices/stp abort), so this runs
+// only where constant arrays are native.
+inline void tuple_array_const_nested(const camada::SMTSolverRef &solver) {
+  auto bv4 = solver->mkBVSort(4);
+  auto init =
+      solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(5, 8)});
+  auto innerConst = solver->mkArrayConst(bv4, init);
+  auto outerConst = solver->mkArrayConst(bv4, innerConst);
+
+  auto i = solver->mkSymbol("i", bv4);
+  auto j = solver->mkSymbol("j", bv4);
+  auto rd = solver->mkArraySelect(solver->mkArraySelect(outerConst, i), j);
+  // Guard against a vacuously UNSAT context (e.g. contradictory default
+  // axioms) before pinning the property itself.
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(rd, init)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
 // Deep nesting: tuple { array of tuple { bv, array of tuple { bool, bv } } }
 // — five levels of alternation; everything must flatten to native
 // nested-arrays-of-scalars and recurse leaf-wise.

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -448,6 +448,117 @@ inline void tuple_array_const_nested(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::checkResult::UNSAT);
 }
 
+// Model extraction for decomposed tuple arrays: getArrayElement returns
+// a tuple value whose fields read back per leaf, and getArrayValues zips
+// the per-leaf sparse models into one tuple-valued model. Native-datatype
+// backends evaluate the array element directly; the decomposed path
+// reassembles from per-leaf model values.
+inline void tuple_array_model_values(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+
+  // Constant array of {bool, bv8} with two distinct stores.
+  auto init = solver->mkTuple({solver->mkBool(true), idx(7)});
+  auto arr = solver->mkArrayConst(bv8, init, Lowering);
+  arr = solver->mkArrayStore(arr, idx(3),
+                             solver->mkTuple({solver->mkBool(false), idx(9)}));
+  arr = solver->mkArrayStore(arr, idx(5),
+                             solver->mkTuple({solver->mkBool(true), idx(11)}));
+  // Touch an untouched index so every backend has the array in the formula.
+  solver->addConstraint(solver->mkEqual(
+      solver->mkTupleSelect(solver->mkArraySelect(arr, idx(0)), 1), idx(7)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // Exact single-index recovery: getArrayElement at a written and an
+  // untouched index, read each tuple field back.
+  auto fieldsAt = [&](int64_t Index, bool &Flag, int64_t &Num) {
+    auto e = solver->getArrayElement(arr, idx(Index));
+    REQUIRE(e->Sort->isTupleSort());
+    auto b = solver->getBool(solver->mkTupleSelect(e, 0));
+    auto n = solver->getBV(solver->mkTupleSelect(e, 1));
+    REQUIRE(b);
+    REQUIRE(n);
+    Flag = b.value();
+    Num = n.value();
+  };
+  bool flag = false;
+  int64_t num = 0;
+  fieldsAt(3, flag, num);
+  REQUIRE_FALSE(flag);
+  REQUIRE(num == 9);
+  fieldsAt(5, flag, num);
+  REQUIRE(flag);
+  REQUIRE(num == 11);
+  fieldsAt(200, flag, num); // never mentioned: the constant default
+  REQUIRE(flag);
+  REQUIRE(num == 7);
+
+  // Sparse model: zip the per-leaf models, then resolve the tuple value
+  // at an index by its model value (first matching entry, else base).
+  auto Model = solver->getArrayValues(arr);
+  if (!Model) {
+    REQUIRE(Model.error().Code == camada::SMTErrorCode::UnsupportedOperation);
+    return;
+  }
+  auto tupleAt = [&](int64_t Index, bool &Flag, int64_t &Num) {
+    for (const auto &Entry : Model.value().Entries) {
+      auto iv = solver->getBV(Entry.first);
+      REQUIRE(iv);
+      if (iv.value() == Index) {
+        auto b = solver->getBool(solver->mkTupleSelect(Entry.second, 0));
+        auto n = solver->getBV(solver->mkTupleSelect(Entry.second, 1));
+        REQUIRE(b);
+        REQUIRE(n);
+        Flag = b.value();
+        Num = n.value();
+        return;
+      }
+    }
+    REQUIRE(Model.value().Base);
+    auto b = solver->getBool(solver->mkTupleSelect(Model.value().Base, 0));
+    auto n = solver->getBV(solver->mkTupleSelect(Model.value().Base, 1));
+    REQUIRE(b);
+    REQUIRE(n);
+    Flag = b.value();
+    Num = n.value();
+  };
+  tupleAt(3, flag, num);
+  REQUIRE_FALSE(flag);
+  REQUIRE(num == 9);
+  tupleAt(5, flag, num);
+  REQUIRE(flag);
+  REQUIRE(num == 11);
+  tupleAt(200, flag, num); // base default
+  REQUIRE(flag);
+  REQUIRE(num == 7);
+
+  // Symbolic tuple array with a single store and no constant default:
+  // exercises the no-base zip path. getArrayValues either yields a model
+  // (native backends) or reports UnsupportedOperation (decomposed
+  // backends whose leaves have no base) — both are contract-valid, and
+  // exact single-index recovery must hold either way.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  auto tupSort = solver->mkTupleSort({solver->mkBoolSort(), bv8});
+  auto sym = solver->mkSymbol("sym_ta", solver->mkArraySort(bv8, tupSort));
+  auto stored = solver->mkTuple({solver->mkBool(true), idx(33)});
+  auto sym1 = solver->mkArrayStore(sym, idx(4), stored);
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  auto e = solver->getArrayElement(sym1, idx(4));
+  auto eb = solver->getBool(solver->mkTupleSelect(e, 0));
+  auto en = solver->getBV(solver->mkTupleSelect(e, 1));
+  REQUIRE(eb);
+  REQUIRE(en);
+  REQUIRE(eb.value());
+  REQUIRE(en.value() == 33);
+  auto SymModel = solver->getArrayValues(sym1);
+  if (!SymModel)
+    REQUIRE(SymModel.error().Code ==
+            camada::SMTErrorCode::UnsupportedOperation);
+}
+
 // Deep nesting: tuple { array of tuple { bv, array of tuple { bool, bv } } }
 // — five levels of alternation; everything must flatten to native
 // nested-arrays-of-scalars and recurse leaf-wise.

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -231,3 +231,10 @@ TEST_CASE("Yices feature capabilities", "[Yices]") {
 #endif
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting Yices test", "[Yices]") {
+  auto solver = camada::createYicesSolver();
+  tuple_array_deep_nesting(solver);
+}

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -238,3 +238,16 @@ TEST_CASE("Deep tuple/array nesting Yices test", "[Yices]") {
   auto solver = camada::createYicesSolver();
   tuple_array_deep_nesting(solver);
 }
+
+// Nested constant tuple arrays need every per-leaf constant array to
+// nest, and lazily lowered constant arrays cannot — pin the abort.
+TEST_CASE("Unsupported nested constant tuple arrays Yices test", "[Yices]") {
+  auto solver = camada::createYicesSolver();
+  require_abort([&]() {
+    auto bv4 = solver->mkBVSort(4);
+    auto init =
+        solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(5, 8)});
+    auto innerConst = solver->mkArrayConst(bv4, init);
+    (void)solver->mkArrayConst(bv4, innerConst);
+  });
+}

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -186,3 +186,10 @@ TEST_CASE("Z3 feature capabilities", "[Z3]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend rather than in tests(): the depth-5 shape
+// flattens to nested-array leaves, which STP's array theory lacks.
+TEST_CASE("Deep tuple/array nesting Z3 test", "[Z3]") {
+  auto solver = camada::createZ3Solver();
+  tuple_array_deep_nesting(solver);
+}

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -193,3 +193,10 @@ TEST_CASE("Deep tuple/array nesting Z3 test", "[Z3]") {
   auto solver = camada::createZ3Solver();
   tuple_array_deep_nesting(solver);
 }
+
+// Registered per backend: nested constant arrays require native constant
+// arrays (lazily lowered constant arrays cannot nest).
+TEST_CASE("Nested constant tuple arrays Z3 test", "[Z3]") {
+  auto solver = camada::createZ3Solver();
+  tuple_array_const_nested(solver);
+}

--- a/src/camada.h
+++ b/src/camada.h
@@ -648,6 +648,13 @@ public:
   /// Selects the element at Index from Tuple.
   virtual SMTExprRef mkTupleSelect(const SMTExprRef &Tuple, unsigned Index) = 0;
 
+  /// Returns a tuple equal to Tuple except that the element at Index is
+  /// replaced by Value; all other elements are unchanged. Index is a
+  /// concrete index — symbolic field selection is deliberately not part
+  /// of the API.
+  virtual SMTExprRef mkTupleUpdate(const SMTExprRef &Tuple, unsigned Index,
+                                   const SMTExprRef &Value) = 0;
+
   /// Applies a function symbol to arguments.
   virtual SMTExprRef mkApply(const SMTExprRef &Function,
                              const std::vector<SMTExprRef> &Args) = 0;

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -1611,12 +1611,10 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
   fatalErrorIf(Array->Sort->getIndexSort() != Index->Sort,
                "Expected array index with matching sort");
-  // Tuple-array model extraction is the model-extraction tuple-plan
-  // phase; the bundle has no backend representation to evaluate yet.
-  fatalErrorIf(!nativeTupleSupport() &&
-                   sortContainsTuple(Array->Sort->getElementSort()),
-               "Model extraction for arrays of tuples is not yet supported "
-               "on this backend; see tuple-plan.md");
+  // Decomposed tuple arrays read each leaf at Index and reassemble the
+  // per-leaf values into a tuple; the per-leaf reads re-enter this wrapper.
+  if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
+    return getCamadaTupleArrayElement(*this, Array, Index);
   if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
     if (SMTExprRef Resolved = resolveLazyArrayElement(Array, Index))
       return Resolved;
@@ -1636,10 +1634,10 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
 
 SMTResult<ArrayModel> SMTSolverImpl::getArrayValues(const SMTExprRef &Array) {
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
+  // Decomposed tuple arrays zip the per-leaf sparse models into one
+  // tuple-valued model; the per-leaf queries re-enter this wrapper.
   if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
-    return SMTError{SMTErrorCode::UnsupportedOperation, Array->getBackendKind(),
-                    "Sparse models for arrays of tuples are not yet "
-                    "supported on this backend; see tuple-plan.md"};
+    return getCamadaTupleArrayValues(*this, Array);
   if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
     return lazyArrayModel(Array);
   return getArrayValuesImpl(Array);

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -369,17 +369,23 @@ SMTSortRef SMTSolverImpl::mkArraySort(const SMTSortRef &IndexSort,
   // no backend sort handle) through mkArraySortImpl, where the backend
   // would static_cast it as one of its own sorts. Reject up front. The
   // per-field array decomposition is tracked in issue #17.
-  fatalErrorIf(IndexSort->isTupleSort() && !nativeTupleSupport(),
-               "Arrays whose index sort is a tuple are not yet supported "
+  fatalErrorIf(sortContainsTuple(IndexSort) && !nativeTupleSupport(),
+               "Arrays whose index sort involves a tuple are not supported "
                "on this backend; see issue #17");
-  fatalErrorIf(ElemSort->isTupleSort() && !nativeTupleSupport(),
-               "Arrays whose element sort is a tuple are not yet supported "
-               "on this backend; see issue #17");
-
   ArraySortCacheKey Key{IndexSort.get(), ElemSort.get()};
   auto It = ArraySortCache.find(Key);
   if (It != ArraySortCache.end())
     return It->second;
+
+  // Element sorts involving tuples have no backend representation on
+  // backends without native datatype support: the array decomposes into
+  // a bundle of per-leaf-field backend arrays (see camadatuple.cpp).
+  if (!nativeTupleSupport() && sortContainsTuple(ElemSort)) {
+    SMTSortRef theSort = mkCamadaTupleArraySort(*this, IndexSort, ElemSort);
+    assert(theSort->isArraySort());
+    ArraySortCache.emplace(Key, theSort);
+    return theSort;
+  }
 
   SMTSortRef theSort = mkArraySortImpl(IndexSort, ElemSort);
   assert(theSort->isArraySort());
@@ -398,13 +404,14 @@ SMTSolverImpl::mkFunctionSort(const std::vector<SMTSortRef> &DomainSorts,
   // support would static_cast a CamadaTupleSort as a backend sort.
   // Reject up front; structural lowering is part of the issue #17 work.
   if (!nativeTupleSupport()) {
-    fatalErrorIf(CodomainSort->isTupleSort(),
-                 "Functions returning tuples are not yet supported on this "
-                 "backend; see issue #17");
+    fatalErrorIf(sortContainsTuple(CodomainSort),
+                 "Functions returning tuples (or tuple-involving arrays) "
+                 "are not yet supported on this backend; see issue #17");
     for (const auto &D : DomainSorts)
-      fatalErrorIf(D->isTupleSort(),
-                   "Functions taking tuple arguments are not yet supported "
-                   "on this backend; see issue #17");
+      fatalErrorIf(sortContainsTuple(D),
+                   "Functions taking tuple (or tuple-involving array) "
+                   "arguments are not yet supported on this backend; see "
+                   "issue #17");
   }
   if (DomainSorts.size() <= 4) {
     SmallFunctionSortCacheKey SmallKey{};
@@ -678,6 +685,11 @@ SMTExprRef SMTSolverImpl::mkEqual(const SMTExprRef &LHS,
   if (LHS->Sort->isTupleSort() && !nativeTupleSupport())
     return mkCamadaTupleEqual(*this, LHS, RHS);
   if (LHS->Sort->isArraySort()) {
+    // Decomposed tuple arrays compare as the conjunction of their leaf
+    // equalities; each leaf re-enters this wrapper and engages the
+    // normal array-equality machinery (lazy witness, STP encoding).
+    if (!nativeTupleSupport() && sortContainsTuple(LHS->Sort->getElementSort()))
+      return mkCamadaTupleArrayEqual(*this, LHS, RHS);
     const bool LazyInvolved = !LazyConstArrayRoots.empty() &&
                               (reachesLazyArray(LHS) || reachesLazyArray(RHS));
     // Backends without native array extensionality (STP) cannot decide
@@ -894,6 +906,11 @@ SMTExprRef SMTSolverImpl::mkIte(const SMTExprRef &Cond, const SMTExprRef &T,
   // node that distributes selection over its fields lazily.
   if (T->Sort->isTupleSort() && !nativeTupleSupport())
     return mkCamadaTupleIte(*this, Cond, T, F);
+  // Decomposed tuple arrays ite leaf-wise; the per-leaf ites re-enter
+  // this wrapper, so the lazy-root union tracking below applies per leaf.
+  if (!nativeTupleSupport() && T->Sort->isArraySort() &&
+      sortContainsTuple(T->Sort->getElementSort()))
+    return mkCamadaTupleArrayIte(*this, Cond, T, F);
   SMTExprRef theExp = mkIteImpl(Cond, T, F);
   assert(theExp->Sort == F->Sort);
   if (!LazyConstArrayRoots.empty() && T->Sort->isArraySort()) {
@@ -1182,6 +1199,11 @@ SMTExprRef SMTSolverImpl::mkArraySelect(const SMTExprRef &Array,
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
   fatalErrorIf(Array->Sort->getIndexSort() != Index->Sort,
                "Expected array index with matching sort");
+  // Decomposed tuple arrays select leaf-wise; the per-leaf selects below
+  // re-enter this wrapper, so observation/lazy instantiation happens per
+  // leaf.
+  if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
+    return mkCamadaTupleArraySelect(*this, Array, Index);
   if (!InLazyModelQuery)
     observeArrayIndex(Index);
   SMTExprRef theExp = mkArraySelectImpl(Array, Index);
@@ -1197,6 +1219,10 @@ SMTExprRef SMTSolverImpl::mkArrayStore(const SMTExprRef &Array,
                "Expected array index with matching sort");
   fatalErrorIf(Array->Sort->getElementSort() != Element->Sort,
                "Expected array element with matching sort");
+  // Decomposed tuple arrays store leaf-wise; the per-leaf stores re-enter
+  // this wrapper, so the lazy guards/tracking below apply per leaf.
+  if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
+    return mkCamadaTupleArrayStore(*this, Array, Index, Element);
   fatalErrorIf(!LazyConstArrayRoots.empty() && reachesLazyArray(Element),
                "Storing a lazily lowered constant array inside another array "
                "is not supported");
@@ -1474,9 +1500,10 @@ SMTExprRef SMTSolverImpl::mkForall(const std::vector<SMTExprRef> &Vars,
   // then static_cast as one of its own expressions. Reject up front.
   if (!nativeTupleSupport())
     for (const auto &V : Vars)
-      fatalErrorIf(V->Sort->isTupleSort(),
-                   "Quantifiers over tuple-typed variables are not yet "
-                   "supported on this backend; see issue #17");
+      fatalErrorIf(sortContainsTuple(V->Sort),
+                   "Quantifiers over tuple-typed (or tuple-involving-array) "
+                   "variables are not yet supported on this backend; see "
+                   "issue #17");
   SMTExprRef theExp = mkForallImpl(Vars, Body);
   assert(theExp->isBoolSort());
   return theExp;
@@ -1492,9 +1519,10 @@ SMTExprRef SMTSolverImpl::mkExists(const std::vector<SMTExprRef> &Vars,
   requireBoolSort(Body, "Expected boolean quantifier body");
   if (!nativeTupleSupport())
     for (const auto &V : Vars)
-      fatalErrorIf(V->Sort->isTupleSort(),
-                   "Quantifiers over tuple-typed variables are not yet "
-                   "supported on this backend; see issue #17");
+      fatalErrorIf(sortContainsTuple(V->Sort),
+                   "Quantifiers over tuple-typed (or tuple-involving-array) "
+                   "variables are not yet supported on this backend; see "
+                   "issue #17");
   SMTExprRef theExp = mkExistsImpl(Vars, Body);
   assert(theExp->isBoolSort());
   return theExp;
@@ -1583,6 +1611,12 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
   fatalErrorIf(Array->Sort->getIndexSort() != Index->Sort,
                "Expected array index with matching sort");
+  // Tuple-array model extraction is the model-extraction tuple-plan
+  // phase; the bundle has no backend representation to evaluate yet.
+  fatalErrorIf(!nativeTupleSupport() &&
+                   sortContainsTuple(Array->Sort->getElementSort()),
+               "Model extraction for arrays of tuples is not yet supported "
+               "on this backend; see tuple-plan.md");
   if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
     if (SMTExprRef Resolved = resolveLazyArrayElement(Array, Index))
       return Resolved;
@@ -1602,6 +1636,10 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
 
 SMTResult<ArrayModel> SMTSolverImpl::getArrayValues(const SMTExprRef &Array) {
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
+  if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
+    return SMTError{SMTErrorCode::UnsupportedOperation, Array->getBackendKind(),
+                    "Sparse models for arrays of tuples are not yet "
+                    "supported on this backend; see tuple-plan.md"};
   if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
     return lazyArrayModel(Array);
   return getArrayValuesImpl(Array);
@@ -1805,6 +1843,12 @@ SMTExprRef SMTSolverImpl::mkSymbolUnchecked(const std::string &Name,
     SymbolExprCache.emplace(Key, theExp);
     return theExp;
   }
+  if (!nativeTupleSupport() && Sort->isArraySort() &&
+      sortContainsTuple(Sort->getElementSort())) {
+    SMTExprRef theExp = mkCamadaTupleArraySymbol(*this, Name, Sort);
+    SymbolExprCache.emplace(Key, theExp);
+    return theExp;
+  }
 
   SMTExprRef theExp = mkSymbolImpl(Name, Sort);
   assert(theExp->Sort == Sort);
@@ -1912,6 +1956,14 @@ SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
 SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
                                        const SMTExprRef &InitValue,
                                        ConstArrayLowering Lowering) {
+  // Tuple-involving initializers decompose into per-leaf constant arrays;
+  // tracked as the next tuple-plan phase.
+  fatalErrorIf(!nativeTupleSupport() && sortContainsTuple(InitValue->Sort),
+               "Constant arrays of tuples are not yet supported on this "
+               "backend; see tuple-plan.md");
+  fatalErrorIf(!nativeTupleSupport() && sortContainsTuple(IndexSort),
+               "Arrays whose index sort involves a tuple are not supported "
+               "on this backend; see issue #17");
   if (Lowering == ConstArrayLowering::Auto)
     Lowering = nativeConstArraySupport() ? ConstArrayLowering::Native
                                          : ConstArrayLowering::Lazy;

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -1956,11 +1956,6 @@ SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
 SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
                                        const SMTExprRef &InitValue,
                                        ConstArrayLowering Lowering) {
-  // Tuple-involving initializers decompose into per-leaf constant arrays;
-  // tracked as the next tuple-plan phase.
-  fatalErrorIf(!nativeTupleSupport() && sortContainsTuple(InitValue->Sort),
-               "Constant arrays of tuples are not yet supported on this "
-               "backend; see tuple-plan.md");
   fatalErrorIf(!nativeTupleSupport() && sortContainsTuple(IndexSort),
                "Arrays whose index sort involves a tuple are not supported "
                "on this backend; see issue #17");
@@ -1970,6 +1965,11 @@ SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
   fatalErrorIf(Lowering == ConstArrayLowering::Native &&
                    !nativeConstArraySupport(),
                "Native constant arrays are not supported by this backend");
+  // Tuple-involving initializers decompose into one constant array per
+  // scalar leaf; the per-leaf calls re-enter this wrapper, so the resolved
+  // lowering (and its lazy machinery) applies per leaf.
+  if (!nativeTupleSupport() && sortContainsTuple(InitValue->Sort))
+    return mkCamadaTupleArrayConst(*this, IndexSort, InitValue, Lowering);
   SMTExprRef theExp = Lowering == ConstArrayLowering::Native
                           ? mkArrayConstImpl(IndexSort, InitValue)
                           : mkLazyConstArray(IndexSort, InitValue);

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -1418,6 +1418,29 @@ SMTExprRef SMTSolverImpl::mkTupleSelect(const SMTExprRef &Tuple,
   return theExp;
 }
 
+SMTExprRef SMTSolverImpl::mkTupleUpdate(const SMTExprRef &Tuple, unsigned Index,
+                                        const SMTExprRef &Value) {
+  fatalErrorIf(!Tuple->Sort->isTupleSort(), "Expected tuple expression");
+  fatalErrorIf(Index >= Tuple->Sort->getTupleElementSorts().size(),
+               "Tuple element index is out of bounds");
+  fatalErrorIf(Tuple->Sort->getTupleElementSorts()[Index] != Value->Sort,
+               "Expected tuple update value with the element's sort");
+  SMTExprRef theExp = mkTupleUpdateImpl(Tuple, Index, Value);
+  assert(theExp->Sort == Tuple->Sort);
+  return theExp;
+}
+
+SMTExprRef SMTSolverImpl::mkTupleUpdateImpl(const SMTExprRef &Tuple,
+                                            unsigned Index,
+                                            const SMTExprRef &Value) {
+  const std::size_t ElementCount = Tuple->Sort->getTupleElementSorts().size();
+  std::vector<SMTExprRef> Elements;
+  Elements.reserve(ElementCount);
+  for (unsigned I = 0; I < ElementCount; ++I)
+    Elements.push_back(I == Index ? Value : mkTupleSelect(Tuple, I));
+  return mkTuple(Elements);
+}
+
 SMTExprRef SMTSolverImpl::mkApply(const SMTExprRef &Function,
                                   const std::vector<SMTExprRef> &Args) {
   fatalErrorIf(!Function->isFunctionSort(), "Expected function expression");

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -456,6 +456,8 @@ public:
   SMTExprRef mkTuple(const std::vector<SMTExprRef> &Elements) override final;
   SMTExprRef mkTupleSelect(const SMTExprRef &Tuple,
                            unsigned Index) override final;
+  SMTExprRef mkTupleUpdate(const SMTExprRef &Tuple, unsigned Index,
+                           const SMTExprRef &Value) override final;
   SMTExprRef mkApply(const SMTExprRef &Function,
                      const std::vector<SMTExprRef> &Args) override final;
   SMTExprRef mkForall(const std::vector<SMTExprRef> &Vars,
@@ -786,6 +788,13 @@ protected:
   virtual SMTExprRef mkTupleImpl(const std::vector<SMTExprRef> &);
 
   virtual SMTExprRef mkTupleSelectImpl(const SMTExprRef &, unsigned);
+
+  /// Default: select-and-rebuild through the public mkTupleSelect/mkTuple,
+  /// which dispatch per regime (native datatypes vs the Camada per-field
+  /// lowering) — the semantic definition of the operation. Backends with a
+  /// native datatype updater can override if profiling ever justifies it.
+  virtual SMTExprRef mkTupleUpdateImpl(const SMTExprRef &Tuple, unsigned Index,
+                                       const SMTExprRef &Value);
 
   virtual SMTExprRef mkApplyImpl(const SMTExprRef &,
                                  const std::vector<SMTExprRef> &);

--- a/src/camadatuple.cpp
+++ b/src/camadatuple.cpp
@@ -167,6 +167,176 @@ const CamadaTupleExpr *toCamadaTupleExpr(const SMTExprRef &Exp) {
   return dynamic_cast<const CamadaTupleExpr *>(Exp.get());
 }
 
+/// Array sort whose element involves a tuple, owned by the Camada layer.
+/// Behaves as a normal array sort through the generic accessors
+/// (getIndexSort/getElementSort); additionally carries the flattened
+/// per-leaf array sorts the bundle representation aligns with.
+class CamadaTupleArraySort : public SMTSort {
+public:
+  CamadaTupleArraySort(SMTBackendKind BackendKind, const SMTSortRef &IndexSort,
+                       const SMTSortRef &ElemSort,
+                       std::vector<SMTSortRef> LeafSorts)
+      : SMTSort(SMTSortKind::Array, ArraySortData{IndexSort, ElemSort}),
+        LeafSorts(std::move(LeafSorts)), BackendKind(BackendKind) {}
+
+  SMTBackendKind getBackendKind() const override { return BackendKind; }
+
+  unsigned getWidthFromSolver() const override {
+    fatalError("Width query on Camada-managed tuple-array sort");
+  }
+
+  void dump(std::string &Out) const override {
+    Out = "(CamadaTupleArray";
+    for (const auto &L : LeafSorts) {
+      Out += " ";
+      std::string LeafOut;
+      L->dump(LeafOut);
+      if (!LeafOut.empty() && LeafOut.back() == '\n')
+        LeafOut.pop_back();
+      Out += LeafOut;
+    }
+    Out += ")\n";
+  }
+
+  std::vector<SMTSortRef> LeafSorts;
+
+private:
+  SMTBackendKind BackendKind;
+};
+
+/// Bundle of per-leaf backend arrays representing an array of tuples.
+/// LeafArrays aligns positionally with the sort's LeafSorts; every leaf
+/// is an ordinary backend array expression, so the existing lazy
+/// constant-array, encoded-equality, and model machinery applies per
+/// leaf with no new backend code.
+class CamadaTupleArrayExpr : public SMTExpr {
+public:
+  CamadaTupleArrayExpr(SMTExprKind ExprKind, SMTBackendKind BackendKind,
+                       const SMTSortRef &Sort, std::vector<SMTExprRef> Leaves)
+      : SMTExpr(ExprKind, Sort), LeafArrays(std::move(Leaves)),
+        BackendKind(BackendKind) {}
+
+  SMTBackendKind getBackendKind() const override { return BackendKind; }
+
+  void dump(std::string &Out) const override {
+    Out = "(CamadaTupleArray";
+    for (const auto &L : LeafArrays) {
+      Out += " ";
+      std::string LeafOut;
+      L->dump(LeafOut);
+      if (!LeafOut.empty() && LeafOut.back() == '\n')
+        LeafOut.pop_back();
+      Out += LeafOut;
+    }
+    Out += ")\n";
+  }
+
+  std::vector<SMTExprRef> LeafArrays;
+
+protected:
+  bool equal_to(SMTExpr const &Other) const override {
+    if (Sort != Other.Sort || Other.getBackendKind() != getBackendKind() ||
+        getKind() != Other.getKind())
+      return false;
+    auto const &Rhs = static_cast<const CamadaTupleArrayExpr &>(Other);
+    if (LeafArrays.size() != Rhs.LeafArrays.size())
+      return false;
+    for (std::size_t I = 0; I < LeafArrays.size(); ++I)
+      if (!(*LeafArrays[I] == *Rhs.LeafArrays[I]))
+        return false;
+    return true;
+  }
+
+private:
+  SMTBackendKind BackendKind;
+};
+
+const CamadaTupleArrayExpr *toCamadaTupleArrayExpr(const SMTExprRef &Exp) {
+  if (!Exp || !Exp->Sort->isArraySort())
+    return nullptr;
+  return dynamic_cast<const CamadaTupleArrayExpr *>(Exp.get());
+}
+
+/// Flattened per-leaf array sorts of `Array<Index, Elem>` where Elem
+/// involves a tuple: one `Array<Index, L>` per scalar leaf path L
+/// through Elem, built through the public mkArraySort (leaves contain no
+/// tuples, so these are native sorts — possibly nested arrays).
+void collectLeafSortsOf(SMTSolverImpl &Solver, const SMTSortRef &Sort,
+                        std::vector<SMTSortRef> &Out) {
+  if (Sort->isTupleSort()) {
+    for (const auto &Elem : Sort->getTupleElementSorts())
+      collectLeafSortsOf(Solver, Elem, Out);
+    return;
+  }
+  if (Sort->isArraySort() && sortContainsTuple(Sort->getElementSort())) {
+    std::vector<SMTSortRef> ElemLeaves;
+    collectLeafSortsOf(Solver, Sort->getElementSort(), ElemLeaves);
+    for (const auto &L : ElemLeaves)
+      Out.push_back(Solver.mkArraySort(Sort->getIndexSort(), L));
+    return;
+  }
+  Out.push_back(Sort);
+}
+
+const std::vector<SMTSortRef> &leafSortsOf(const SMTSortRef &Sort) {
+  const auto *AS = dynamic_cast<const CamadaTupleArraySort *>(Sort.get());
+  fatalErrorIf(AS == nullptr, "Expected a Camada-managed tuple-array sort");
+  return AS->LeafSorts;
+}
+
+/// Flatten a value of a tuple-involving sort into its leaf expressions,
+/// in leaf-sort order. Tuple values decompose through the public
+/// mkTupleSelect (which handles symbol/value/ite shapes); tuple-array
+/// values contribute their bundles; scalars and native arrays are leaves.
+void collectLeafExprsOf(SMTSolverImpl &Solver, const SMTExprRef &Value,
+                        std::vector<SMTExprRef> &Out) {
+  if (Value->Sort->isTupleSort()) {
+    const std::size_t Fields = Value->Sort->getTupleElementSorts().size();
+    for (unsigned I = 0; I < Fields; ++I)
+      collectLeafExprsOf(Solver, Solver.mkTupleSelect(Value, I), Out);
+    return;
+  }
+  if (Value->Sort->isArraySort() &&
+      sortContainsTuple(Value->Sort->getElementSort())) {
+    const CamadaTupleArrayExpr *AE = toCamadaTupleArrayExpr(Value);
+    fatalErrorIf(AE == nullptr,
+                 "Tuple-array-sorted expression is not a Camada bundle");
+    Out.insert(Out.end(), AE->LeafArrays.begin(), AE->LeafArrays.end());
+    return;
+  }
+  Out.push_back(Value);
+}
+
+/// Rebuild a value of the given sort from leaf expressions (consumed in
+/// order) — the inverse of collectLeafExprsOf.
+SMTExprRef assembleFromLeaves(SMTSolverImpl &Solver, const SMTSortRef &Sort,
+                              const std::vector<SMTExprRef> &Leaves,
+                              std::size_t &Pos) {
+  if (Sort->isTupleSort()) {
+    std::vector<SMTExprRef> Fields;
+    const auto &ElemSorts = Sort->getTupleElementSorts();
+    Fields.reserve(ElemSorts.size());
+    for (const auto &Elem : ElemSorts)
+      Fields.push_back(assembleFromLeaves(Solver, Elem, Leaves, Pos));
+    return Solver.mkTuple(Fields);
+  }
+  if (Sort->isArraySort() && sortContainsTuple(Sort->getElementSort())) {
+    std::vector<SMTSortRef> SubLeafSorts;
+    collectLeafSortsOf(Solver, Sort, SubLeafSorts);
+    std::vector<SMTExprRef> SubLeaves;
+    SubLeaves.reserve(SubLeafSorts.size());
+    for (std::size_t I = 0; I < SubLeafSorts.size(); ++I) {
+      fatalErrorIf(Pos >= Leaves.size(), "Tuple-array leaf underflow");
+      SubLeaves.push_back(Leaves[Pos++]);
+    }
+    return Solver.makeExprRef<CamadaTupleArrayExpr>(SMTExprKind::ArrayConst,
+                                                    Sort->getBackendKind(),
+                                                    Sort, std::move(SubLeaves));
+  }
+  fatalErrorIf(Pos >= Leaves.size(), "Tuple-array leaf underflow");
+  return Leaves[Pos++];
+}
+
 } // namespace
 
 SMTSortRef mkCamadaTupleSort(SMTSolverImpl &Solver,
@@ -251,6 +421,111 @@ SMTExprRef mkCamadaTupleIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
                "mkCamadaTupleIte on non-tuple branches");
   return Solver.makeExprRef<CamadaTupleExpr>(
       SMTExprKind::Ite, T->getBackendKind(), T->Sort, Cond, T, F);
+}
+
+bool sortContainsTuple(const SMTSortRef &Sort) {
+  if (Sort->isTupleSort())
+    return true;
+  if (Sort->isArraySort())
+    return sortContainsTuple(Sort->getElementSort());
+  return false;
+}
+
+SMTSortRef mkCamadaTupleArraySort(SMTSolverImpl &Solver,
+                                  const SMTSortRef &IndexSort,
+                                  const SMTSortRef &ElemSort) {
+  fatalErrorIf(!sortContainsTuple(ElemSort),
+               "mkCamadaTupleArraySort on a tuple-free element sort");
+  std::vector<SMTSortRef> LeafSorts;
+  collectLeafSortsOf(Solver, ElemSort, LeafSorts);
+  for (auto &Leaf : LeafSorts)
+    Leaf = Solver.mkArraySort(IndexSort, Leaf);
+  return Solver.makeSortRef(CamadaTupleArraySort(
+      IndexSort->getBackendKind(), IndexSort, ElemSort, std::move(LeafSorts)));
+}
+
+SMTExprRef mkCamadaTupleArraySymbol(SMTSolverImpl &Solver,
+                                    const std::string &Name,
+                                    const SMTSortRef &Sort) {
+  const std::vector<SMTSortRef> &LeafSorts = leafSortsOf(Sort);
+  std::vector<SMTExprRef> Leaves;
+  Leaves.reserve(LeafSorts.size());
+  for (std::size_t I = 0; I < LeafSorts.size(); ++I)
+    Leaves.push_back(Solver.mkSymbolUnchecked(
+        "__CAMADA_tuparr_" + Name + "_" + std::to_string(I), LeafSorts[I]));
+  return Solver.makeExprRef<CamadaTupleArrayExpr>(
+      SMTExprKind::Symbol, Sort->getBackendKind(), Sort, std::move(Leaves));
+}
+
+SMTExprRef mkCamadaTupleArraySelect(SMTSolverImpl &Solver,
+                                    const SMTExprRef &Array,
+                                    const SMTExprRef &Index) {
+  const CamadaTupleArrayExpr *AE = toCamadaTupleArrayExpr(Array);
+  fatalErrorIf(AE == nullptr,
+               "mkCamadaTupleArraySelect on a non-bundle expression");
+  std::vector<SMTExprRef> SelectedLeaves;
+  SelectedLeaves.reserve(AE->LeafArrays.size());
+  for (const auto &Leaf : AE->LeafArrays)
+    SelectedLeaves.push_back(Solver.mkArraySelect(Leaf, Index));
+  std::size_t Pos = 0;
+  SMTExprRef Element = assembleFromLeaves(Solver, Array->Sort->getElementSort(),
+                                          SelectedLeaves, Pos);
+  fatalErrorIf(Pos != SelectedLeaves.size(), "Tuple-array leaf overflow");
+  return Element;
+}
+
+SMTExprRef mkCamadaTupleArrayStore(SMTSolverImpl &Solver,
+                                   const SMTExprRef &Array,
+                                   const SMTExprRef &Index,
+                                   const SMTExprRef &Element) {
+  const CamadaTupleArrayExpr *AE = toCamadaTupleArrayExpr(Array);
+  fatalErrorIf(AE == nullptr,
+               "mkCamadaTupleArrayStore on a non-bundle expression");
+  std::vector<SMTExprRef> ElementLeaves;
+  collectLeafExprsOf(Solver, Element, ElementLeaves);
+  fatalErrorIf(ElementLeaves.size() != AE->LeafArrays.size(),
+               "Tuple-array store leaf count mismatch");
+  std::vector<SMTExprRef> StoredLeaves;
+  StoredLeaves.reserve(AE->LeafArrays.size());
+  for (std::size_t I = 0; I < AE->LeafArrays.size(); ++I)
+    StoredLeaves.push_back(
+        Solver.mkArrayStore(AE->LeafArrays[I], Index, ElementLeaves[I]));
+  return Solver.makeExprRef<CamadaTupleArrayExpr>(
+      SMTExprKind::ArrayStore, Array->getBackendKind(), Array->Sort,
+      std::move(StoredLeaves));
+}
+
+SMTExprRef mkCamadaTupleArrayEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
+                                   const SMTExprRef &RHS) {
+  const CamadaTupleArrayExpr *LE = toCamadaTupleArrayExpr(LHS);
+  const CamadaTupleArrayExpr *RE = toCamadaTupleArrayExpr(RHS);
+  fatalErrorIf(LE == nullptr || RE == nullptr,
+               "mkCamadaTupleArrayEqual on a non-bundle expression");
+  fatalErrorIf(LE->LeafArrays.size() != RE->LeafArrays.size(),
+               "Tuple-array equality leaf count mismatch");
+  if (LE->LeafArrays.empty())
+    return Solver.mkBool(true);
+  SMTExprRef Acc = Solver.mkEqual(LE->LeafArrays[0], RE->LeafArrays[0]);
+  for (std::size_t I = 1; I < LE->LeafArrays.size(); ++I)
+    Acc =
+        Solver.mkAnd(Acc, Solver.mkEqual(LE->LeafArrays[I], RE->LeafArrays[I]));
+  return Acc;
+}
+
+SMTExprRef mkCamadaTupleArrayIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
+                                 const SMTExprRef &T, const SMTExprRef &F) {
+  const CamadaTupleArrayExpr *TE = toCamadaTupleArrayExpr(T);
+  const CamadaTupleArrayExpr *FE = toCamadaTupleArrayExpr(F);
+  fatalErrorIf(TE == nullptr || FE == nullptr,
+               "mkCamadaTupleArrayIte on a non-bundle expression");
+  fatalErrorIf(TE->LeafArrays.size() != FE->LeafArrays.size(),
+               "Tuple-array ite leaf count mismatch");
+  std::vector<SMTExprRef> Leaves;
+  Leaves.reserve(TE->LeafArrays.size());
+  for (std::size_t I = 0; I < TE->LeafArrays.size(); ++I)
+    Leaves.push_back(Solver.mkIte(Cond, TE->LeafArrays[I], FE->LeafArrays[I]));
+  return Solver.makeExprRef<CamadaTupleArrayExpr>(
+      SMTExprKind::Ite, T->getBackendKind(), T->Sort, std::move(Leaves));
 }
 
 } // namespace camada

--- a/src/camadatuple.cpp
+++ b/src/camadatuple.cpp
@@ -24,6 +24,7 @@
 #include "camadacommon.h"
 #include "camadaimpl.h"
 
+#include <algorithm>
 #include <utility>
 
 namespace camada {
@@ -543,6 +544,135 @@ SMTExprRef mkCamadaTupleArrayIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
     Leaves.push_back(Solver.mkIte(Cond, TE->LeafArrays[I], FE->LeafArrays[I]));
   return Solver.makeExprRef<CamadaTupleArrayExpr>(
       SMTExprKind::Ite, T->getBackendKind(), T->Sort, std::move(Leaves));
+}
+
+SMTExprRef getCamadaTupleArrayElement(SMTSolverImpl &Solver,
+                                      const SMTExprRef &Array,
+                                      const SMTExprRef &Index) {
+  const CamadaTupleArrayExpr *AE = toCamadaTupleArrayExpr(Array);
+  fatalErrorIf(AE == nullptr,
+               "getCamadaTupleArrayElement on a non-bundle expression");
+  std::vector<SMTExprRef> ElementLeaves;
+  ElementLeaves.reserve(AE->LeafArrays.size());
+  for (const auto &Leaf : AE->LeafArrays)
+    ElementLeaves.push_back(Solver.getArrayElement(Leaf, Index));
+  std::size_t Pos = 0;
+  SMTExprRef Element = assembleFromLeaves(Solver, Array->Sort->getElementSort(),
+                                          ElementLeaves, Pos);
+  fatalErrorIf(Pos != ElementLeaves.size(), "Tuple-array leaf overflow");
+  return Element;
+}
+
+SMTResult<ArrayModel> getCamadaTupleArrayValues(SMTSolverImpl &Solver,
+                                                const SMTExprRef &Array) {
+  const CamadaTupleArrayExpr *AE = toCamadaTupleArrayExpr(Array);
+  fatalErrorIf(AE == nullptr,
+               "getCamadaTupleArrayValues on a non-bundle expression");
+
+  // One sparse model per leaf array. Each entry/base value is a leaf-sort
+  // value (scalar or native array) usable as a tuple component.
+  std::vector<ArrayModel> LeafModels;
+  LeafModels.reserve(AE->LeafArrays.size());
+  for (const auto &Leaf : AE->LeafArrays) {
+    SMTResult<ArrayModel> Leaf_M = Solver.getArrayValues(Leaf);
+    if (!Leaf_M)
+      return Leaf_M.error();
+    LeafModels.push_back(std::move(Leaf_M.value()));
+  }
+
+  const SMTSortRef &ElementSort = Array->Sort->getElementSort();
+
+  // Canonicalize an index by its model value (the ArrayModel contract is
+  // value-based, never term identity). Bool and BV index sorts are the
+  // only ones the lazy machinery produces entries for; anything else
+  // cannot be canonicalized.
+  auto indexBitsOf = [&](const SMTExprRef &Idx) -> std::string {
+    if (Idx->isBoolSort()) {
+      SMTResult<bool> V = Solver.getBool(Idx);
+      return V ? std::string(V.value() ? "1" : "0") : std::string();
+    }
+    if (Idx->isBVSort()) {
+      SMTResult<std::string> V = Solver.getBVInBin(Idx);
+      return V ? V.value() : std::string();
+    }
+    return std::string();
+  };
+
+  // The defined indexes are the union across leaves, canonicalized by
+  // model value — aliased indexes across leaves merge to one tuple entry.
+  // Keep the first index expression seen for each value; iteration order
+  // is leaf-major so the result is deterministic.
+  std::vector<SMTExprRef> IndexExprs;
+  std::vector<std::string> IndexBits;
+  for (const ArrayModel &M : LeafModels) {
+    for (const auto &Entry : M.Entries) {
+      const std::string Bits = indexBitsOf(Entry.first);
+      if (Bits.empty())
+        return SMTError{SMTErrorCode::BackendError, Array->getBackendKind(),
+                        "Could not canonicalize a tuple-array model index"};
+      if (std::find(IndexBits.begin(), IndexBits.end(), Bits) ==
+          IndexBits.end()) {
+        IndexBits.push_back(Bits);
+        IndexExprs.push_back(Entry.first);
+      }
+    }
+  }
+
+  // Per leaf, resolve the value at a given index by its model value: the
+  // first matching entry wins, else the leaf base.
+  auto leafValueAt = [&](const ArrayModel &M, const std::string &Bits,
+                         bool &Found) -> SMTExprRef {
+    for (const auto &Entry : M.Entries) {
+      if (indexBitsOf(Entry.first) == Bits) {
+        Found = true;
+        return Entry.second;
+      }
+    }
+    if (M.Base) {
+      Found = true;
+      return M.Base;
+    }
+    Found = false;
+    return {};
+  };
+
+  ArrayModel Result;
+  for (std::size_t K = 0; K < IndexExprs.size(); ++K) {
+    std::vector<SMTExprRef> LeafValues;
+    LeafValues.reserve(LeafModels.size());
+    for (const ArrayModel &M : LeafModels) {
+      bool Found = false;
+      SMTExprRef V = leafValueAt(M, IndexBits[K], Found);
+      if (!Found)
+        return SMTError{SMTErrorCode::UnsupportedOperation,
+                        Array->getBackendKind(),
+                        "A tuple-array leaf has no value at a defined index "
+                        "and no base default"};
+      LeafValues.push_back(V);
+    }
+    std::size_t Pos = 0;
+    Result.Entries.emplace_back(
+        IndexExprs[K],
+        assembleFromLeaves(Solver, ElementSort, LeafValues, Pos));
+  }
+
+  // Base: a tuple of the per-leaf bases, only when every leaf has one.
+  bool AllBases = true;
+  std::vector<SMTExprRef> BaseLeaves;
+  BaseLeaves.reserve(LeafModels.size());
+  for (const ArrayModel &M : LeafModels) {
+    if (!M.Base) {
+      AllBases = false;
+      break;
+    }
+    BaseLeaves.push_back(M.Base);
+  }
+  if (AllBases) {
+    std::size_t Pos = 0;
+    Result.Base = assembleFromLeaves(Solver, ElementSort, BaseLeaves, Pos);
+  }
+
+  return Result;
 }
 
 } // namespace camada

--- a/src/camadatuple.cpp
+++ b/src/camadatuple.cpp
@@ -495,6 +495,23 @@ SMTExprRef mkCamadaTupleArrayStore(SMTSolverImpl &Solver,
       std::move(StoredLeaves));
 }
 
+SMTExprRef mkCamadaTupleArrayConst(SMTSolverImpl &Solver,
+                                   const SMTSortRef &IndexSort,
+                                   const SMTExprRef &InitValue,
+                                   ConstArrayLowering Lowering) {
+  fatalErrorIf(!sortContainsTuple(InitValue->Sort),
+               "mkCamadaTupleArrayConst on a tuple-free initializer");
+  SMTSortRef Sort = Solver.mkArraySort(IndexSort, InitValue->Sort);
+  std::vector<SMTExprRef> InitLeaves;
+  collectLeafExprsOf(Solver, InitValue, InitLeaves);
+  std::vector<SMTExprRef> Leaves;
+  Leaves.reserve(InitLeaves.size());
+  for (const auto &Init : InitLeaves)
+    Leaves.push_back(Solver.mkArrayConst(IndexSort, Init, Lowering));
+  return Solver.makeExprRef<CamadaTupleArrayExpr>(
+      SMTExprKind::ArrayConst, Sort->getBackendKind(), Sort, std::move(Leaves));
+}
+
 SMTExprRef mkCamadaTupleArrayEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
   const CamadaTupleArrayExpr *LE = toCamadaTupleArrayExpr(LHS);

--- a/src/camadatuple.h
+++ b/src/camadatuple.h
@@ -58,6 +58,43 @@ SMTExprRef mkCamadaTupleEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
 SMTExprRef mkCamadaTupleIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
                             const SMTExprRef &T, const SMTExprRef &F);
 
+/// True when Sort is a tuple sort or an array sort whose element sort
+/// (recursively) involves a tuple. Drives the decomposed tuple-array
+/// dispatch: such sorts have no backend representation on backends
+/// without native datatype support.
+bool sortContainsTuple(const SMTSortRef &Sort);
+
+/// Camada-managed arrays of tuples: an `Array<Idx, T>` where T involves a
+/// tuple is represented as a bundle of per-leaf-field backend arrays —
+/// `Array<Idx, Tuple{BV32, Tuple{Bool}}>` becomes `{Array<Idx, BV32>,
+/// Array<Idx, Bool>}`. The tuple structure is dissolved at the Camada
+/// layer; all array reasoning stays in the backend's native theory.
+/// Operations recurse leaf-wise, so arbitrary tuple/array nesting
+/// flattens to native nested-arrays-of-scalars.
+
+SMTSortRef mkCamadaTupleArraySort(SMTSolverImpl &Solver,
+                                  const SMTSortRef &IndexSort,
+                                  const SMTSortRef &ElemSort);
+
+SMTExprRef mkCamadaTupleArraySymbol(SMTSolverImpl &Solver,
+                                    const std::string &Name,
+                                    const SMTSortRef &Sort);
+
+SMTExprRef mkCamadaTupleArraySelect(SMTSolverImpl &Solver,
+                                    const SMTExprRef &Array,
+                                    const SMTExprRef &Index);
+
+SMTExprRef mkCamadaTupleArrayStore(SMTSolverImpl &Solver,
+                                   const SMTExprRef &Array,
+                                   const SMTExprRef &Index,
+                                   const SMTExprRef &Element);
+
+SMTExprRef mkCamadaTupleArrayEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
+                                   const SMTExprRef &RHS);
+
+SMTExprRef mkCamadaTupleArrayIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
+                                 const SMTExprRef &T, const SMTExprRef &F);
+
 } // namespace camada
 
 #endif

--- a/src/camadatuple.h
+++ b/src/camadatuple.h
@@ -100,6 +100,20 @@ SMTExprRef mkCamadaTupleArrayEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
 SMTExprRef mkCamadaTupleArrayIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
                                  const SMTExprRef &T, const SMTExprRef &F);
 
+/// Model extraction for decomposed tuple arrays. getCamadaTupleArrayElement
+/// reads each leaf array at Index through the public getArrayElement and
+/// reassembles the per-leaf values into a tuple value — exact single-index
+/// recovery. getCamadaTupleArrayValues zips the per-leaf sparse ArrayModels
+/// into one tuple-valued ArrayModel: indexes are unioned by model value,
+/// and the Base is a tuple of the per-leaf bases only when every leaf
+/// reports one (otherwise null — no fabricated partial default).
+SMTExprRef getCamadaTupleArrayElement(SMTSolverImpl &Solver,
+                                      const SMTExprRef &Array,
+                                      const SMTExprRef &Index);
+
+SMTResult<ArrayModel> getCamadaTupleArrayValues(SMTSolverImpl &Solver,
+                                                const SMTExprRef &Array);
+
 } // namespace camada
 
 #endif

--- a/src/camadatuple.h
+++ b/src/camadatuple.h
@@ -89,6 +89,11 @@ SMTExprRef mkCamadaTupleArrayStore(SMTSolverImpl &Solver,
                                    const SMTExprRef &Index,
                                    const SMTExprRef &Element);
 
+SMTExprRef mkCamadaTupleArrayConst(SMTSolverImpl &Solver,
+                                   const SMTSortRef &IndexSort,
+                                   const SMTExprRef &InitValue,
+                                   ConstArrayLowering Lowering);
+
 SMTExprRef mkCamadaTupleArrayEqual(SMTSolverImpl &Solver, const SMTExprRef &LHS,
                                    const SMTExprRef &RHS);
 

--- a/src/mathsatsolver.cpp
+++ b/src/mathsatsolver.cpp
@@ -954,6 +954,17 @@ MathSATSolver::getArrayValuesImpl(const SMTExprRef &Array) {
     return makeExprRef<MathSATExpr>(valueKindForSort(Sort), &Context, Sort,
                                     Value);
   };
+  // Bool-element arrays are stored as BV1 (mkArraySortImpl), so the model
+  // write chain yields BV1 constants where a Bool value is expected;
+  // recover the Bool literal the same way mkArraySelectImpl does.
+  const auto wrapElem = [&](msat_term Value) {
+    if (!ElemSort->isBoolSort())
+      return wrap(Value, ElemSort);
+    const SMTExprRef &one = mkBVFromDec(1, mkBVSort(1));
+    return makeExprRef<MathSATExpr>(
+        SMTExprKind::BoolConst, &Context, mkBoolSort(),
+        msat_make_eq(Context, Value, toMathSATTerm(one)));
+  };
 
   msat_term Val = msat_get_model_value(Context, toMathSATTerm(Array));
   if (MSAT_ERROR_TERM(Val))
@@ -962,11 +973,11 @@ MathSATSolver::getArrayValuesImpl(const SMTExprRef &Array) {
   ArrayModel Result;
   while (msat_term_is_array_write(Context, Val)) {
     Result.Entries.emplace_back(wrap(msat_term_get_arg(Val, 1), IndexSort),
-                                wrap(msat_term_get_arg(Val, 2), ElemSort));
+                                wrapElem(msat_term_get_arg(Val, 2)));
     Val = msat_term_get_arg(Val, 0);
   }
   if (msat_term_is_array_const(Context, Val))
-    Result.Base = wrap(msat_term_get_arg(Val, 0), ElemSort);
+    Result.Base = wrapElem(msat_term_get_arg(Val, 0));
   return Result;
 }
 

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -131,6 +131,11 @@ SMTSortRef STPSolver::mkBVRMSortImpl() {
 
 SMTSortRef STPSolver::mkArraySortImpl(const SMTSortRef &IndexSort,
                                       const SMTSortRef &ElemSort) {
+  // STP's array theory is strictly BV-indexed, BV-valued (bools are
+  // adapted below); arrays of arrays do not exist in it, and passing one
+  // through would trip STP's own fatal handler with a cryptic message.
+  fatalErrorIf(IndexSort->isArraySort() || ElemSort->isArraySort(),
+               "Nested arrays are not supported by STP");
   const SMTSortRef &backend_elem_sort =
       ElemSort->isBoolSort() ? mkBVSort(1) : ElemSort;
   return makeSortRef<STPSort>(


### PR DESCRIPTION
Implements the custom tuple subsystem from `tuple-plan.md` — the solver-side machinery to eventually replace ESBMC's own tuple/tuple-array lowering. One commit per phase; supersedes the earlier stacked PRs #99, #100, #101.

On backends with native datatypes (Z3, CVC5, SMT-LIB native mode) tuples and arrays of tuples pass straight through. On backends without them (Bitwuzla, MathSAT, STP, Yices, SMT-LIB Camada mode) they are dissolved at the Camada layer into native scalar/array operations, so all array reasoning stays in the backend's own theory — no software array encoding.

## Commits (one per phase)

1. **Add mkTupleUpdate to the public tuple API** — `mkTupleUpdate(T, k, V)` returns a tuple equal to T except at field k. ESBMC's choke point for `with`-on-struct and pointer-arithmetic updates; constant index only, matching what ESBMC asserts. Native updater on datatype backends, select-and-rebuild on the decomposed path.

3. **Add decomposed tuple-array core for solvers without datatypes** — `Array<I, Tuple{...}>` becomes a `CamadaTupleArrayExpr` bundle of one native backend array per scalar leaf, applied recursively (`Array<I, Tuple{...}> ≅ Tuple{Array<I, ...>}`) so arbitrary tuple/array nesting flattens to native nested-arrays-of-scalars. Select/store/equality/ite distribute over leaves and re-enter the public wrappers, so the v0.12 lazy const-array, encoded-equality and index-observation machinery applies per leaf unchanged. Dispatch boundaries hardened (`mkFunctionSort`, quantifier bound vars, array index sorts) and STP nested-array gap reported loudly.

4. **Support constant arrays of tuples through per-leaf lowering** — `mkArrayConst` with a tuple initializer decomposes into one constant array per scalar leaf, each re-entering the public wrapper so the resolved lowering (native or lazy) applies per leaf. Nested constant tuple arrays work where constant arrays are native (Z3, CVC5, MathSAT) and abort cleanly on lazy-lowering backends. Covers ESBMC's `pointer_array_of` scenario.

5. **Extract models from decomposed tuple arrays** — `getArrayElement` reassembles a tuple value from per-leaf reads (exact single-index recovery); `getArrayValues` zips the per-leaf sparse models into one tuple-valued model, unioning indexes by model value and producing a tuple `Base` only when every leaf reports one (no fabricated partial defaults). Also fixes a pre-existing MathSAT bug surfaced here: Bool-element arrays are stored as BV1, so `getArrayValuesImpl` returned BV1 constants tagged as Bool that `getBool` could not evaluate — now recovered as a Bool literal exactly as `mkArraySelectImpl` does.

## Tests

New fixtures in `regression/tuple.test.h`, run across all 7 backends (most under both `Auto` and `Lazy` constant-array lowering): `tuple_update_semantics`, `tuple_array_semantics`, `tuple_array_equality_ite`, `tuple_array_const`, `tuple_array_model_values` (exact recovery + sparse zip, written and default indexes, bool field, and a symbolic no-base case), plus per-backend deep-nesting (5-level alternation) and nested-constant-array success/abort pins. Full suite: **177/177**.

## Remaining (not in this PR)

Phase 2 (ESBMC adapter skeleton) and phase 6 (adapter completion against ESBMC's regression suite) live in the ESBMC tree, not camada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
