### PR TITLE
Update STP to 2.4.0: native overflow predicates, SMT-LIB pipeline child

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,7 @@ set(RELEASE_MODE
 config_solver(Bitwuzla 0.9.1)
 config_solver(CVC5 1.0.8)
 config_solver(MathSAT 5.6.3)
-config_solver(STP 2.3.4)
+config_solver(STP 2.4.0)
 config_solver(Yices 2.6.1)
 config_solver(Z3 4.16.0)
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ shared fixtures from `tests.h`):
 | bitwuzla     | `{"bitwuzla"}`                                                  | speaks SMT-LIB on stdin without extra flags |
 | yices-smt2   | `{"yices-smt2", "--incremental"}`                               | `--incremental` is required for `(push)` / `(pop)`. No floating-point support — callers using native FP get an `unsupported` from the child. Use `FPEncoding::BV` to route every FP op through the common-layer bit-blast path, which works against yices. |
 | mathsat      | `{"mathsat"}`                                                   | the CLI binary, not the C library; staged under `<build>/deps/src/mathsat-<version>-linux-x86_64/bin/mathsat` |
+| stp          | `{"stp"}`                                                       | STP ≥ 2.4.0 only (older releases die on SMT-LIB2 commands they do not implement). BV/Bool/plain-array fragment: rejects `(set-logic ALL)` (Camada falls back to `QF_AUFBV`), answers `unsupported` to `:global-declarations` (symbols declared inside a `(push)` die with their scope), `:produce-unsat-assumptions`, and `(check-sat-assuming ...)` (Camada routes through the push/assert/check/pop fallback), rejects `((as const ...))`, and only supports `(get-value ...)` on declared symbols. Use `FPEncoding::BV` for FP. |
 
 The Camada preamble unconditionally sends `(set-option :print-success true)`,
 `(set-option :produce-models true)`,
@@ -177,9 +178,11 @@ The Camada preamble unconditionally sends `(set-option :print-success true)`,
 `unsupported` still solves normally; only `getUnsatAssumptions` degrades,
 and `supports(SolverFeature::UnsatAssumptions)` reflects the child's
 answer),
-`(set-option :global-declarations true)`, `(set-info :status unknown)`, and
-`(set-logic ALL)` at startup, so any solver that honors the SMT-LIB option
-contract should work. Other solvers should be
+`(set-option :global-declarations true)` (`unsupported` is tolerated, with
+the scope caveat above), `(set-info :status unknown)`, and
+`(set-logic ALL)` (with one fallback attempt at `QF_AUFBV` for children
+that only accept concrete logic names) at startup, so any solver that
+honors the SMT-LIB option contract should work. Other solvers should be
 straightforward to plug in via the `createSMTLIBSolver(argv)` factory.
 
 Caveats:

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ When CMake downloads dependencies itself:
   Linux. macOS stays pinned to `5.6.16`: the `5.6.17` macOS tarball ships
   `libmathsat.a` as a plain `ar` archive of fat Mach-O objects, a layout
   Apple's `ld` rejects.
-- `STP` still falls back to a source build. The `2.3.4_cadical` GitHub release
-  only ships a standalone `stp` executable, not the headers and libraries that
-  Camada needs to link against the STP C++ API.
-- `CryptoMiniSat` and `Minisat` still build from source as part of the STP
-  dependency chain.
+- `STP` still falls back to a source build of `2.4.0`. The `2.4.0` GitHub
+  release only ships a standalone `stp` executable, not the headers and
+  libraries that Camada needs to link against the STP C++ API.
+- `CryptoMiniSat`, `Minisat`, and CryptoMiniSat's patched `CaDiCaL`/`CadiBack`
+  forks still build from source as part of the STP dependency chain.
 
 The `<build-dir>/deps/install` directory will contain the staged solver headers,
 libraries, and auxiliary artifacts, and Camada will use them from this
