### PR TITLE
Update Z3 to 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ config_solver(CVC5 1.0.8)
 config_solver(MathSAT 5.6.3)
 config_solver(STP 2.3.4)
 config_solver(Yices 2.6.1)
-config_solver(Z3 4.16.0)
+config_solver(Z3 5.0.0)
 
 # The SMT-LIB pipeline backend drives an external SMT-LIB-speaking process via
 # fork/exec/setrlimit/select, so it is POSIX-only. Default ON elsewhere; force

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ config_solver(CVC5 1.0.8)
 config_solver(MathSAT 5.6.3)
 config_solver(STP 2.3.4)
 config_solver(Yices 2.6.1)
-config_solver(Z3 5.0.0)
+config_solver(Z3 4.16.0)
 
 # The SMT-LIB pipeline backend drives an external SMT-LIB-speaking process via
 # fork/exec/setrlimit/select, so it is POSIX-only. Default ON elsewhere; force

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Downloaded sources and locally installed solver artifacts are stored under
 
 When CMake downloads dependencies itself:
 - `Bitwuzla` uses the prebuilt static release archive from `0.9.1`.
-- `Z3` uses the prebuilt release archive from `z3-4.16.0`.
+- `Z3` uses the prebuilt release archive from `z3-5.0.0`.
 - `CVC5` uses the prebuilt static release archive from `cvc5-1.3.4`.
 - `Yices` uses a source build.
 - `GMP` uses a source build when it is needed by downloaded dependencies and no
@@ -128,7 +128,7 @@ location during the build.
 | [MathSAT](https://mathsat.fbk.eu/)         |  5.6.3          | ✔️<sup>1</sup> |
 | [STP](https://stp.github.io/)              |  2.3.4          |   |
 | [Yices](https://yices.csl.sri.com/)        |  2.6.1          |   |
-| [Z3](https://github.com/Z3Prover/z3)       |  4.16.0         | ✔️ |
+| [Z3](https://github.com/Z3Prover/z3)       |  5.0.0          | ✔️ |
 | SMT-LIB (any external solver) | n/a | depends on child |
 
 <sup>1</sup> `fp.fma` and `fp.rem` are bit-blasted when using MathSAT because

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -26,22 +26,22 @@ set(CAMADA_DEPS_INSTALL_DIR
     CACHE PATH "Directory used to install downloaded solver dependencies")
 
 set(CAMADA_Z3_LINUX_X86_64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-x64-glibc-2.39.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-x64-glibc-2.39.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for Linux x86_64")
 set(CAMADA_Z3_LINUX_AARCH64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-arm64-glibc-2.38.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-arm64-glibc-2.38.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for Linux aarch64")
 set(CAMADA_Z3_MACOS_X86_64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-x64-osx-15.7.3.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-x64-osx-13.3.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for macOS x86_64")
 set(CAMADA_Z3_MACOS_ARM64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-arm64-osx-15.7.3.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-arm64-osx-13.3.zip"
     CACHE STRING "URL used to download the prebuilt Z3 archive for macOS arm64")
 set(CAMADA_Z3_WINDOWS_X86_64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-4.16.0/z3-4.16.0-x64-win.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-x64-win.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for Windows x86_64")
 set(CAMADA_CVC5_LINUX_X86_64_URL


### PR DESCRIPTION
## Summary

- update the required Z3 version to 5.0.0
- use the official Z3 5.0.0 prebuilt archives on supported platforms
- update the documented bundled and minimum versions

## Verification

- configured a fresh isolated Z3-only build; CMake detected Z3 5.0.0
- built Camada and camada-regression successfully
- ran the Z3 regression tag: 1,232 assertions in 9 test cases passed