### PR TITLE
Make unsat-assumption production opt-in on Bitwuzla and cvc5

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ even if it lacks native floating-point support.
 | Tuples | ✔️<sup>2</sup> | ✔️ | ✔️<sup>2</sup> | ✔️<sup>2</sup> | ✔️<sup>2</sup> | ✔️ |
 | Quantifiers | ✔️ | ✔️ |   |   |   | ✔️ |
 | Overflow predicates | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
-| Unsat assumptions | ✔️ | ✔️ | ✔️ |   | ✔️ | ✔️ |
+| Unsat assumptions | ✔️<sup>5</sup> | ✔️<sup>5</sup> | ✔️ |   | ✔️ | ✔️ |
 | Timeouts (`setTimeout`) | ✔️ | ✔️ | ✔️ | ✔️<sup>4</sup> | ✔️<sup>3</sup> | ✔️ |
 | Array models (`getArrayValues`) | ✔️ | ✔️ | ✔️ |   | ✔️ | ✔️ |
 
@@ -281,6 +281,12 @@ at most one timed Yices check may run at a time process-wide.
 
 <sup>4</sup> STP's native time budget is whole seconds for the entire
 query; millisecond limits round up to the next second.
+
+<sup>5</sup> Opt-in at solver creation: producing unsat assumptions slows
+every check on these backends and the option is frozen at context
+creation, so `createBitwuzlaSolver`/`createCVC5Solver` default it off —
+pass `UnsatAssumptionsMode::On` to extract cores. `checkSatAssuming`
+itself works regardless.
 
 The last four rows (and any platform splits) are queryable at runtime via
 `supports(SolverFeature)`; `checkSatAssuming` itself works on every

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -179,9 +179,34 @@ TEST_CASE("Bitwuzla feature capabilities", "[Bitwuzla]") {
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeConstantArrays));
-  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  // Core extraction is opt-in at construction: producing unsat
+  // assumptions slows every check, so the default context leaves it off.
+  REQUIRE_FALSE(solver->supports(SolverFeature::UnsatAssumptions));
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
+
+  auto withCores =
+      camada::createBitwuzlaSolver(camada::UnsatAssumptionsMode::On);
+  REQUIRE(withCores->supports(SolverFeature::UnsatAssumptions));
+}
+
+TEST_CASE("Unsat-assumption opt-in Bitwuzla test", "[Bitwuzla]") {
+  // The default solver runs the shared fixture through its
+  // core-unsupported branch (inside tests()); the opted-in solver must
+  // produce real cores end to end.
+  auto solver = camada::createBitwuzlaSolver(camada::UnsatAssumptionsMode::On);
+  check_sat_assuming_semantics(solver);
+  // The shared fixture tolerates core-less backends, so pin explicitly
+  // that this solver actually produces one — and that the opt-in survives
+  // reset() (bitwuzla recreates its context there).
+  solver->reset();
+  REQUIRE(solver->supports(camada::SolverFeature::UnsatAssumptions));
+  auto a = solver->mkSymbol("a", solver->mkBoolSort());
+  REQUIRE(solver->checkSatAssuming({a, solver->mkNot(a)}) ==
+          camada::checkResult::UNSAT);
+  auto core = solver->getUnsatAssumptions();
+  REQUIRE(core);
+  REQUIRE(!core.value().empty());
 }
 
 // Registered per backend rather than in tests(): the depth-5 shape

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -163,9 +163,33 @@ TEST_CASE("CVC5 feature capabilities", "[CVC5]") {
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
   REQUIRE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
-  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  // Core extraction is opt-in at construction: producing unsat
+  // assumptions slows every check, so the default context leaves it off.
+  REQUIRE_FALSE(solver->supports(SolverFeature::UnsatAssumptions));
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
+
+  auto withCores = camada::createCVC5Solver(camada::UnsatAssumptionsMode::On);
+  REQUIRE(withCores->supports(SolverFeature::UnsatAssumptions));
+}
+
+TEST_CASE("Unsat-assumption opt-in CVC5 test", "[CVC5]") {
+  // The default solver runs the shared fixture through its
+  // core-unsupported branch (inside tests()); the opted-in solver must
+  // produce real cores end to end.
+  auto solver = camada::createCVC5Solver(camada::UnsatAssumptionsMode::On);
+  check_sat_assuming_semantics(solver);
+  // The shared fixture tolerates core-less backends, so pin explicitly
+  // that this solver actually produces one — and that the opt-in survives
+  // reset() (cvc5 keeps its options through resetAssertions()).
+  solver->reset();
+  REQUIRE(solver->supports(camada::SolverFeature::UnsatAssumptions));
+  auto a = solver->mkSymbol("a", solver->mkBoolSort());
+  REQUIRE(solver->checkSatAssuming({a, solver->mkNot(a)}) ==
+          camada::checkResult::UNSAT);
+  auto core = solver->getUnsatAssumptions();
+  REQUIRE(core);
+  REQUIRE(!core.value().empty());
 }
 
 // Registered per backend rather than in tests(): the depth-5 shape