@@ -126,7 +126,7 @@ location during the build.
 | [Bitwuzla](https://bitwuzla.github.io/)    |  0.9.1          | ✔️ |
 | [CVC5](https://cvc5.github.io/)            |  1.0.8          | ✔️ |
 | [MathSAT](https://mathsat.fbk.eu/)         |  5.6.3          | ✔️<sup>1</sup> |
-| [STP](https://stp.github.io/)              |  2.3.4          |   |
+| [STP](https://stp.github.io/)              |  2.4.0          |   |
 | [Yices](https://yices.csl.sri.com/)        |  2.6.1          |   |
 | [Z3](https://github.com/Z3Prover/z3)       |  4.16.0         | ✔️ |
 | SMT-LIB (any external solver) | n/a | depends on child |

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ even if it lacks native floating-point support.
 | Quantifiers | ✔️ | ✔️ |   |   |   | ✔️ |
 | Overflow predicates | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 | Unsat assumptions | ✔️ | ✔️ | ✔️ |   | ✔️ | ✔️ |
-| Timeouts (`setTimeout`) | ✔️ | ✔️ | ✔️ |   | ✔️<sup>3</sup> | ✔️ |
+| Timeouts (`setTimeout`) | ✔️ | ✔️ | ✔️ | ✔️<sup>4</sup> | ✔️<sup>3</sup> | ✔️ |
 | Array models (`getArrayValues`) | ✔️ | ✔️ | ✔️ |   | ✔️ | ✔️ |
 
 <sup>1</sup> On `MathSAT`, `fp.fma` and `fp.rem` are lowered through the
@@ -270,6 +270,9 @@ datatypes; some gaps remain (e.g. arrays of tuples). Query
 
 <sup>3</sup> POSIX only, enforced through a process-global SIGALRM timer —
 at most one timed Yices check may run at a time process-wide.
+
+<sup>4</sup> STP's native time budget is whole seconds for the entire
+query; millisecond limits round up to the next second.
 
 The last four rows (and any platform splits) are queryable at runtime via
 `supports(SolverFeature)`; `checkSatAssuming` itself works on every

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -50,6 +50,11 @@ target_link_libraries(${REGRESSION_TARGET_NAME} PRIVATE ${PROJECT_NAME}
 # parameterized over every binary that's actually on disk, falling back to PATH
 # for missing ones. Each macro is defined only when the binary is present; the
 # test code uses #ifdef to discover them.
+if(EXISTS "${CAMADA_DEPS_INSTALL_DIR}/bin/stp_simple")
+  target_compile_definitions(
+    ${REGRESSION_TARGET_NAME}
+    PRIVATE "CAMADA_TEST_STP_BIN=\"${CAMADA_DEPS_INSTALL_DIR}/bin/stp_simple\"")
+endif()
 if(EXISTS "${CAMADA_DEPS_INSTALL_DIR}/bin/z3")
   target_compile_definitions(
     ${REGRESSION_TARGET_NAME}

--- a/regression/smtlib_pipeline.test.h
+++ b/regression/smtlib_pipeline.test.h
@@ -113,6 +113,17 @@ inline std::vector<std::string> yicesSmt2Command() {
   return {Bin, "--incremental"};
 }
 
+// Staged binary only, no PATH fallback: the pipe contract (answering
+// unimplemented SMT-LIB2 commands instead of dying) is new in STP 2.4.0, so
+// an older `stp` from PATH would fail the tests rather than skip them.
+inline std::vector<std::string> stpCommand() {
+#ifdef CAMADA_TEST_STP_BIN
+  if (isExecutable(CAMADA_TEST_STP_BIN))
+    return {CAMADA_TEST_STP_BIN};
+#endif
+  return {};
+}
+
 inline std::vector<std::string> mathsatCommand() {
 #ifdef CAMADA_TEST_MATHSAT_BIN
   std::string Bin = findExecutable("mathsat", CAMADA_TEST_MATHSAT_BIN);

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -32,7 +32,7 @@ TEST_CASE("STP feature capabilities", "[STP]") {
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeConstantArrays));
   REQUIRE_FALSE(solver->supports(SolverFeature::UnsatAssumptions));
-  REQUIRE_FALSE(solver->supports(SolverFeature::Timeouts));
+  REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE_FALSE(solver->supports(SolverFeature::ArrayModels));
 }
 

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -1,4 +1,7 @@
 
+#if SOLVER_SMTLIB_ENABLED
+#include "smtlib_pipeline.test.h"
+#endif
 #include "tests.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -60,3 +63,52 @@ TEST_CASE("Unsupported nested constant tuple arrays STP test", "[STP]") {
     (void)stp->mkArrayConst(bv4, innerConst);
   });
 }
+#if SOLVER_SMTLIB_ENABLED
+// ---------------------------------------------------------------------------
+// SMT-LIB pipeline tests against the stp binary (STP >= 2.4.0, which answers
+// the SMT-LIB2 commands it does not implement instead of dying). stp supports
+// BV, Bool, plain arrays, and FP-BV (via bit-blast). It rejects
+// (set-logic ALL) — the preamble falls back to QF_AUFBV — and answers
+// `unsupported` to :global-declarations, :produce-unsat-assumptions, and
+// (check-sat-assuming ...), so checkSatAssuming routes through the common
+// push/assert/check/pop fallback and symbols declared inside a (push) die
+// with their scope (symbol_cache_survives_push_pop is therefore absent).
+// Array fixtures are absent for the same reasons as yices-smt2: they all use
+// `mkArrayConst`, and stp additionally rejects `((as const ...))` syntax and
+// (get-value ...) on compound terms.
+// ---------------------------------------------------------------------------
+
+#define CAMADA_STP_SMTLIB_PIPELINE_TEST(NameStr, RunFn)                        \
+  TEST_CASE("SMTLIB pipeline: " NameStr " [stp]", "[STP][SMTLIB][pipeline]") { \
+    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::stpCommand(), "stp"); \
+    camada_smtlib_pipeline::RunFn(Cmd);                                        \
+  }
+
+CAMADA_STP_SMTLIB_PIPELINE_TEST("public factory works", runSMTLIBPublicFactory)
+CAMADA_STP_SMTLIB_PIPELINE_TEST("dual emitter logs to file too",
+                                runSMTLIBDualEmitter)
+
+#undef CAMADA_STP_SMTLIB_PIPELINE_TEST
+
+#define CAMADA_STP_SMTLIB_SHARED_TEST(NameStr, FixtureCall)                    \
+  TEST_CASE("SMTLIB pipeline: " NameStr " [stp]", "[STP][SMTLIB][pipeline]") { \
+    CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::stpCommand(), "stp"); \
+    camada::SMTSolverRef solver =                                              \
+        camada_smtlib_pipeline::makeSMTLIBSolver(Cmd);                         \
+    FixtureCall;                                                               \
+  }
+
+CAMADA_STP_SMTLIB_SHARED_TEST("equal_ten", equal_ten(solver))
+CAMADA_STP_SMTLIB_SHARED_TEST("implies_semantics", implies_semantics(solver))
+CAMADA_STP_SMTLIB_SHARED_TEST("implies_true_implies_false",
+                              implies_true_implies_false(solver))
+CAMADA_STP_SMTLIB_SHARED_TEST("check_sat_assuming_semantics",
+                              check_sat_assuming_semantics(solver))
+CAMADA_STP_SMTLIB_SHARED_TEST("bv_lshr_semantics", bv_lshr_semantics(solver))
+CAMADA_STP_SMTLIB_SHARED_TEST("incremental_push_pop",
+                              incremental_push_pop(solver))
+CAMADA_STP_SMTLIB_SHARED_TEST("fp_equal BVFP",
+                              fp_equal(solver, camada::FPEncoding::BV))
+
+#undef CAMADA_STP_SMTLIB_SHARED_TEST
+#endif

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -997,10 +997,17 @@ function(camada_setup_stp)
       -DONLY_SIMPLE=ON
       -DCMAKE_INSTALL_PREFIX=${CAMADA_DEPS_INSTALL_DIR}
       -DCMAKE_BUILD_TYPE=Release
-      -DBUILD_EXECUTABLES=OFF
+      # The stp binary doubles as an SMT-LIB pipeline child in the regression
+      # suite.
+      -DBUILD_EXECUTABLES=ON
       -DSTATICCOMPILE=ON
       -DBUILD_SHARED_LIBS=OFF
       -Dminisat_DIR=${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/minisat
+      # STP's Findminisat.cmake module ignores minisat_DIR; without these hints
+      # it can resolve a system minisat whose headers and ABI differ from the
+      # staged one.
+      -DMINISAT_INCLUDE_DIRS=${CAMADA_DEPS_INSTALL_DIR}/include
+      -DMINISAT_LIBDIR=${CAMADA_DEPS_INSTALL_DIR}/lib
       -Dcryptominisat5_DIR=${cms_config_dir})
   if(stp_bison_executable)
     list(APPEND _camada_stp_cmake_args

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -529,6 +529,9 @@ endfunction()
 function(camada_fetch_git_source package_name repository git_tag out_var)
   camada_include_cpm()
   set(FETCHCONTENT_QUIET FALSE)
+  if(package_name STREQUAL "cryptominisat")
+    set(git_submodules_arg GIT_SUBMODULES)
+  endif()
   cpmaddpackage(
     NAME
     ${package_name}
@@ -538,6 +541,7 @@ function(camada_fetch_git_source package_name repository git_tag out_var)
     ${repository}
     GIT_TAG
     ${git_tag}
+    ${git_submodules_arg}
     GIT_PROGRESS
     TRUE)
   set(${out_var}

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -566,14 +566,25 @@ function(camada_prepare_cryptominisat_dependency_layout dependency_dir
   endif()
 endfunction()
 
+# -fno-gnu-unique for the whole CMS stack (GCC/ELF only): the archives get
+# merged into one relocatable object whose non-CMSat symbols are localized, and
+# objcopy cannot demote STB_GNU_UNIQUE symbols.
+if(APPLE)
+  set(CAMADA_CMS_EXTRA_CXX_FLAGS "")
+else()
+  set(CAMADA_CMS_EXTRA_CXX_FLAGS "-fno-gnu-unique")
+endif()
+
+# CMS 5.11.x hard-requires meelgroup's patched cadical/cadiback forks and
+# expects them as sibling directories of the CMS source tree.
 function(camada_setup_cryptominisat_solver_deps cms_source_dir)
   get_filename_component(cms_parent_dir "${cms_source_dir}" DIRECTORY)
   set(cms_cadical_dir "${cms_parent_dir}/cadical")
+  set(cms_cadiback_dir "${cms_parent_dir}/cadiback")
 
-  if(NOT EXISTS "${cms_cadical_dir}/build/libcadical.a"
-     OR NOT EXISTS "${cms_cadical_dir}/src/cadical.hpp")
-    camada_fetch_git_source(cryptominisat_cadical arminbiere/cadical rel-1.4.0
-                            cms_cadical_source_dir)
+  if(NOT EXISTS "${cms_cadical_dir}/build/libcadical.a")
+    camada_fetch_git_source(cryptominisat_cadical meelgroup/cadical
+                            mate-only-libraries-1.8.0 cms_cadical_source_dir)
     camada_prepare_cryptominisat_dependency_layout("${cms_cadical_dir}"
                                                    "${cms_cadical_source_dir}")
     camada_run_checked(
@@ -582,6 +593,10 @@ function(camada_setup_cryptominisat_solver_deps cms_source_dir)
       MESSAGE
       "Configuring CryptoMiniSat CaDiCaL"
       COMMAND
+      ${CMAKE_COMMAND}
+      -E
+      env
+      "CXXFLAGS=${CAMADA_CMS_EXTRA_CXX_FLAGS}"
       ./configure
       -fPIC
       -O3)
@@ -595,20 +610,58 @@ function(camada_setup_cryptominisat_solver_deps cms_source_dir)
       -j
       libcadical.a)
   endif()
+
+  if(NOT EXISTS "${cms_cadiback_dir}/libcadiback.a")
+    # The 'mate' branch CMS 5.11.22 documents no longer exists; this is the last
+    # contemporary main commit whose CadiBack::doit() signature still matches
+    # CMS 5.11.22's backbone.cpp (2024-06-07).
+    camada_fetch_git_source(
+      cryptominisat_cadiback meelgroup/cadiback
+      69255f55e411207c4bdea02c6c2ab1ef29740ce1 cms_cadiback_source_dir)
+    camada_prepare_cryptominisat_dependency_layout("${cms_cadiback_dir}"
+                                                   "${cms_cadiback_source_dir}")
+    camada_run_checked(
+      WORKING_DIRECTORY
+      "${cms_cadiback_dir}"
+      MESSAGE
+      "Configuring CryptoMiniSat CadiBack"
+      COMMAND
+      ${CMAKE_COMMAND}
+      -E
+      env
+      "CXXFLAGS=-fPIC ${CAMADA_CMS_EXTRA_CXX_FLAGS}"
+      ./configure)
+    camada_run_checked(
+      WORKING_DIRECTORY
+      "${cms_cadiback_dir}"
+      MESSAGE
+      "Building CryptoMiniSat CadiBack"
+      COMMAND
+      make
+      -j
+      libcadiback.a)
+  endif()
 endfunction()
 
 function(camada_setup_cryptominisat)
   set(cms_config
       "${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/cryptominisat5/cryptominisat5Config.cmake"
   )
-  if(EXISTS "${cms_config}")
+  # Version stamp so a stale CMS (e.g. 5.6.3 from an older checkout) in an
+  # existing build directory is rebuilt instead of silently reused.
+  set(cms_stamp
+      "${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/cryptominisat5/camada-cms-5.11.22.stamp"
+  )
+  if(EXISTS "${cms_config}" AND EXISTS "${cms_stamp}")
     return()
   endif()
 
   camada_ensure_deps_dirs()
-  camada_fetch_git_source(cryptominisat msoos/cryptominisat 5.6.3
+  # 5.11.22 is the version STP 2.4.0 bumped its CI to (stp/stp#493).
+  camada_fetch_git_source(cryptominisat msoos/cryptominisat 5.11.22
                           cms_source_dir)
   camada_setup_cryptominisat_solver_deps("${cms_source_dir}")
+  get_filename_component(cms_parent_dir "${cms_source_dir}" DIRECTORY)
 
   set(cms_build_dir "${cms_source_dir}/build")
   file(REMOVE_RECURSE "${cms_build_dir}")
@@ -623,12 +676,12 @@ function(camada_setup_cryptominisat)
     ${CMAKE_COMMAND}
     ..
     -GNinja
-    -DSTATICCOMPILE=ON
-    -DONLY_SIMPLE=ON
-    -DENABLE_PYTHON_INTERFACE=OFF
-    -DNOM4RI=ON
+    -DENABLE_ASSERTIONS=OFF
+    -DBUILD_SHARED_LIBS=OFF
+    -DNOZLIB=ON
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     -DCMAKE_BUILD_TYPE=Release
+    "-DCMAKE_CXX_FLAGS=${CAMADA_CMS_EXTRA_CXX_FLAGS}"
     -DCMAKE_INSTALL_PREFIX=${CAMADA_DEPS_INSTALL_DIR})
   camada_run_checked(WORKING_DIRECTORY "${cms_build_dir}" MESSAGE
                      "Building CryptoMiniSat" COMMAND ninja)
@@ -640,6 +693,56 @@ function(camada_setup_cryptominisat)
     COMMAND
     ninja
     install)
+
+  set(cms_lib "${CAMADA_DEPS_INSTALL_DIR}/lib/libcryptominisat5.a")
+  set(cms_cadical_lib "${cms_parent_dir}/cadical/build/libcadical.a")
+  set(cms_cadiback_lib "${cms_parent_dir}/cadiback/libcadiback.a")
+  if(NOT APPLE)
+    # Merge CMS with its patched cadical/cadiback into one relocatable object
+    # and localize everything but the CMSat:: API. bitwuzla's and cvc5's static
+    # archives carry their own (vanilla) cadical objects, so any global CaDiCaL
+    # symbol left here would be a duplicate-definition error in the final link.
+    camada_run_checked(
+      WORKING_DIRECTORY
+      "${cms_build_dir}"
+      MESSAGE
+      "Bundling CryptoMiniSat with cadical/cadiback"
+      COMMAND
+      bash
+      -c
+      "nm --defined-only -g '${cms_lib}' | awk 'NF==3{print \$3}' | grep 5CMSat | sort -u > camada-cms-keep.syms && \
+       ld -r --force-group-allocation -o camada-cms-bundle.o --whole-archive '${cms_lib}' '${cms_cadiback_lib}' '${cms_cadical_lib}' --no-whole-archive && \
+       objcopy --keep-global-symbols=camada-cms-keep.syms camada-cms-bundle.o && \
+       rm -f '${cms_lib}' && ar rcs '${cms_lib}' camada-cms-bundle.o")
+  else()
+    # ponytail: no objcopy on macOS; stage the fork archives and let
+    # FindSTP.cmake link them after libcryptominisat5.a. Collides if another
+    # enabled backend bundles a conflicting cadical — bundle+localize with
+    # Mach-O tools if that ever happens on the mac CI. Renamed so it cannot
+    # clobber cvc5's staged libcadical.a.
+    file(COPY_FILE "${cms_cadiback_lib}"
+         "${CAMADA_DEPS_INSTALL_DIR}/lib/libcadiback.a")
+    file(COPY_FILE "${cms_cadical_lib}"
+         "${CAMADA_DEPS_INSTALL_DIR}/lib/libcadical-cms.a")
+  endif()
+
+  # CMS's install exports cadical/cadiback CMake packages whose archives are
+  # never installed, and hardcodes their absolute paths (one of them into the
+  # build tree, one onto cvc5's staged libcadical.a) in the cryptominisat5
+  # export; STP's find_package trips over both. The bundle above already carries
+  # those objects (Linux) or FindSTP.cmake links the staged copies (macOS), so
+  # scrub the references.
+  file(REMOVE_RECURSE "${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/cadiback"
+       "${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/cadical")
+  set(cms_targets_file
+      "${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/cryptominisat5/cryptominisat5Targets.cmake"
+  )
+  file(READ "${cms_targets_file}" cms_targets_contents)
+  string(REGEX REPLACE ";?[^;\"]*libcadi(back|cal)\\.a" "" cms_targets_contents
+                       "${cms_targets_contents}")
+  file(WRITE "${cms_targets_file}" "${cms_targets_contents}")
+
+  file(TOUCH "${cms_stamp}")
 endfunction()
 
 function(camada_setup_gmp)
@@ -864,18 +967,22 @@ endfunction()
 
 function(camada_setup_stp)
   set(stp_config "${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/STP/STPConfig.cmake")
-  if(EXISTS "${stp_config}")
+  # libabc-pic.a is staged by this function for STP >= 2.4.0 only, so its
+  # presence also distinguishes a current install from a stale 2.3.x one left
+  # behind in an existing build directory.
+  if(EXISTS "${stp_config}" AND EXISTS
+                                "${CAMADA_DEPS_INSTALL_DIR}/lib/libabc-pic.a")
     return()
   endif()
 
   message(
     STATUS
-      "The STP 2.3.4_cadical GitHub release asset is a standalone solver binary, not a development package with headers and libraries. Falling back to a source build for Camada's STP API wrapper."
+      "The STP 2.4.0 GitHub release asset is a standalone solver binary, not a development package with headers and libraries. Falling back to a source build for Camada's STP API wrapper."
   )
 
   camada_setup_minisat()
   camada_setup_cryptominisat()
-  camada_fetch_git_source(stpsrc stp/stp 2.3.4 stp_source_dir)
+  camada_fetch_git_source(stpsrc stp/stp 2.4.0 stp_source_dir)
 
   set(stp_build_dir "${stp_source_dir}/build")
   set(cms_config_dir "${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/cryptominisat5")
@@ -920,6 +1027,12 @@ function(camada_setup_stp)
     COMMAND
     ninja
     install)
+
+  # STP >= 2.4.0 builds ABC as a separate static archive that its exported
+  # target references from the build tree but never installs; stage it next to
+  # libstp.a so FindSTP.cmake can link it.
+  file(COPY "${stp_build_dir}/lib/libabc-pic.a"
+       DESTINATION "${CAMADA_DEPS_INSTALL_DIR}/lib")
 endfunction()
 
 function(camada_setup_yices)

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -1010,6 +1010,9 @@ function(camada_setup_stp)
       -DMINISAT_INCLUDE_DIRS=${CAMADA_DEPS_INSTALL_DIR}/include
       -DMINISAT_LIBDIR=${CAMADA_DEPS_INSTALL_DIR}/lib
       -Dcryptominisat5_DIR=${cms_config_dir})
+  if(APPLE)
+    list(APPEND _camada_stp_cmake_args -DHAVE_UNISTD_H=ON)
+  endif()
   if(stp_bison_executable)
     list(APPEND _camada_stp_cmake_args
          -DBISON_EXECUTABLE=${stp_bison_executable})

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -997,6 +997,7 @@ function(camada_setup_stp)
       -DONLY_SIMPLE=ON
       -DCMAKE_INSTALL_PREFIX=${CAMADA_DEPS_INSTALL_DIR}
       -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_CXX_FLAGS=-DABC_USE_STDINT_H=1
       # The stp binary doubles as an SMT-LIB pipeline child in the regression
       # suite.
       -DBUILD_EXECUTABLES=ON

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -997,6 +997,16 @@ function(camada_setup_stp)
   camada_setup_minisat()
   camada_setup_cryptominisat()
   camada_fetch_git_source(stpsrc stp/stp 2.4.0 stp_source_dir)
+  if(APPLE)
+    file(READ "${stp_source_dir}/CMakeLists.txt" stp_cmake_contents)
+    string(
+      REPLACE
+        "        set(CMAKE_EXE_LINKER_FLAGS \"\${CMAKE_EXE_LINKER_FLAGS} -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -static \")"
+        ""
+        stp_cmake_contents
+        "${stp_cmake_contents}")
+    file(WRITE "${stp_source_dir}/CMakeLists.txt" "${stp_cmake_contents}")
+  endif()
 
   set(stp_build_dir "${stp_source_dir}/build")
   set(cms_config_dir "${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/cryptominisat5")

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -738,6 +738,10 @@ function(camada_setup_cryptominisat)
          "${CAMADA_DEPS_INSTALL_DIR}/lib/libcadiback.a")
     file(COPY_FILE "${cms_cadical_lib}"
          "${CAMADA_DEPS_INSTALL_DIR}/lib/libcadical-cms.a")
+    file(
+      APPEND "${cms_config}"
+      "\nset(CRYPTOMINISAT5_STATIC_LIBRARIES_DEPS \"${CAMADA_DEPS_INSTALL_DIR}/lib/libcadiback.a;${CAMADA_DEPS_INSTALL_DIR}/lib/libcadical-cms.a\")\n"
+    )
   endif()
 
   # CMS's install exports cadical/cadiback CMake packages whose archives are

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -661,8 +661,16 @@ function(camada_setup_cryptominisat)
   endif()
 
   camada_ensure_deps_dirs()
-  file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/_deps/cryptominisat-src"
-       "${CMAKE_BINARY_DIR}/_deps/cryptominisat-subbuild")
+  file(
+    REMOVE_RECURSE
+    "${CMAKE_BINARY_DIR}/_deps/cryptominisat-src"
+    "${CMAKE_BINARY_DIR}/_deps/cryptominisat-subbuild"
+    "${CMAKE_BINARY_DIR}/_deps/cryptominisat_cadical-src"
+    "${CMAKE_BINARY_DIR}/_deps/cryptominisat_cadical-subbuild"
+    "${CMAKE_BINARY_DIR}/_deps/cryptominisat_cadiback-src"
+    "${CMAKE_BINARY_DIR}/_deps/cryptominisat_cadiback-subbuild"
+    "${CMAKE_BINARY_DIR}/_deps/cadical"
+    "${CMAKE_BINARY_DIR}/_deps/cadiback")
   # 5.11.22 is the version STP 2.4.0 bumped its CI to (stp/stp#493).
   camada_fetch_git_source(cryptominisat msoos/cryptominisat 5.11.22
                           cms_source_dir)

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -661,6 +661,8 @@ function(camada_setup_cryptominisat)
   endif()
 
   camada_ensure_deps_dirs()
