### PR TITLE
Update the STP source build to 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ When CMake downloads dependencies itself:
   Linux. macOS stays pinned to `5.6.16`: the `5.6.17` macOS tarball ships
   `libmathsat.a` as a plain `ar` archive of fat Mach-O objects, a layout
   Apple's `ld` rejects.
-- `STP` still falls back to a source build of `2.4.0`. The `2.4.0` GitHub
+- `STP` still falls back to a source build of `2.4.1`. The `2.4.1` GitHub
   release only ships a standalone `stp` executable, not the headers and
   libraries that Camada needs to link against the STP C++ API.
 - `CryptoMiniSat`, `Minisat`, and CryptoMiniSat's patched `CaDiCaL`/`CadiBack`

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -995,12 +995,12 @@ function(camada_setup_stp)
 
   message(
     STATUS
-      "The STP 2.4.0 GitHub release asset is a standalone solver binary, not a development package with headers and libraries. Falling back to a source build for Camada's STP API wrapper."
+      "The STP 2.4.1 GitHub release asset is a standalone solver binary, not a development package with headers and libraries. Falling back to a source build for Camada's STP API wrapper."
   )
 
   camada_setup_minisat()
   camada_setup_cryptominisat()
-  camada_fetch_git_source(stpsrc stp/stp 2.4.0 stp_source_dir)
+  camada_fetch_git_source(stpsrc stp/stp 2.4.1 stp_source_dir)
   if(APPLE)
     file(READ "${stp_source_dir}/CMakeLists.txt" stp_cmake_contents)
     string(


### PR DESCRIPTION
## Summary

Bugfix release published 2026-08-01: guards the multiplication constant-bit propagator's column bounds against a shrunken column (stp/stp#699) and fixes an overflow seeding the ground-path square root (stp/stp#702). Only the downloaded/source-built version moves — the 2.4.0 minimum in `config_solver` is unchanged (STP's version file accepts any 2.4.x).

## Test plan

Full regression suite passes 173/173 on Linux x86_64 against the freshly staged 2.4.1 (verified via the installed `STPConfigVersion.cmake`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)