--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -96,22 +96,30 @@ inline void solver_timeout_semantics(const camada::SMTSolverRef &solver) {
   // Factoring a 64-bit semiprime exactly (the 128-bit extension rules out
   // wrap-around shortcuts) is far beyond a 150ms budget on every backend,
   // so the limit must turn the query into UNKNOWN instead of a hang. The
-  // reset also pins that the limit itself survives reset().
-  solver->reset();
-  auto a = solver->mkSymbol("a", solver->mkBVSort(64));
-  auto b = solver->mkSymbol("b", solver->mkBVSort(64));
-  constexpr uint64_t Semiprime = 4294967291ULL * 4294967279ULL;
-  auto prod =
-      solver->mkBVMul(solver->mkBVZeroExt(64, a), solver->mkBVZeroExt(64, b));
-  auto k = solver->mkBVZeroExt(
-      64, solver->mkBVFromDec(static_cast<int64_t>(Semiprime), 64));
-  solver->addConstraint(solver->mkEqual(prod, k));
-  auto one = solver->mkBVFromDec(1, 64);
-  solver->addConstraint(solver->mkBVUgt(a, one));
-  solver->addConstraint(solver->mkBVUgt(b, one));
+  // resets also pin that the limit itself survives reset().
+  auto assertSemiprimeFactoring = [&]() {
+    solver->reset();
+    auto a = solver->mkSymbol("a", solver->mkBVSort(64));
+    auto b = solver->mkSymbol("b", solver->mkBVSort(64));
+    constexpr uint64_t Semiprime = 4294967291ULL * 4294967279ULL;
+    auto prod =
+        solver->mkBVMul(solver->mkBVZeroExt(64, a), solver->mkBVZeroExt(64, b));
+    auto k = solver->mkBVZeroExt(
+        64, solver->mkBVFromDec(static_cast<int64_t>(Semiprime), 64));
+    solver->addConstraint(solver->mkEqual(prod, k));
+    auto one = solver->mkBVFromDec(1, 64);
+    solver->addConstraint(solver->mkBVUgt(a, one));
+    solver->addConstraint(solver->mkBVUgt(b, one));
+  };
+  assertSemiprimeFactoring();
   REQUIRE(solver->check() == camada::checkResult::UNKNOWN);
 
-  // The limit applies to assumption-based checks too.
+  // The limit applies to assumption-based checks too. Rebuild the problem
+  // from scratch first: an incremental solver resumes the interrupted
+  // search with everything it already learned, and the cumulative budget
+  // was occasionally enough to actually factor the semiprime (seen with
+  // bitwuzla), turning this deterministic UNKNOWN into a flaky SAT.
+  assertSemiprimeFactoring();
   auto t = solver->mkSymbol("t", solver->mkBoolSort());
   REQUIRE(solver->checkSatAssuming({t}) == camada::checkResult::UNKNOWN);
 

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -121,7 +121,8 @@ void BitwExpr::dump(std::string &Out) const {
   Out = bitwuzla_term_to_string(Expr);
 }
 
-BitwuzlaSolver::BitwuzlaSolver() {
+BitwuzlaSolver::BitwuzlaSolver(UnsatAssumptionsMode Mode)
+    : ProduceUnsatAssumptions(Mode == UnsatAssumptionsMode::On) {
   initializeContext();
   initializeCommonSingletons();
 }
@@ -135,7 +136,11 @@ void BitwuzlaSolver::initializeContext() {
   TermManager = bitwuzla_term_manager_new();
   Options = bitwuzla_options_new();
   bitwuzla_set_option(Options, BITWUZLA_OPT_PRODUCE_MODELS, 1);
-  bitwuzla_set_option(Options, BITWUZLA_OPT_PRODUCE_UNSAT_ASSUMPTIONS, 1);
+  // Tracking which assumptions participate in a refutation slows every
+  // check, so core production is opt-in (UnsatAssumptionsMode::On at
+  // construction) and the default context stays fast.
+  if (ProduceUnsatAssumptions)
+    bitwuzla_set_option(Options, BITWUZLA_OPT_PRODUCE_UNSAT_ASSUMPTIONS, 1);
   bitwuzla_set_abort_callback(bitwuzlaErrorHandler);
   Context = bitwuzla_new(TermManager, Options);
   bitwuzla_set_termination_callback(Context, bitwuzlaTerminationCallback,
@@ -1014,10 +1019,11 @@ bool BitwuzlaSolver::supportsImpl(SolverFeature Feature) const {
   case SolverFeature::Quantifiers: // BV/FP quantifiers only
   case SolverFeature::UninterpretedFunctions:
   case SolverFeature::NativeFloatingPoint:
-  case SolverFeature::UnsatAssumptions:
   case SolverFeature::Timeouts:
   case SolverFeature::ArrayModels:
     return true;
+  case SolverFeature::UnsatAssumptions:
+    return ProduceUnsatAssumptions;
   case SolverFeature::IntRealArithmetic:
     return false;
   case SolverFeature::NativeTuples:
@@ -1065,6 +1071,13 @@ checkResult BitwuzlaSolver::checkSatAssumingImpl(
 }
 
 SMTResult<std::vector<SMTExprRef>> BitwuzlaSolver::getUnsatAssumptionsImpl() {
+  // Guard: querying bitwuzla for a core it was not configured to produce
+  // trips its abort handler rather than returning an error.
+  if (!ProduceUnsatAssumptions)
+    return SMTError{SMTErrorCode::UnsupportedOperation,
+                    SMTBackendKind::Bitwuzla,
+                    "Unsat-assumption production is off; create the solver "
+                    "with UnsatAssumptionsMode::On to extract cores"};
   size_t size = 0;
   const BitwuzlaTerm *core = bitwuzla_get_unsat_assumptions(Context, &size);
   std::vector<SMTExprRef> Result;

--- a/src/bitwuzlasolver.h
+++ b/src/bitwuzlasolver.h
@@ -66,7 +66,8 @@ public:
 
 class BitwuzlaSolver : public SMTSolverImpl {
 public:
-  BitwuzlaSolver();
+  explicit BitwuzlaSolver(
+      UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off);
   ~BitwuzlaSolver() override;
 
 protected:
@@ -77,6 +78,12 @@ protected:
 
   void initializeContext();
   void destroyContext();
+
+  /// Whether contexts are created with BITWUZLA_OPT_PRODUCE_UNSAT_ASSUMPTIONS
+  /// (opt-in: tracking assumption participation slows every check, and the
+  /// option is frozen at context creation). Survives reset(), which recreates
+  /// the context through initializeContext().
+  bool ProduceUnsatAssumptions = false;
 
   // Arm CheckDeadline from TimeoutMs; both check paths call it before
   // querying the solver.

--- a/src/camada.cpp
+++ b/src/camada.cpp
@@ -75,19 +75,21 @@ SMTSolverRef createMathSATSolver() {
 #endif
 }
 
-SMTSolverRef createCVC5Solver() {
+SMTSolverRef createCVC5Solver(UnsatAssumptionsMode Mode) {
 #if SOLVER_CVC5_ENABLED
-  return std::make_unique<CVC5Solver>();
+  return std::make_unique<CVC5Solver>(Mode);
 #else
+  (void)Mode;
   fatalError("Camada was not compiled with CVC5 support, rebuild with "
              "-DCAMADA_ENABLE_SOLVER_CVC5=ON");
 #endif
 }
 
-SMTSolverRef createBitwuzlaSolver() {
+SMTSolverRef createBitwuzlaSolver(UnsatAssumptionsMode Mode) {
 #if SOLVER_BITWUZLA_ENABLED
-  return std::make_unique<BitwuzlaSolver>();
+  return std::make_unique<BitwuzlaSolver>(Mode);
 #else
+  (void)Mode;
   fatalError("Camada was not compiled with Bitwuzla support, rebuild with "
              "-DCAMADA_ENABLE_SOLVER_BITWUZLA=ON");
 #endif

--- a/src/camada.h
+++ b/src/camada.h
@@ -108,6 +108,23 @@ enum class FPNegBehavior {
 ///   yices) already use.
 enum class TupleEncoding { Native, Camada };
 
+/// Selects whether a solver context is created with unsat-assumption
+/// production enabled. Producing the core is not free: backends whose SAT
+/// engine must track assumption participation (bitwuzla, cvc5) pay a
+/// solve-time cost on *every* check, and the setting is frozen at context
+/// creation — so it is opt-in.
+///
+/// - Off (default): fast contexts. checkSatAssuming() works unchanged;
+///   getUnsatAssumptions() reports UnsupportedOperation and
+///   supports(SolverFeature::UnsatAssumptions) answers false.
+/// - On: the backend tracks assumptions and getUnsatAssumptions() returns
+///   real cores after an UNSAT checkSatAssuming().
+///
+/// Backends that answer cores without a creation-time option (Z3 enables
+/// unsat_core per query, MathSAT and Yices track natively) ignore this
+/// and always support core extraction.
+enum class UnsatAssumptionsMode { Off, On };
+
 enum class RM {
   ROUND_TO_EVEN = 0,
   ROUND_TO_AWAY = 1,
@@ -1055,11 +1072,15 @@ SMTSolverRef createZ3Solver();
 /// Convenience method to create a MathSATSolver object
 SMTSolverRef createMathSATSolver();
 
-/// Convenience method to create a CVC5Solver object
-SMTSolverRef createCVC5Solver();
+/// Convenience method to create a CVC5Solver object. Core extraction via
+/// getUnsatAssumptions() is opt-in (see UnsatAssumptionsMode).
+SMTSolverRef
+createCVC5Solver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off);
 
-/// Convenience method to create a BitwuzlaSolver object
-SMTSolverRef createBitwuzlaSolver();
+/// Convenience method to create a BitwuzlaSolver object. Core extraction
+/// via getUnsatAssumptions() is opt-in (see UnsatAssumptionsMode).
+SMTSolverRef
+createBitwuzlaSolver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off);
 
 /// Convenience method to create a YicesSolver object
 SMTSolverRef createYicesSolver();

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -104,11 +104,17 @@ void CVC5Expr::dump(std::string &Out) const {
   Out += "\n";
 }
 
-CVC5Solver::CVC5Solver() : Context(Terms) {
+CVC5Solver::CVC5Solver(UnsatAssumptionsMode Mode)
+    : Context(Terms),
+      ProduceUnsatAssumptions(Mode == UnsatAssumptionsMode::On) {
   Context.setOption("arrays-exp", "true");
   Context.setOption("produce-models", "true");
   Context.setOption("produce-assertions", "true");
-  Context.setOption("produce-unsat-assumptions", "true");
+  // Tracking which assumptions participate in a refutation slows every
+  // check, so core production is opt-in (UnsatAssumptionsMode::On at
+  // construction) and the default context stays fast.
+  if (ProduceUnsatAssumptions)
+    Context.setOption("produce-unsat-assumptions", "true");
   initializeCommonSingletons();
 }
 
@@ -1252,10 +1258,11 @@ bool CVC5Solver::supportsImpl(SolverFeature Feature) const {
   case SolverFeature::Quantifiers:
   case SolverFeature::UninterpretedFunctions:
   case SolverFeature::NativeFloatingPoint:
-  case SolverFeature::UnsatAssumptions:
   case SolverFeature::Timeouts:
   case SolverFeature::ArrayModels:
     return true;
+  case SolverFeature::UnsatAssumptions:
+    return ProduceUnsatAssumptions;
   case SolverFeature::NativeTuples:
   case SolverFeature::NativeConstantArrays:
     break; // answered by the common layer's hooks
@@ -1299,6 +1306,12 @@ CVC5Solver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
 }
 
 SMTResult<std::vector<SMTExprRef>> CVC5Solver::getUnsatAssumptionsImpl() {
+  // Guard: cvc5 throws when queried for a core it was not configured to
+  // produce.
+  if (!ProduceUnsatAssumptions)
+    return SMTError{SMTErrorCode::UnsupportedOperation, SMTBackendKind::CVC5,
+                    "Unsat-assumption production is off; create the solver "
+                    "with UnsatAssumptionsMode::On to extract cores"};
   std::vector<cvc5::Term> core = Context.getUnsatAssumptions();
   std::vector<SMTExprRef> Result;
   for (const cvc5::Term &Term : core)

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -105,8 +105,8 @@ void CVC5Expr::dump(std::string &Out) const {
 }
 
 CVC5Solver::CVC5Solver(UnsatAssumptionsMode Mode)
-    : Context(Terms),
-      ProduceUnsatAssumptions(Mode == UnsatAssumptionsMode::On) {
+    : ProduceUnsatAssumptions(Mode == UnsatAssumptionsMode::On),
+      Context(Terms) {
   Context.setOption("arrays-exp", "true");
   Context.setOption("produce-models", "true");
   Context.setOption("produce-assertions", "true");

--- a/src/cvc5solver.h
+++ b/src/cvc5solver.h
@@ -66,7 +66,7 @@ public:
 
 class CVC5Solver : public SMTSolverImpl {
 public:
-  CVC5Solver();
+  explicit CVC5Solver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off);
   ~CVC5Solver() override;
 
 protected:
@@ -371,6 +371,11 @@ protected:
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
 
   bool supportsImpl(SolverFeature Feature) const override;
+
+  /// Whether the context was created with produce-unsat-assumptions
+  /// (opt-in: tracking assumption participation slows every check, and
+  /// cvc5 only honors the option when set before solving starts).
+  bool ProduceUnsatAssumptions = false;
 
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;


### PR DESCRIPTION
## Summary

Fixes a solve-time regression in ESBMC introduced by PR #80: Bitwuzla and cvc5 were creating every context with unsat-assumption production enabled, and tracking which assumptions participate in a refutation restricts the SAT engine on **every** check — even for callers that never extract a core. Both backends freeze the option at context creation (unlike Z3, which enables `unsat_core` per query), so the fix is a creation-time opt-in.

### Design

`createBitwuzlaSolver` / `createCVC5Solver` (and the underlying constructors) take a new `UnsatAssumptionsMode` enum, defaulted to `Off` — the same defaulted-trailing-enum shape as `createSMTLIBSolver`'s `TupleEncoding`:

- **Off (default)**: fast contexts. `checkSatAssuming()` works unchanged; `supports(SolverFeature::UnsatAssumptions)` answers false; `getUnsatAssumptions()` returns a clean `UnsupportedOperation` error instead of reaching Bitwuzla's process-abort or cvc5's exception.
- **On**: restores full core extraction. The flag survives `reset()` on both backends (Bitwuzla re-reads it when `resetImpl` recreates the context; cvc5's `resetAssertions()` keeps options).

Z3, MathSAT, and Yices pay no creation-time cost for cores and keep unconditional support; the SMT-LIB pipe keeps its own runtime negotiation with the child. Existing call sites are source-compatible; ESBMC gets the speed back with no changes.

### Flaky timeout test fixed

Removing the tracking drag made Bitwuzla fast enough to *frequently* trip the known-flaky `solver_timeout_semantics` assumption-based re-check (the same flake seen on #108's CI): the incremental solver resumed the interrupted semiprime search with everything it had learned, and the cumulative budget was occasionally enough to actually factor it. The fixture now rebuilds the problem from scratch for that check, making the expected UNKNOWN deterministic — verified stable across repeated runs.

## Test plan

Full suite passes 205/205. Capability tests pin the new default (`REQUIRE_FALSE` on default solvers, `REQUIRE` on `UnsatAssumptionsMode::On` solvers); new opt-in test cases run the shared assumption fixture **and** explicitly require a non-empty core after `reset()`, since the shared fixture deliberately tolerates core-less backends and alone cannot catch a silently broken opt-in. README parity table documents the opt-in in a footnote.

Follow-ups noted from review discussion (not in this PR): expose `TupleEncoding` for Z3/cvc5 (forcing the Camada tuple lowering on native-datatype backends), and consolidate the accumulating creation-time knobs into a per-solver config object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)