### PR TITLE
Support nested lazily-lowered constant arrays

### DIFF
--- a/regression/array.test.h
+++ b/regression/array.test.h
@@ -457,6 +457,198 @@ inline void const_array_equality_semantics(
   REQUIRE(solver->check() == camada::checkResult::UNSAT);
 }
 
+// A symbol array equated to one lazy const array, then disequated from a
+// second — exercises the encoded-equality witness over an operand that is
+// itself a plain symbol equated (via a separate encoded equality) to a
+// lazy root. The disequality's witness is unobserved, so the symbol=root
+// congruence does not bind there: the model must be free to exhibit a real
+// difference, yet a forced agreement at a concrete index must still hold.
+inline void lazy_array_transitive_equality(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto arrsort = solver->mkArraySort(bv8, bv8);
+
+  // B = array_of(7); C = array_of(9); B != C is satisfiable (they differ
+  // at every index, exhibitable at the disequality's own witness).
+  auto b = solver->mkSymbol("lat_b", arrsort);
+  auto c = solver->mkSymbol("lat_c", arrsort);
+  solver->addConstraint(
+      solver->mkEqual(b, solver->mkArrayConst(bv8, idx(7), Lowering)));
+  solver->addConstraint(
+      solver->mkEqual(c, solver->mkArrayConst(bv8, idx(9), Lowering)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(b, c)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // But B's value is still pinned: reading B at any index must be 7, even
+  // though B != C let the solver pick a witness where B and C differ.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  arrsort = solver->mkArraySort(bv8, bv8);
+  auto b2 = solver->mkSymbol("lat_b2", arrsort);
+  auto c2 = solver->mkSymbol("lat_c2", arrsort);
+  solver->addConstraint(
+      solver->mkEqual(b2, solver->mkArrayConst(bv8, idx(7), Lowering)));
+  solver->addConstraint(
+      solver->mkEqual(c2, solver->mkArrayConst(bv8, idx(9), Lowering)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(b2, c2)));
+  auto m = solver->mkSymbol("lat_m", bv8);
+  solver->addConstraint(
+      solver->mkNot(solver->mkEqual(solver->mkArraySelect(b2, m), idx(7))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Constant array whose initializer is itself a constant array —
+// array_of(array_of(v)), ESBMC's multidimensional `array_of`. On native
+// constant-array backends the inner const array is just an array-sorted
+// element; on lazy backends both levels lower lazily, so the outer
+// default axiom is an array equality between select(outer, i) and the
+// inner lazy root. This pins read-through, store-over-inner, the
+// negative direction, equality propagation, and model round-trip.
+inline void nested_const_array_semantics(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto innerSort = solver->mkArraySort(bv8, bv8);
+
+  // Default read-through: every cell of the outer array is the inner
+  // const array, whose every cell is v. So select(select(outer,i),j)==v.
+  auto inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  auto outer = solver->mkArrayConst(bv8, inner, Lowering);
+  REQUIRE(outer->Sort->getElementSort() == innerSort);
+  auto i = solver->mkSymbol("i", bv8);
+  auto j = solver->mkSymbol("j", bv8);
+  auto deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(deep, idx(7))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Store into the inner array at a concrete index, read elsewhere: the
+  // written cell holds the stored value, every other cell the default.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  auto innerStored = solver->mkArrayStore(inner, idx(2), idx(99));
+  auto k = solver->mkSymbol("k", bv8);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(k, idx(2))));
+  auto ok = solver->mkAnd(
+      solver->mkEqual(solver->mkArraySelect(innerStored, idx(2)), idx(99)),
+      solver->mkEqual(solver->mkArraySelect(innerStored, k), idx(7)));
+  solver->addConstraint(solver->mkNot(ok));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Negative direction must stay satisfiable: a deep read equal to a
+  // value different from the default is impossible, but equal to the
+  // default is fine — no false UNSAT, and no spurious model either.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  outer = solver->mkArrayConst(bv8, inner, Lowering);
+  i = solver->mkSymbol("i2", bv8);
+  j = solver->mkSymbol("j2", bv8);
+  deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
+  solver->addConstraint(solver->mkEqual(deep, idx(7)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  outer = solver->mkArrayConst(bv8, inner, Lowering);
+  i = solver->mkSymbol("i3", bv8);
+  j = solver->mkSymbol("j3", bv8);
+  deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
+  solver->addConstraint(solver->mkEqual(deep, idx(8))); // != default 7
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Equality propagation: two equal nested const arrays agree on a deep
+  // read even when one side was derived before the equality.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  innerSort = solver->mkArraySort(bv8, bv8);
+  auto outerSort = solver->mkArraySort(bv8, innerSort);
+  auto a = solver->mkSymbol("a", outerSort);
+  i = solver->mkSymbol("i4", bv8);
+  j = solver->mkSymbol("j4", bv8);
+  auto aDeep = solver->mkArraySelect(solver->mkArraySelect(a, i), j);
+  solver->addConstraint(solver->mkEqual(
+      a, solver->mkArrayConst(bv8, solver->mkArrayConst(bv8, idx(5), Lowering),
+                              Lowering)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(aDeep, idx(5))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Model round-trip: getArrayElement on the outer returns an inner
+  // array whose deep read matches the default.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  outer = solver->mkArrayConst(bv8, inner, Lowering);
+  // Touch a deep cell so the array is in the formula on every backend.
+  solver->addConstraint(solver->mkEqual(
+      solver->mkArraySelect(solver->mkArraySelect(outer, idx(0)), idx(0)),
+      idx(7)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  auto innerModel = solver->getArrayElement(outer, idx(1));
+  REQUIRE(innerModel->Sort == solver->mkArraySort(bv8, bv8));
+  auto cell = solver->getBV(solver->getArrayElement(innerModel, idx(3)));
+  REQUIRE(cell);
+  REQUIRE(cell.value() == 7);
+
+  // Adversarial: two independent inner-array disequalities must each be
+  // exhibitable at their OWN witness index — a shared witness would
+  // conflate them and force a spurious UNSAT. Each equality's negative
+  // witness is fresh, so this stays SAT.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  innerSort = solver->mkArraySort(bv8, bv8);
+  auto m1 = solver->mkSymbol("m1", innerSort);
+  auto n1 = solver->mkSymbol("n1", innerSort);
+  auto m2 = solver->mkSymbol("m2", innerSort);
+  auto n2 = solver->mkSymbol("n2", innerSort);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(m1, n1)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(m2, n2)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // Adversarial negative direction with a lazy const array: a difference
+  // claimed against the default must be a real one. select(outer,i) is the
+  // inner const array (all 7s); claiming select(select(outer,i),j) == 4 is
+  // impossible, but the model must not fabricate a difference at an
+  // unobserved index — pinned by the witness default. UNSAT.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  outer = solver->mkArrayConst(bv8, inner, Lowering);
+  auto sym = solver->mkSymbol("sym", solver->mkArraySort(bv8, bv8));
+  i = solver->mkSymbol("i5", bv8);
+  // sym equals the inner const array, but disagrees with it at j: UNSAT,
+  // because sym = select(outer,i) = inner forces agreement everywhere
+  // observed.
+  solver->addConstraint(solver->mkEqual(sym, solver->mkArraySelect(outer, i)));
+  auto j5 = solver->mkSymbol("j5", bv8);
+  solver->addConstraint(
+      solver->mkNot(solver->mkEqual(solver->mkArraySelect(sym, j5), idx(7))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// nested_const_array_semantics inside a pushed scope: the deep default
+// asserted in the scope must still bind handles that outlive the pop.
+inline void nested_const_array_survives_pop(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  auto outer = solver->mkArrayConst(bv8, inner, Lowering);
+  auto i = solver->mkSymbol("ncsp_i", bv8);
+  auto j = solver->mkSymbol("ncsp_j", bv8);
+
+  solver->push();
+  auto deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
+  solver->pop();
+
+  solver->addConstraint(solver->mkNot(solver->mkEqual(deep, idx(7))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
 inline void const_array_lowering_interop(const camada::SMTSolverRef &solver) {
   auto idx = solver->mkBVSort(8);
   auto elem = solver->mkBVSort(8);

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -176,3 +176,16 @@ TEST_CASE("Bitwuzla feature capabilities", "[Bitwuzla]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays Bitwuzla test", "[Bitwuzla]") {
+  auto solver = camada::createBitwuzlaSolver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
+}

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -155,3 +155,16 @@ TEST_CASE("CVC5 feature capabilities", "[CVC5]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays CVC5 test", "[CVC5]") {
+  auto solver = camada::createCVC5Solver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
+}

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -233,3 +233,16 @@ TEST_CASE("MathSAT feature capabilities", "[MathSAT]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays MathSAT test", "[MathSAT]") {
+  auto solver = camada::createMathSATSolver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
+}

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -32,3 +32,8 @@ TEST_CASE("STP feature capabilities", "[STP]") {
   REQUIRE_FALSE(solver->supports(SolverFeature::Timeouts));
   REQUIRE_FALSE(solver->supports(SolverFeature::ArrayModels));
 }
+
+TEST_CASE("Unsupported nested constant arrays STP test", "[STP]") {
+  auto stp = camada::createSTPSolver();
+  require_abort([&]() { nested_const_array_semantics(stp); });
+}

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -76,6 +76,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(array_model_values);
   RESETANDTEST(const_array_model_values);
   RESETANDARGTEST(const_array_model_values, LazyArrays);
+  RESETANDTEST(lazy_array_transitive_equality);
+  RESETANDARGTEST(lazy_array_transitive_equality, LazyArrays);
   RESETANDTEST(const_array_lowering_interop);
   RESETANDTEST(tuple_semantics);
   RESETANDTEST(tuple_with_array_field);

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -231,3 +231,16 @@ TEST_CASE("Yices feature capabilities", "[Yices]") {
 #endif
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays Yices test", "[Yices]") {
+  auto solver = camada::createYicesSolver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
+}

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -186,3 +186,16 @@ TEST_CASE("Z3 feature capabilities", "[Z3]") {
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 }
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays Z3 test", "[Z3]") {
+  auto solver = camada::createZ3Solver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
+}

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -680,36 +680,21 @@ SMTExprRef SMTSolverImpl::mkEqual(const SMTExprRef &LHS,
   if (LHS->Sort->isArraySort()) {
     const bool LazyInvolved = !LazyConstArrayRoots.empty() &&
                               (reachesLazyArray(LHS) || reachesLazyArray(RHS));
-    // Backends without native array extensionality (STP) cannot decide
-    // array equality at all — their only array predicate is select — so
-    // every array equality is lowered to the witness + observed-index
-    // congruence encoding. Its witness selects also instantiate any lazy
-    // defaults, so this subsumes the lazy lemma below.
-    if (!nativeArrayExtensionality())
+    // Two cases need the witness + observed-index congruence encoding:
+    //  - Backends without native array extensionality (STP) cannot decide
+    //    array equality at all — their only array predicate is select.
+    //  - A lazy root's default axiom binds only at observed indexes, so on
+    //    any backend native equality alone could fake a difference (or
+    //    agreement) at an unobserved index.
+    // Both route through mkEncodedArrayEqual, whose witness selects also
+    // instantiate lazy defaults. Crucially, when the element sort is itself
+    // an array the encoded witness's inner equality re-enters this same
+    // path, strictly decreasing element-array depth — so nested lazy const
+    // arrays (array_of(array_of(v))) terminate. An inline native witness
+    // here would instead recurse through mkEqual, spawning a fresh witness
+    // index per level whose observation re-fires the default unboundedly.
+    if (!nativeArrayExtensionality() || LazyInvolved)
       return mkEncodedArrayEqual(LHS, RHS);
-    if (LazyInvolved) {
-      // Extensionality witness for lazy constant arrays. The backend
-      // decides array equality natively, but a lazy root's default axiom
-      // is only instantiated at observed indexes, so a model could fake a
-      // difference (or agreement) at an unobserved index. The standard
-      // reduction plugs this: a fresh witness index per equality, the
-      // universally valid lemma
-      //   LHS = RHS  \/  select(LHS, K) != select(RHS, K)
-      // and default instantiation at K (done by mkArraySelect below). Any
-      // model claiming LHS != RHS must now exhibit the difference at K,
-      // where defaults are enforced.
-      SMTExprRef Witness = mkSymbolUnchecked(
-          "__CAMADA_lazyarr_ext" + std::to_string(LazyConstArrayCounter++),
-          LHS->Sort->getIndexSort());
-      SMTExprRef SelL = mkArraySelect(LHS, Witness);
-      SMTExprRef SelR = mkArraySelect(RHS, Witness);
-      SMTExprRef theEq = mkEqualImpl(LHS, RHS);
-      assert(theEq->isBoolSort());
-      SMTExprRef Lemma = mkOr(theEq, mkNot(mkEqual(SelL, SelR)));
-      addConstraint(Lemma);
-      LazyConstraintLevels.back().push_back(std::move(Lemma));
-      return theEq;
-    }
   }
   SMTExprRef theExp = mkEqualImpl(LHS, RHS);
   assert(theExp->isBoolSort());
@@ -1189,6 +1174,17 @@ SMTExprRef SMTSolverImpl::mkArraySelect(const SMTExprRef &Array,
   return theExp;
 }
 
+SMTExprRef SMTSolverImpl::mkArraySelectUnobserved(const SMTExprRef &Array,
+                                                  const SMTExprRef &Index) {
+  fatalErrorIf(!Array->isArraySort(), "Expected array expression");
+  fatalErrorIf(Array->Sort->getIndexSort() != Index->Sort,
+               "Expected array index with matching sort");
+  // Deliberately NOT observeArrayIndex(Index): see the header.
+  SMTExprRef theExp = mkArraySelectImpl(Array, Index);
+  assert(theExp->Sort == Array->Sort->getElementSort());
+  return theExp;
+}
+
 SMTExprRef SMTSolverImpl::mkArrayStore(const SMTExprRef &Array,
                                        const SMTExprRef &Index,
                                        const SMTExprRef &Element) {
@@ -1229,9 +1225,14 @@ bool SMTSolverImpl::reachesLazyArray(const SMTExprRef &Exp) const {
 
 SMTExprRef SMTSolverImpl::mkLazyConstArray(const SMTSortRef &IndexSort,
                                            const SMTExprRef &InitValue) {
-  fatalErrorIf(InitValue->isArraySort() && reachesLazyArray(InitValue),
-               "Lazily lowered constant arrays cannot be nested inside one "
-               "another");
+  // A lazy const array whose initializer is itself a lazy const array
+  // (array_of(array_of(v))) is sound: the outer default axiom is the
+  // array equality select(outer, i) == inner, which routes through the
+  // extensionality witness (native-extensionality backends) or the
+  // encoded-equality congruence (STP). A read select(select(outer,i), j)
+  // observes j at the inner index sort, firing inner's default there, and
+  // the equality propagates it to j. Model extraction returns the inner
+  // lazy array as the base; the consumer re-queries it via getArrayElement.
   SMTSortRef ArraySort = mkArraySort(IndexSort, InitValue->Sort);
   SMTExprRef Root = mkSymbolUnchecked(
       "__CAMADA_lazyarr" + std::to_string(LazyConstArrayCounter++), ArraySort);
@@ -1260,6 +1261,26 @@ void SMTSolverImpl::instantiateLazyDefaultAt(const SMTExpr *RootKey,
   // Copy: the maps may rehash while the constraint is built.
   const LazyConstArrayRoot Root = LazyConstArrayRoots.at(RootKey);
   SMTExprRef Constraint = mkEqual(mkArraySelect(Root.Root, Index), Root.Init);
+  addConstraint(Constraint);
+  LazyConstraintLevels.back().push_back(std::move(Constraint));
+}
+
+void SMTSolverImpl::instantiateLazyDefaultAtUnobserved(
+    const SMTExpr *RootKey, const SMTExprRef &Index) {
+  // Memo-first, like instantiateLazyDefaultAt: here it guards the nested
+  // recursion (the mkEqual below re-enters mkEncodedArrayEqual for array
+  // initializers), not an observeArrayIndex re-entry — the select is
+  // unobserved.
+  if (!LazyTouched.insert({RootKey, &*Index}).second)
+    return;
+  const LazyConstArrayRoot Root = LazyConstArrayRoots.at(RootKey);
+  // The select is built on the unobserved path: Index is a witness, read
+  // only inside the equality lemma that produced it. When Root.Init is
+  // itself an array (the nested lazy case) this mkEqual re-enters
+  // mkEncodedArrayEqual with a fresh witness, again unobserved — strictly
+  // decreasing element-array depth, so it terminates.
+  SMTExprRef Constraint =
+      mkEqual(mkArraySelectUnobserved(Root.Root, Index), Root.Init);
   addConstraint(Constraint);
   LazyConstraintLevels.back().push_back(std::move(Constraint));
 }
@@ -1319,17 +1340,41 @@ SMTExprRef SMTSolverImpl::mkEncodedArrayEqual(const SMTExprRef &LHS,
   }
 
   // Negative direction: a claimed difference must be exhibitable at the
-  // witness. The selects below also flow through mkArraySelect, which
-  // asserts this link's congruence at W and instantiates lazy defaults,
-  // so EqVar is fully tied to the arrays' contents at W.
+  // witness. The witness is a fresh index read ONLY here, so its selects
+  // use the unobserved path — registering it as a sort-global observed
+  // index would re-fire every lazy root (including ones registered under
+  // the witness's own sort) at a brand-new index, which for nested lazy
+  // const arrays never terminates (each cycle mints another witness).
+  // enforceWitnessFacts instead pins exactly LHS's and RHS's lazy defaults
+  // at the witness, which is all soundness needs. When the element sort is
+  // itself an array, the inner mkEqual below re-enters this function with a
+  // fresh witness, strictly decreasing element-array depth, so it
+  // terminates.
   SMTExprRef Witness = mkSymbolUnchecked(
       "__CAMADA_arreq_wit" + std::to_string(ArrayEqualCounter++),
       LHS->Sort->getIndexSort());
-  SMTExprRef Lemma = mkOr(EqVar, mkNot(mkEqual(mkArraySelect(LHS, Witness),
-                                               mkArraySelect(RHS, Witness))));
+  SMTExprRef LSel = mkArraySelectUnobserved(LHS, Witness);
+  SMTExprRef RSel = mkArraySelectUnobserved(RHS, Witness);
+  enforceWitnessFacts(LHS, RHS, Witness);
+  SMTExprRef Lemma = mkOr(EqVar, mkNot(mkEqual(LSel, RSel)));
   addConstraint(Lemma);
   LazyConstraintLevels.back().push_back(std::move(Lemma));
   return EqVar;
+}
+
+void SMTSolverImpl::enforceWitnessFacts(const SMTExprRef &LHS,
+                                        const SMTExprRef &RHS,
+                                        const SMTExprRef &Witness) {
+  if (LazyConstArrayRoots.empty())
+    return;
+  // Pin each operand's lazy-root default at the witness so select(op, W)
+  // is determined (modulo the operand's store/ite chain, which the backend
+  // select already models). Scoped to these two operands; the sort-global
+  // root/link fan-out is intentionally not touched. The unobserved
+  // instantiation keeps the witness out of the global observed set.
+  for (const SMTExprRef &Operand : {LHS, RHS})
+    for (const SMTExpr *RootKey : lazyArrayRootsOf(Operand))
+      instantiateLazyDefaultAtUnobserved(RootKey, Witness);
 }
 
 void SMTSolverImpl::assertArrayEqualCongruence(std::size_t LinkId,

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -180,6 +180,16 @@ protected:
       ObservedIndexesBySort;
   std::set<std::pair<const SMTSort *, const SMTExpr *>> ObservedIndexSeen;
   void observeArrayIndex(const SMTExprRef &Index);
+
+  // Build select(Array, Index) WITHOUT registering Index as a sort-global
+  // observed index. Used only for encoded-equality witnesses: a fresh
+  // witness is read at exactly one syntactic position (its equality's
+  // lemma), so the sort-global fan-out observeArrayIndex performs is never
+  // needed for it — and for nested lazy const arrays that fan-out is
+  // exactly what fails to terminate, since the witness's own observation
+  // re-fires the roots it was minted under, each time at a new witness.
+  SMTExprRef mkArraySelectUnobserved(const SMTExprRef &Array,
+                                     const SMTExprRef &Index);
   // True while a model query (getArrayElement) is evaluating: selects
   // built for evaluation must not instantiate default axioms or count as
   // formula observations — asserting after check() invalidates the
@@ -219,6 +229,16 @@ protected:
   SMTExprRef mkEncodedArrayEqual(const SMTExprRef &LHS, const SMTExprRef &RHS);
   void assertArrayEqualCongruence(std::size_t LinkId, const SMTExprRef &Index);
 
+  // Enforce, at an encoded equality's fresh (non-observed) witness, exactly
+  // the lazy default axioms its two operands need so a claimed difference at
+  // the witness is a real one and not fabricated where a value is
+  // unconstrained. Scoped to LHS/RHS only — never the sort-global root set —
+  // and uses the unobserved select path so the witness is never globally
+  // observed. Array-element operands are handled by the structural recursion
+  // in mkEncodedArrayEqual (the inner select equality re-enters it).
+  void enforceWitnessFacts(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                           const SMTExprRef &Witness);
+
   /// Lower a constant array as a fresh backend array symbol whose
   /// "every element equals InitValue" semantics are enforced lazily: the
   /// default axiom is instantiated at each index term the formula observes
@@ -235,6 +255,11 @@ protected:
   bool reachesLazyArray(const SMTExprRef &Exp) const;
   void instantiateLazyDefaultAt(const SMTExpr *RootKey,
                                 const SMTExprRef &Index);
+  // As instantiateLazyDefaultAt, but the default's select is built on the
+  // unobserved path: used for encoded-equality witnesses (see
+  // enforceWitnessFacts) so the witness index is not globally observed.
+  void instantiateLazyDefaultAtUnobserved(const SMTExpr *RootKey,
+                                          const SMTExprRef &Index);
   SMTExprRef resolveLazyArrayElement(const SMTExprRef &Array,
                                      const SMTExprRef &Index);
 


### PR DESCRIPTION
Lifts the restriction that lazily-lowered constant arrays could not be nested (`array_of(array_of(v))`), which previously aborted with *"Lazily lowered constant arrays cannot be nested inside one another"* on Bitwuzla, STP, Yices, and on any backend when `ConstArrayLowering::Lazy` is forced.

## Why it was guarded

A lazy constant array is a fresh symbol whose "every element == Init" semantics are enforced by a default axiom `select(root, i) == Init` instantiated at each observed index. When the initializer is itself a lazy array, the outer default axiom `select(outer, i) == inner` is an **array equality** — and naively enabling it caused unbounded recursion: the encoded-equality witness was built with the observing `mkArraySelect`, so the fresh witness index got registered sort-globally, which re-fired every lazy root registered under that index sort (including the same root that minted it, whenever index sorts coincide, e.g. `bv8 → bv8 → v`), each time minting another fresh witness.

## The fix

1. **Route all lazy-involved array equality through the encoded witness + observed-index congruence** (`mkEncodedArrayEqual`) on every backend, not just no-extensionality backends (STP). The outer default is an array equality, and this is the mechanism that already handles it soundly.
2. **Decouple the encoded-equality witness from sort-global observation.** A fresh witness is read at exactly one syntactic site — its own equality's lemma — so observing it globally is both unnecessary and the source of nontermination. `mkArraySelectUnobserved` builds the witness selects without calling `observeArrayIndex`, and `enforceWitnessFacts` pins **only the two operands'** lazy-root defaults at the witness (via `instantiateLazyDefaultAtUnobserved`). Nesting then terminates by strictly decreasing element-array depth: the inner `select == select` equality re-enters `mkEncodedArrayEqual` one level shallower.

The `mkArrayStore` guard (storing a lazy array *as an element value*) is intentionally **not** lifted — it is orthogonal and not needed for nested constant arrays.

## Soundness

This touches the array-equality machinery that had three soundness defects in v0.11/v0.12, so it was checked adversarially (a dedicated review pass found no false-SAT/false-UNSAT case). The negative direction stays sound because the witness selects are real backend terms over the operand arrays, and `enforceWitnessFacts` pins the lazy defaults so a claimed difference cannot be fabricated at an index where a value would otherwise be unconstrained; the positive direction (observed-index congruence) is unchanged.

## Tests

`array.test.h`:
- `nested_const_array_semantics` (Z3, CVC5, Bitwuzla, MathSAT, Yices; Auto + Lazy): read-through, store-over-inner, negative direction (SAT at default, UNSAT off default), equality propagation, model round-trip, two-independent-disequalities (would break under a shared witness), and a lazy negative-direction case.
- `nested_const_array_survives_pop`: deep default asserted in a pushed scope binds handles that outlive the pop.
- `lazy_array_transitive_equality` (all backends, Auto + Lazy): a symbol equated to one lazy const array and disequated from another — the subtle encoded-equality-over-equated-operand path.
- STP: `require_abort` pin — STP's BV-only array theory cannot represent a nested array sort at all, independent of this fix.

Full suite: 170/170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