+  file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/_deps/cryptominisat-src"
+       "${CMAKE_BINARY_DIR}/_deps/cryptominisat-subbuild")
   # 5.11.22 is the version STP 2.4.0 bumped its CI to (stp/stp#493).
   camada_fetch_git_source(cryptominisat msoos/cryptominisat 5.11.22
                           cms_source_dir)

--- a/scripts/cmake/FindSTP.cmake
+++ b/scripts/cmake/FindSTP.cmake
@@ -48,10 +48,24 @@ function(_camada_normalize_stp_target)
 
   if(EXISTS "${_camada_stp_minisat_lib}" AND EXISTS
                                              "${_camada_stp_cryptominisat_lib}")
-    set_property(
-      TARGET stp
-      PROPERTY INTERFACE_LINK_LIBRARIES
-               "${_camada_stp_minisat_lib};${_camada_stp_cryptominisat_lib}")
+    set(_camada_stp_dep_libs "${_camada_stp_minisat_lib}"
+                             "${_camada_stp_cryptominisat_lib}")
+    # STP >= 2.4.0 builds ABC as a separate archive instead of folding it into
+    # libstp.a.
+    set(_camada_stp_abc_lib "${CAMADA_DEPS_INSTALL_DIR}/lib/libabc-pic.a")
+    if(EXISTS "${_camada_stp_abc_lib}")
+      list(APPEND _camada_stp_dep_libs "${_camada_stp_abc_lib}")
+    endif()
+    # On platforms where CMS's patched cadical/cadiback forks are not bundled
+    # into libcryptominisat5.a (macOS), they are staged separately; cadiback
+    # references cadical symbols, so it must come first.
+    set(_camada_stp_cadiback_lib "${CAMADA_DEPS_INSTALL_DIR}/lib/libcadiback.a")
+    if(EXISTS "${_camada_stp_cadiback_lib}")
+      list(APPEND _camada_stp_dep_libs "${_camada_stp_cadiback_lib}"
+           "${CAMADA_DEPS_INSTALL_DIR}/lib/libcadical-cms.a")
+    endif()
+    set_property(TARGET stp PROPERTY INTERFACE_LINK_LIBRARIES
+                                     "${_camada_stp_dep_libs}")
   elseif(TARGET minisat AND TARGET libcryptominisat5)
     set_property(TARGET stp PROPERTY INTERFACE_LINK_LIBRARIES
                                      "minisat;libcryptominisat5")

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -736,9 +736,18 @@ void SMTLIBSolver::emitPreamble() {
   // discarded on (pop). Camada's API lets a caller mkSymbol() inside a pushed
   // scope and use the returned expression after pop(); without this option,
   // the next (assert ...) or (get-value ...) referring to that symbol would
-  // hit "unknown constant" in the child solver. All solvers in the verified
-  // matrix accept this option.
-  emitLine("(set-option :global-declarations true)");
+  // hit "unknown constant" in the child solver. Like the option above, not
+  // every child implements it (stp answers `unsupported`); against such
+  // children a symbol declared inside a (push) dies with its scope, and the
+  // first command referring to it after (pop) aborts with the child's error.
+  const std::string GlobalDeclsOpt = "(set-option :global-declarations true)\n";
+  if (File)
+    File->emitRaw(GlobalDeclsOpt);
+  if (Proc) {
+    Proc->emitRaw(GlobalDeclsOpt);
+    Proc->flush();
+    (void)Proc->readResponse();
+  }
   emitLine("(set-info :status unknown)");
   // ALL covers BV/Bool/arrays/FP/Int/Real, which is the full Camada
   // surface. Children that don't support a particular sort will reject the
@@ -746,7 +755,36 @@ void SMTLIBSolver::emitPreamble() {
   // who want a portable script across heterogeneous solvers should pick
   // FPEncoding::BV at sort-construction time — that already routes every FP
   // op through the common-layer bit-blast path.
-  emitLine("(set-logic ALL)");
+  //
+  // Children that only accept concrete logic names get one fallback attempt
+  // with QF_AUFBV, the broadest quantifier-free fragment such children
+  // implement. The tee file records whichever logic the child accepted.
+  if (Proc) {
+    std::string Logic = "ALL";
+    Proc->emitRaw("(set-logic ALL)\n");
+    Proc->flush();
+    if (Proc->readResponse() != "success") {
+      // stp rejects ALL with a stray diagnostic line and then still answers
+      // `success` for the command; consume that stray ack or every later
+      // response is off by one. ponytail: this two-line pairing is
+      // stp-shaped — a child that emits only the error line would block
+      // here and needs echo-based resynchronization instead.
+      (void)Proc->readResponse();
+      Logic = "QF_AUFBV";
+      Proc->emitRaw("(set-logic QF_AUFBV)\n");
+      Proc->flush();
+      std::string Resp = Proc->readResponse();
+      fatalErrorIf(Resp != "success",
+                   ("SMTLIBSolver: child solver rejected both (set-logic ALL) "
+                    "and (set-logic QF_AUFBV): " +
+                    Resp)
+                       .c_str());
+    }
+    if (File)
+      File->emitRaw("(set-logic " + Logic + ")\n");
+  } else if (File) {
+    File->emitRaw("(set-logic ALL)\n");
+  }
 }
 
 void SMTLIBSolver::emitLine(const std::string &Text) const {
@@ -1512,7 +1550,8 @@ std::string extractValueFromGetValue(const std::string &Resp) {
   I = skipWS(Resp, I);
   if (I >= Resp.size() || Resp[I] != '(')
     return {};
-  ++I; // consume inner '(' opening the valuation pair
+  ++I;                 // consume inner '(' opening the valuation pair
+  I = skipWS(Resp, I); // stp emits `( |x|  #x0A )` with a leading space
   // Skip the <term>: walk until top-level whitespace, respecting `|...|`,
   // `"..."`, and nested parens.
   int Depth = 0;
@@ -2103,6 +2142,15 @@ SMTResult<bool> SMTLIBSolver::getBoolImpl(const SMTExprRef &Exp) {
 }
 
 SMTResult<std::string> SMTLIBSolver::getBVInBinImpl(const SMTExprRef &Exp) {
+  // A BV literal is its own model value — decode it locally instead of
+  // round-tripping. Some children (stp) reject (get-value ...) on anything
+  // but a declared symbol.
+  const std::string Text = renderSMTLIBExpr(Exp);
+  if (!Text.empty() && Text[0] == '#') {
+    std::string Bits = bvValueToBinary(Text, Exp->getWidth());
+    if (!Bits.empty())
+      return Bits;
+  }
   std::string Resp;
   SMTResult<std::string> Value = sendGetValue(Exp, Resp);
   if (!Value)
@@ -2218,6 +2266,13 @@ checkResult SMTLIBSolver::checkImpl() {
 
 checkResult
 SMTLIBSolver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
+  // A child that rejected :produce-unsat-assumptions may not implement
+  // (check-sat-assuming ...) at all (stp answers `unsupported`), and without
+  // the option there is no unsat core to salvage from the native form
+  // anyway — use the common layer's equisatisfiable push/assert/check/pop
+  // fallback instead.
+  if (Proc && !UnsatAssumptionsSupported)
+    return SMTSolverImpl::checkSatAssumingImpl(Assumptions);
   // Activate each assumption through a fresh literal: assert
   // (=> lit assumption), then assume the literal. This is equisatisfiable
   // with assuming the term directly, stays inside the standard's

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -190,6 +190,39 @@ SMTExprRef STPSolver::mkBVMulImpl(const SMTExprRef &LHS,
                          toSolverExpr<STPExpr>(*RHS).Expr));
 }
 
+SMTExprRef STPSolver::mkBVAddOverflowImpl(const SMTExprRef &LHS,
+                                          const SMTExprRef &RHS,
+                                          bool IsSigned) {
+  STP::Expr L = toSolverExpr<STPExpr>(*LHS).Expr;
+  STP::Expr R = toSolverExpr<STPExpr>(*RHS).Expr;
+  return makeExprRef<STPExpr>(
+      SMTExprKind::BVAddOverflow, &Context, mkBoolSort(),
+      IsSigned ? STP::vc_bvSignedAddOverflowExpr(Context, L, R)
+               : STP::vc_bvUnsignedAddOverflowExpr(Context, L, R));
+}
+
+SMTExprRef STPSolver::mkBVSubOverflowImpl(const SMTExprRef &LHS,
+                                          const SMTExprRef &RHS,
+                                          bool IsSigned) {
+  STP::Expr L = toSolverExpr<STPExpr>(*LHS).Expr;
+  STP::Expr R = toSolverExpr<STPExpr>(*RHS).Expr;
+  return makeExprRef<STPExpr>(
+      SMTExprKind::BVSubOverflow, &Context, mkBoolSort(),
+      IsSigned ? STP::vc_bvSignedSubOverflowExpr(Context, L, R)
+               : STP::vc_bvUnsignedSubOverflowExpr(Context, L, R));
+}
+
+SMTExprRef STPSolver::mkBVMulOverflowImpl(const SMTExprRef &LHS,
+                                          const SMTExprRef &RHS,
+                                          bool IsSigned) {
+  STP::Expr L = toSolverExpr<STPExpr>(*LHS).Expr;
+  STP::Expr R = toSolverExpr<STPExpr>(*RHS).Expr;
+  return makeExprRef<STPExpr>(
+      SMTExprKind::BVMulOverflow, &Context, mkBoolSort(),
+      IsSigned ? STP::vc_bvSignedMulOverflowExpr(Context, L, R)
+               : STP::vc_bvUnsignedMulOverflowExpr(Context, L, R));
+}
+
 SMTExprRef STPSolver::mkBVSRemImpl(const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
   return makeExprRef<STPExpr>(

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -25,8 +25,10 @@
 #include "camada.h"
 #include "camadacommon.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 
 namespace camada {
 
@@ -599,7 +601,18 @@ SMTExprRef STPSolver::mkArrayConstImpl(const SMTSortRef &, const SMTExprRef &) {
 
 checkResult STPSolver::checkImpl() {
   STP::Expr query = STP::vc_falseExpr(Context);
-  int res = STP::vc_query(Context, query);
+  // -1 disables the budget. The time budget is whole seconds for the
+  // entire query, so the millisecond deadline rounds up; the CryptoMiniSat
+  // backend abandons the search when it expires (return code 3).
+  int MaxTimeSecs = -1;
+  if (TimeoutMs) {
+    const uint64_t Secs = (TimeoutMs + 999) / 1000;
+    MaxTimeSecs = static_cast<int>(
+        std::min<uint64_t>(Secs, std::numeric_limits<int>::max()));
+  }
+  int res =
+      STP::vc_query_with_timeout(Context, query,
+                                 /*timeout_max_conflicts=*/-1, MaxTimeSecs);
   STP::vc_DeleteExpr(query);
   if (!res)
     return checkResult::SAT;
@@ -607,7 +620,20 @@ checkResult STPSolver::checkImpl() {
   if (res == 1)
     return checkResult::UNSAT;
 
+  // 2 is an error, 3 a timeout.
   return checkResult::UNKNOWN;
+}
+
+bool STPSolver::setTimeoutImpl(uint64_t) {
+  // Nothing to configure on the context; checkImpl() reads the current
+  // TimeoutMs on every query.
+  return true;
+}
+
+bool STPSolver::supportsImpl(SolverFeature Feature) const {
+  if (Feature == SolverFeature::Timeouts)
+    return true;
+  return SMTSolverImpl::supportsImpl(Feature);
 }
 
 void STPSolver::resetImpl() {

--- a/src/stpsolver.h
+++ b/src/stpsolver.h
@@ -109,6 +109,18 @@ protected:
 
   SMTExprRef mkBVMulImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
 
+  // STP >= 2.4.0 exposes native SMT-LIB 2.7 overflow predicates through the
+  // C API; sdiv/neg overflow have no constructors there and stay on the
+  // common-layer encoding.
+  SMTExprRef mkBVAddOverflowImpl(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                                 bool IsSigned) override;
+
+  SMTExprRef mkBVSubOverflowImpl(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                                 bool IsSigned) override;
+
+  SMTExprRef mkBVMulOverflowImpl(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                                 bool IsSigned) override;
+
   SMTExprRef mkBVSRemImpl(const SMTExprRef &LHS,
                           const SMTExprRef &RHS) override;
 

--- a/src/stpsolver.h
+++ b/src/stpsolver.h
@@ -223,6 +223,13 @@ protected:
 
   checkResult checkImpl() override;
 
+  // Per-check wall-clock limit enforced through vc_query_with_timeout's
+  // whole-second time budget (STP >= 2.4.0 gives it one meaning across
+  // its SAT backends); millisecond limits round up to the next second.
+  bool setTimeoutImpl(uint64_t Milliseconds) override;
+
+  bool supportsImpl(SolverFeature Feature) const override;
+
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;


### PR DESCRIPTION
## Summary

Updates the STP backend to STP 2.4.0 (released 2026-07-30) and takes advantage of its two new capabilities: native SMT-LIB 2.7 overflow predicates in the C API, and well-behaved SMT-LIB2 stdin operation that lets `stp` serve as an SMT-LIB pipeline child.

### 1. Dependency bump (STP 2.4.0, CryptoMiniSat 5.11.22)

- STP 2.4.0 requires a CMS with `set_sls()`, so CMS moves from 5.6.3 to 5.11.22 (the version stp/stp#493 CI used), together with meelgroup's patched cadical/cadiback forks that CMS 5.11 hard-requires.
- The fork's CaDiCaL globals collide with the vanilla cadical objects bundled inside bitwuzla's and cvc5's static archives. On Linux, CMS + cadiback + cadical are merged into one relocatable object (`ld -r --force-group-allocation`) with every symbol outside the `CMSat::` namespace localized (`objcopy --keep-global-symbols`, stack built `-fno-gnu-unique`). On macOS (no objcopy) the fork archives are staged unbundled — if the same collision exists under ld64 the mac CI will show it, and the bundle step needs a Mach-O port.
- STP 2.4.0 splits ABC into `libabc-pic.a`, which its exported CMake target references but never installs; it is now staged and linked explicitly. STP's `Findminisat.cmake` also silently resolved a *system* minisat with mismatched headers/ABI — now pinned to the staged one.
- The setup functions are version-guarded so a stale `build/deps` from an older checkout rebuilds instead of failing with confusing link errors.
- `config_solver(STP 2.4.0)`: STP's CMake version file only accepts matching major.minor, so the requested version selects the series.

### 2. STP as a verified SMT-LIB pipeline child

STP ≥ 2.4.0 answers the SMT-LIB2 commands it does not implement (stp/stp#641), so the pipe backend can drive it. Backend accommodations, each probed against the real binary:

- `(set-logic ALL)` is rejected with a stray diagnostic line *plus* a `success` ack; the preamble consumes the stray ack and falls back to `QF_AUFBV`.
- `unsupported` answers to `:global-declarations` are tolerated (symbols declared inside a `(push)` die with their scope against such children).
- `checkSatAssuming` routes through the common push/assert/check/pop fallback when the child lacks native assumption support.
- BV literals answer `getBV` locally without a `(get-value ...)` round-trip (STP only supports it on declared symbols; also saves a round-trip for every child).
- The model parser accepts STP's `( |x|  #x0A )` response spacing.

The staged STP build now produces the `stp_simple` binary and the regression suite drives it through the shared BV/Bool/FP-BV fixtures (9 new tests). Array fixtures are absent for the same reason as yices-smt2 (`mkArrayConst` needs `((as const ...))`), plus STP-specific gaps documented in the test file and README.

### 3. Native overflow predicates

`mkBV{S,U}{Add,Sub,Mul}Overflow` now use STP 2.4.0's `vc_bv{Signed,Unsigned}{Add,Sub,Mul}OverflowExpr` constructors (stp/stp#626) instead of the common-layer BV encoding, so STP's interval and constant-bit passes reduce them natively. `mkBVSDivOverflow`/`mkBVNegOverflow` stay on the common layer (no C API constructors exist).

### 4. Native per-check timeouts

`setTimeout` now works on STP: `checkImpl` routes through `vc_query_with_timeout`, whose time budget STP 2.4.0 unified across its SAT backends (stp/stp#596); the CryptoMiniSat backend abandons the search when the budget expires and the check answers `UNKNOWN`. The budget is whole seconds, so millisecond limits round up to the next second. This fills STP's `setTimeout` gap in the parity table, and the shared `solver_timeout_semantics` fixture now runs its full body against STP.

## Test plan

- Full regression suite: 173/173 (164 pre-existing + 9 new STP pipeline tests) on Linux x86_64, all six native backends plus all pipeline children.
- `bv_overflow_semantics` proves each native STP overflow predicate equivalent to an independent reference encoding.
- Fresh-configure, incremental-reconfigure (no-op), and stale-deps upgrade paths exercised for the dependency machinery.
- Not verified here: macOS (no Mach-O bundling equivalent — see caveat above); watch the mac CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)