### PR TITLE
Add a one-shot mode to the SMT-LIB backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,32 @@ auto result = solver->check();          // sat / unsat / unknown
 auto value = solver->getBV(symbol);     // round-trips through (get-value ...)
 ```
 
+A fourth, **one-shot** mode serves solvers that read a complete formula
+file and print a verdict instead of speaking interactive SMT-LIB
+(Mallob-style distributed solvers, ML-based solvers):
+
+```cpp
+auto solver = std::make_unique<camada::SMTLIBSolver>(
+    camada::SMTLIBOneShotTag{}, "/tmp/formula.smt2",
+    "mallob -mono=%f -mono-app=SMT",   // %f = shell-quoted formula path
+    {"z3", "-in"});                    // optional model solver for get-value
+```
+
+The script (including `(check-sat)`) is written to the formula file, the
+shell command runs on it once, and stdout is scanned with a strict
+per-line verdict parser (`sat`/`unsat`/`unknown` and the SAT-competition
+`s ...` forms; the last verdict wins; a verdict from a signal-killed
+command is discarded). Because the one-shot process cannot answer
+`(get-value)`, an optional interactive model solver receives the same
+script in parallel and serves models after a `sat` verdict — its own
+verdict is exposed via `oneShotModelVerdict()` so callers can detect a
+diverging model solver. The command runs in its own process group and a
+spawn-time callback hands out the pgid for the caller's signal/timeout
+teardown paths. One `check()` per solver; no-verdict runs return UNKNOWN
+with the command, exit status, and output tail retrievable via
+`oneShotDiagnostics()`. Unlike every other mode, the command template is
+executed **via a shell** — do not build it from untrusted input.
+
 A two-argument form also tees the emitted SMT-LIB script to a file, useful
 when you want both an interactive answer and a reproducer to share:
 

--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -31,10 +31,14 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <csignal>
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "camada.h"
@@ -378,4 +382,294 @@ TEST_CASE("SMTLIB feature capabilities", "[SMTLIB]") {
   solver.reset();
   camadaTuples.reset();
   std::remove(Path.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// One-shot mode (SMTLIBOneShotTag): serialize to a file, run a shell command
+// on it, scan stdout for a verdict; an optional interactive model solver
+// serves get-value queries after a sat verdict.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Write an executable shell script and return its path.
+std::string makeScript(const std::string &Body) {
+  std::string Path = makeTempPath();
+  {
+    std::ofstream Out(Path);
+    REQUIRE(Out.good());
+    Out << "#!/bin/sh\n" << Body;
+  }
+  REQUIRE(::chmod(Path.c_str(), 0755) == 0);
+  return Path;
+}
+
+std::vector<std::string> z3ModelArgv() {
+#ifdef CAMADA_TEST_Z3_BIN
+  if (::access(CAMADA_TEST_Z3_BIN, X_OK) == 0)
+    return {CAMADA_TEST_Z3_BIN, "-in"};
+#endif
+  return {};
+}
+
+// Fork-and-expect-abort, local copy of the tests.h helper (this file does
+// not include the shared fixture headers).
+template <typename Fn> void requireAborts(Fn &&Body) {
+  ::pid_t Pid = ::fork();
+  REQUIRE(Pid >= 0);
+  if (Pid == 0) {
+    Body();
+    std::_Exit(0);
+  }
+  int Status = 0;
+  REQUIRE(::waitpid(Pid, &Status, 0) == Pid);
+  REQUIRE(WIFSIGNALED(Status));
+  REQUIRE(WTERMSIG(Status) == SIGABRT);
+}
+
+} // namespace
+
+TEST_CASE("SMTLIB one-shot verdict scanner contract", "[SMTLIB][oneshot]") {
+  using camada::checkResult;
+  using camada::parseOneShotVerdictLine;
+
+  // Bare SMT-LIB verdicts.
+  REQUIRE(parseOneShotVerdictLine("sat") == checkResult::SAT);
+  REQUIRE(parseOneShotVerdictLine("unsat") == checkResult::UNSAT);
+  REQUIRE(parseOneShotVerdictLine("unknown") == checkResult::UNKNOWN);
+
+  // SAT-competition style.
+  REQUIRE(parseOneShotVerdictLine("s SATISFIABLE") == checkResult::SAT);
+  REQUIRE(parseOneShotVerdictLine("s UNSATISFIABLE") == checkResult::UNSAT);
+  REQUIRE(parseOneShotVerdictLine("s UNKNOWN") == checkResult::UNKNOWN);
+
+  // Surrounding whitespace tolerated.
+  REQUIRE(parseOneShotVerdictLine("  sat") == checkResult::SAT);
+  REQUIRE(parseOneShotVerdictLine("unsat\r\n") == checkResult::UNSAT);
+  REQUIRE(parseOneShotVerdictLine("\t s SATISFIABLE \n") == checkResult::SAT);
+
+  // Everything else rejected — no substring matching.
+  REQUIRE_FALSE(parseOneShotVerdictLine("").has_value());
+  REQUIRE_FALSE(parseOneShotVerdictLine("   ").has_value());
+  REQUIRE_FALSE(parseOneShotVerdictLine("c solving /tmp/q.smt2").has_value());
+  REQUIRE_FALSE(
+      parseOneShotVerdictLine("[NeuroSym] loading model...").has_value());
+  REQUIRE_FALSE(parseOneShotVerdictLine("unsat core").has_value());
+  REQUIRE_FALSE(parseOneShotVerdictLine("presat").has_value());
+  REQUIRE_FALSE(parseOneShotVerdictLine("SATISFIABLE").has_value());
+  REQUIRE_FALSE(parseOneShotVerdictLine("s sat").has_value());
+}
+
+TEST_CASE("SMTLIB one-shot sat with model solver", "[SMTLIB][oneshot]") {
+  auto ModelArgv = z3ModelArgv();
+  if (ModelArgv.empty())
+    SKIP("no staged z3 binary for the model solver");
+
+  std::string Formula = makeTempPath();
+  // The stand-in checks it actually received the formula file, emits log
+  // noise a substring scanner would trip on, then the verdict.
+  std::string Script = makeScript("test -f \"$1\" || exit 9\n"
+                                  "echo '[fake-mallob] c unsat core noise'\n"
+                                  "echo sat\n");
+  long SeenPgid = 0;
+  auto solver = std::make_unique<camada::SMTLIBSolver>(
+      camada::SMTLIBOneShotTag{}, Formula, Script + " %f", ModelArgv,
+      [&SeenPgid](long Pgid) { SeenPgid = Pgid; });
+
+  auto X = solver->mkSymbol("x", solver->mkBVSort(8));
+  solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(5, 8)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // Pgid handed out at spawn; the formula file is complete.
+  REQUIRE(SeenPgid > 0);
+  std::string Written = readFile(Formula);
+  REQUIRE(Written.find("(check-sat)") != std::string::npos);
+  REQUIRE(Written.find("(assert") != std::string::npos);
+
+  // The parallel model solver agrees and serves the model.
+  REQUIRE(solver->oneShotModelVerdict() == camada::checkResult::SAT);
+  REQUIRE(solver->oneShotModelSolverLive());
+  auto Val = solver->getBV(X);
+  REQUIRE(Val);
+  REQUIRE(Val.value() == 5);
+
+  // Single-query restriction: a second check aborts.
+  requireAborts([&]() { (void)solver->check(); });
+
+  solver.reset();
+  std::remove(Formula.c_str());
+  std::remove(Script.c_str());
+}
+
+TEST_CASE("SMTLIB one-shot verdict handling", "[SMTLIB][oneshot]") {
+  // Last verdict wins, and SAT-competition style is accepted.
+  {
+    std::string Formula = makeTempPath();
+    std::string Script = makeScript("echo sat\necho 's UNSATISFIABLE'\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f");
+    solver->addConstraint(solver->mkBool(true));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+  }
+  // No verdict: UNKNOWN, with the command, exit status, and output tail
+  // retrievable for the caller's diagnostics.
+  {
+    std::string Formula = makeTempPath();
+    std::string Script =
+        makeScript("echo '[fake] warming up'\necho '[fake] done'\nexit 3\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f");
+    solver->addConstraint(solver->mkBool(true));
+    REQUIRE(solver->check() == camada::checkResult::UNKNOWN);
+    const camada::OneShotDiagnostics &D = solver->oneShotDiagnostics();
+    REQUIRE(D.Command.find(Formula) != std::string::npos);
+    REQUIRE(D.ExitStatus == "exit code 3");
+    REQUIRE(D.OutputTail.find("[fake] warming up") != std::string::npos);
+    REQUIRE(D.OutputTail.find("[fake] done") != std::string::npos);
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+  }
+  // A verdict from a signal-killed solver is discarded: a truncated run
+  // must not become a verification verdict.
+  {
+    std::string Formula = makeTempPath();
+    std::string Script = makeScript("echo sat\nkill -9 $$\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f");
+    solver->addConstraint(solver->mkBool(true));
+    REQUIRE(solver->check() == camada::checkResult::UNKNOWN);
+    REQUIRE(solver->oneShotDiagnostics().ExitStatus == "signal 9");
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+  }
+}
+
+TEST_CASE("SMTLIB one-shot %f substitution", "[SMTLIB][oneshot]") {
+  // Every %f is replaced with the same (quoted) path.
+  {
+    std::string Formula = makeTempPath();
+    std::string Script = makeScript(
+        "test -f \"$1\" && test \"$1\" = \"$2\" && echo sat || echo unsat\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f %f");
+    solver->addConstraint(solver->mkBool(true));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+  }
+  // Without %f the quoted path is appended — even when it contains
+  // characters a shell would otherwise split or interpret.
+  {
+    char Dir[] = "/tmp/camada one-shot XXXXXX";
+    REQUIRE(::mkdtemp(Dir) != nullptr);
+    std::string Formula = std::string(Dir) + "/it's a formula.smt2";
+    std::string Script =
+        makeScript("test -f \"$1\" && echo sat || echo unsat\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script);
+    solver->addConstraint(solver->mkBool(true));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    solver.reset();
+    std::remove(Formula.c_str());
+    ::rmdir(Dir);
+    std::remove(Script.c_str());
+  }
+}
+
+TEST_CASE("SMTLIB one-shot diverging and dying model solvers",
+          "[SMTLIB][oneshot]") {
+  // Diverging: the one-shot solver claims sat on an unsatisfiable formula;
+  // the model solver disagrees. Camada returns both verdicts and does NOT
+  // abort — the caller compares and decides how to report it.
+  {
+    auto ModelArgv = z3ModelArgv();
+    if (ModelArgv.empty())
+      SKIP("no staged z3 binary for the model solver");
+    std::string Formula = makeTempPath();
+    std::string Script = makeScript("echo sat\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f", ModelArgv);
+    auto A = solver->mkSymbol("a", solver->mkBoolSort());
+    solver->addConstraint(A);
+    solver->addConstraint(solver->mkNot(A));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->oneShotModelVerdict() == camada::checkResult::UNSAT);
+    REQUIRE_FALSE(solver->oneShotModelSolverLive());
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+  }
+  // Dying: a model solver that exits immediately is dropped; the one-shot
+  // flow continues file-only without counterexample support.
+  {
+    std::string Formula = makeTempPath();
+    std::string Script = makeScript("echo sat\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f",
+        std::vector<std::string>{"false"});
+    auto X = solver->mkSymbol("x", solver->mkBVSort(8));
+    solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(5, 8)));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE_FALSE(solver->oneShotModelSolverLive());
+    REQUIRE_FALSE(solver->oneShotModelVerdict().has_value());
+    REQUIRE_FALSE(solver->getBV(X));
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+  }
+}
+
+TEST_CASE("SMTLIB one-shot assumption checks and mid-negotiation death",
+          "[SMTLIB][oneshot]") {
+  // checkSatAssuming must route through the one-shot flow (assumptions
+  // land in the formula file inside a scope), not silently query only the
+  // auxiliary model solver.
+  {
+    std::string Formula = makeTempPath();
+    std::string Script = makeScript("echo sat\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f");
+    auto A = solver->mkSymbol("a", solver->mkBoolSort());
+    REQUIRE(solver->checkSatAssuming({A}) == camada::checkResult::SAT);
+    std::string Written = readFile(Formula);
+    REQUIRE(Written.find("(check-sat)") != std::string::npos);
+    REQUIRE(Written.find("(push 1)") != std::string::npos);
+    // The single-query restriction holds through this entry point too.
+    requireAborts([&]() { (void)solver->check(); });
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+  }
+  // A model child that rejects (set-logic ALL) and then dies exercises the
+  // fallback branch of the preamble negotiation: it must degrade to
+  // file-only, not abort the host.
+  {
+    std::string Formula = makeTempPath();
+    std::string Script = makeScript("echo sat\n");
+    // Ack the five preamble reads before set-logic, reject ALL, then exit:
+    // print-success, produce-models, produce-unsat-assumptions,
+    // global-declarations, set-info.
+    std::string DyingModel = makeScript("echo success\n"
+                                        "echo success\n"
+                                        "echo success\n"
+                                        "echo success\n"
+                                        "echo success\n"
+                                        "echo '(error \"no ALL here\")'\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f",
+        std::vector<std::string>{DyingModel});
+    REQUIRE_FALSE(solver->oneShotModelSolverLive());
+    solver->addConstraint(solver->mkBool(true));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+    std::remove(DyingModel.c_str());
+  }
 }

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -24,10 +24,12 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <climits>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
+#include <deque>
 #include <fcntl.h>
 #include <string>
 #include <sys/resource.h>
@@ -702,6 +704,189 @@ SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
   initializeCommonSingletons();
 }
 
+SMTLIBSolver::SMTLIBSolver(SMTLIBOneShotTag, const std::string &FormulaPath,
+                           const std::string &ShellCmd,
+                           const std::vector<std::string> &ModelArgv,
+                           PgidCallback OnSpawn, TupleEncoding TupleMode)
+    : OneShotMode(true), OneShotFormulaPath(FormulaPath),
+      OneShotShellCmd(ShellCmd), OneShotOnSpawn(std::move(OnSpawn)),
+      File(std::make_unique<FileEmitter>(FormulaPath)),
+      Proc(ModelArgv.empty() ? nullptr
+                             : std::make_unique<ProcessEmitter>(ModelArgv)),
+      TupleMode(TupleMode) {
+  emitPreamble();
+  initializeCommonSingletons();
+}
+
+std::optional<checkResult> parseOneShotVerdictLine(const std::string &Raw) {
+  const std::size_t Start = Raw.find_first_not_of(" \t\r\n");
+  if (Start == std::string::npos)
+    return std::nullopt;
+  const std::size_t End = Raw.find_last_not_of(" \t\r\n");
+  const std::string Line = Raw.substr(Start, End - Start + 1);
+
+  if (Line == "sat" || Line == "s SATISFIABLE")
+    return checkResult::SAT;
+  if (Line == "unsat" || Line == "s UNSATISFIABLE")
+    return checkResult::UNSAT;
+  if (Line == "unknown" || Line == "s UNKNOWN")
+    return checkResult::UNKNOWN;
+  return std::nullopt;
+}
+
+namespace {
+
+// waitpid()-style status word -> human-readable, so diagnostics show
+// "exit code 10" rather than 2560.
+std::string describeExitStatus(int Status) {
+  if (WIFEXITED(Status))
+    return "exit code " + std::to_string(WEXITSTATUS(Status));
+  if (WIFSIGNALED(Status))
+    return "signal " + std::to_string(WTERMSIG(Status));
+  return "status " + std::to_string(Status);
+}
+
+// POSIX single-quote quoting; embedded quotes become '\''.
+std::string shellQuotePath(const std::string &Path) {
+  std::string Escaped = Path;
+  for (std::size_t Q = Escaped.find('\''); Q != std::string::npos;
+       Q = Escaped.find('\'', Q + 4))
+    Escaped.replace(Q, 1, "'\\''");
+  return "'" + Escaped + "'";
+}
+
+} // namespace
+
+checkResult SMTLIBSolver::runOneShotCommand() {
+  // Substitute the formula file for every %f, or append it, quoting the
+  // path for the shell the command runs under.
+  const std::string Quoted = shellQuotePath(OneShotFormulaPath);
+  std::string Cmd = OneShotShellCmd;
+  std::size_t Pos = Cmd.find("%f");
+  if (Pos == std::string::npos)
+    Cmd += " " + Quoted;
+  else
+    for (; Pos != std::string::npos; Pos = Cmd.find("%f", Pos)) {
+      Cmd.replace(Pos, 2, Quoted);
+      Pos += Quoted.size();
+    }
+  Diags = OneShotDiagnostics{};
+  Diags.Command = Cmd;
+
+  // Spawn the command in its own process group so the caller's
+  // signal/timeout exit paths can kill the whole subtree (a wrapper shell
+  // and any further children, e.g. an mpirun job) with one killpg.
+  int Fds[2];
+  fatalErrorIf(::pipe(Fds) != 0, "SMTLIBSolver: one-shot pipe() failed");
+  const ::pid_t Pid = ::fork();
+  fatalErrorIf(Pid < 0, "SMTLIBSolver: one-shot fork() failed");
+  if (Pid == 0) {
+    ::setpgid(0, 0); // become leader of a new group; pgid == pid
+    ::close(Fds[0]);
+    if (Fds[1] != STDOUT_FILENO) {
+      ::dup2(Fds[1], STDOUT_FILENO);
+      ::close(Fds[1]);
+    }
+    const char *Shell = ::getenv("SHELL");
+    if (!Shell || !*Shell)
+      Shell = "sh";
+    ::execlp(Shell, Shell, "-c", Cmd.c_str(), static_cast<char *>(nullptr));
+    ::_exit(127);
+  }
+  ::setpgid(Pid, Pid); // also from the parent, closing the fork/exec race
+  ::close(Fds[1]);
+  // Hand the pgid out immediately: a getter polled later would leave a
+  // window in which a caller timeout leaks the subtree.
+  if (OneShotOnSpawn)
+    OneShotOnSpawn(static_cast<long>(Pid));
+
+  std::FILE *ChildOut = ::fdopen(Fds[0], "r");
+  fatalErrorIf(ChildOut == nullptr, "SMTLIBSolver: one-shot fdopen() failed");
+
+  // Scan the output for verdict lines; the LAST one wins. Keep a tail of
+  // the output for the caller's diagnostics.
+  std::optional<checkResult> Verdict;
+  std::deque<std::string> Tail;
+  char Buf[4096];
+  while (std::fgets(Buf, sizeof(Buf), ChildOut)) {
+    std::string Line(Buf);
+    while (!Line.empty() &&
+           std::isspace(static_cast<unsigned char>(Line.back())))
+      Line.pop_back();
+    const std::size_t Start = Line.find_first_not_of(" \t");
+    if (Start != std::string::npos)
+      Line.erase(0, Start);
+
+    if (std::optional<checkResult> V = parseOneShotVerdictLine(Line))
+      Verdict = V;
+
+    Tail.push_back(std::move(Line));
+    if (Tail.size() > 20)
+      Tail.pop_front();
+  }
+  std::fclose(ChildOut);
+  int Status = 0;
+  ::waitpid(Pid, &Status, 0);
+
+  Diags.ExitStatus = describeExitStatus(Status);
+  for (const std::string &Line : Tail) {
+    Diags.OutputTail += Line;
+    Diags.OutputTail += '\n';
+  }
+
+  // A verdict from a solver that died on a signal (crash, OOM kill, a
+  // wrapper tearing the job down) cannot be trusted: a truncated run must
+  // not become a verification verdict. Non-zero *exit codes* stay
+  // accepted — SAT-competition-style solvers exit 10/20.
+  if (Verdict && WIFSIGNALED(Status))
+    return checkResult::UNKNOWN;
+  if (!Verdict)
+    return checkResult::UNKNOWN;
+  return *Verdict;
+}
+
+checkResult SMTLIBSolver::oneShotCheck() {
+  fatalErrorIf(OneShotCheckDone,
+               "SMTLIBSolver: one-shot mode supports a single (check-sat) "
+               "query per run; incremental strategies are not supported");
+  OneShotCheckDone = true;
+
+  // Complete the formula file first: the shell command reads it from disk.
+  if (File) {
+    File->emitRaw("(check-sat)\n");
+    File->flush();
+  }
+  // Start the model solver on the same query before the one-shot run so it
+  // solves in parallel; its answer is read only on a sat verdict.
+  if (Proc) {
+    Proc->emitRaw("(check-sat)\n");
+    Proc->flush();
+  }
+
+  const checkResult Verdict = runOneShotCommand();
+
+  if (Verdict == checkResult::SAT && Proc) {
+    const std::string Resp = Proc->readResponse();
+    if (Resp.empty()) {
+      // The model solver died mid-solve; continue without counterexample
+      // support. The caller sees oneShotModelSolverLive() == false.
+      Proc.reset();
+    } else {
+      OneShotModelVerdictValue = Resp == "sat"     ? checkResult::SAT
+                                 : Resp == "unsat" ? checkResult::UNSAT
+                                                   : checkResult::UNKNOWN;
+      // A disagreeing model solver has no model to serve; the caller
+      // compares the two verdicts and decides how to report it.
+      if (*OneShotModelVerdictValue != checkResult::SAT)
+        Proc.reset();
+    }
+  } else if (Proc) {
+    // Not sat (or no verdict): stop the parallel model solver unread.
+    Proc.reset();
+  }
+  return Verdict;
+}
+
 SMTLIBSolver::~SMTLIBSolver() { invalidateGeneratedObjects(); }
 
 void SMTLIBSolver::emitPreamble() {
@@ -763,7 +948,13 @@ void SMTLIBSolver::emitPreamble() {
     std::string Logic = "ALL";
     Proc->emitRaw("(set-logic ALL)\n");
     Proc->flush();
-    if (Proc->readResponse() != "success") {
+    const std::string FirstResp = Proc->readResponse();
+    if (OneShotMode && FirstResp.empty()) {
+      // The one-shot model solver died during startup; drop it and continue
+      // file-only (the emitLine death path, reachable here because this
+      // block reads responses by hand).
+      Proc.reset();
+    } else if (FirstResp != "success") {
       // stp rejects ALL with a stray diagnostic line and then still answers
       // `success` for the command; consume that stray ack or every later
       // response is off by one. ponytail: this two-line pairing is
@@ -774,11 +965,18 @@ void SMTLIBSolver::emitPreamble() {
       Proc->emitRaw("(set-logic QF_AUFBV)\n");
       Proc->flush();
       std::string Resp = Proc->readResponse();
-      fatalErrorIf(Resp != "success",
-                   ("SMTLIBSolver: child solver rejected both (set-logic ALL) "
-                    "and (set-logic QF_AUFBV): " +
-                    Resp)
-                       .c_str());
+      if (OneShotMode && Resp.empty()) {
+        // The one-shot model solver died mid-negotiation; drop it and
+        // continue file-only, same policy as everywhere else.
+        Proc.reset();
+      } else {
+        fatalErrorIf(
+            Resp != "success",
+            ("SMTLIBSolver: child solver rejected both (set-logic ALL) "
+             "and (set-logic QF_AUFBV): " +
+             Resp)
+                .c_str());
+      }
     }
     if (File)
       File->emitRaw("(set-logic " + Logic + ")\n");
@@ -787,7 +985,7 @@ void SMTLIBSolver::emitPreamble() {
   }
 }
 
-void SMTLIBSolver::emitLine(const std::string &Text) const {
+void SMTLIBSolver::emitLine(const std::string &Text) {
   const std::string Line = Text + "\n";
   if (File)
     File->emitRaw(Line);
@@ -798,9 +996,17 @@ void SMTLIBSolver::emitLine(const std::string &Text) const {
     // with the message — there's no recovery from a malformed command in this
     // simple synchronous protocol.
     std::string Resp = Proc->readResponse();
-    if (Resp != "success")
+    if (Resp != "success") {
+      // A one-shot model solver is auxiliary: on child death (EOF reads as
+      // an empty response), drop it and continue file-only — the one-shot
+      // run is the verdict source, only counterexample support is lost.
+      if (OneShotMode && Resp.empty()) {
+        Proc.reset();
+        return;
+      }
       fatalErrorIf(true,
                    ("SMTLIBSolver: child solver returned: " + Resp).c_str());
+    }
   }
 }
 
@@ -2268,6 +2474,8 @@ checkResult SMTLIBSolver::emitCheckCommand(const std::string &Cmd) {
 }
 
 checkResult SMTLIBSolver::checkImpl() {
+  if (OneShotMode)
+    return oneShotCheck();
   return emitCheckCommand("(check-sat)\n");
 }
 
@@ -2277,8 +2485,10 @@ SMTLIBSolver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
   // (check-sat-assuming ...) at all (stp answers `unsupported`), and without
   // the option there is no unsat core to salvage from the native form
   // anyway — use the common layer's equisatisfiable push/assert/check/pop
-  // fallback instead.
-  if (Proc && !UnsatAssumptionsSupported)
+  // fallback instead. One-shot mode must take the fallback too: its checkImpl
+  // is the one-shot run itself, and emitting (check-sat-assuming ...) here
+  // would silently query only the auxiliary model solver.
+  if (OneShotMode || (Proc && !UnsatAssumptionsSupported))
     return SMTSolverImpl::checkSatAssumingImpl(Assumptions);
   // Activate each assumption through a fresh literal: assert
   // (=> lit assumption), then assume the literal. This is equisatisfiable

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -24,7 +24,9 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -157,6 +159,37 @@ private:
 /// child solver process from the one that writes to a file.
 struct SMTLIBProcessTag {};
 
+/// Tag type for the one-shot constructor: serialize the whole script to a
+/// file and run a shell command on it once (see the constructor docs).
+struct SMTLIBOneShotTag {};
+
+/// Invoked in the parent immediately after the one-shot child is spawned
+/// and placed in its own process group, with the child's pgid. Lets the
+/// caller register the group for teardown on signal/timeout exit paths
+/// that skip destructors (a library destructor is not an equivalent
+/// fallback: _exit() runs neither destructors nor atexit handlers, and a
+/// one-shot solver may own a whole process subtree, e.g. an mpirun job).
+using PgidCallback = std::function<void(long Pgid)>;
+
+/// Strict verdict scanner for one-shot solver output, applied per line.
+/// Accepts exactly the bare SMT-LIB verdicts (`sat`, `unsat`, `unknown`)
+/// and the SAT-competition forms (`s SATISFIABLE`, `s UNSATISFIABLE`,
+/// `s UNKNOWN`), with surrounding whitespace tolerated; `unknown` maps to
+/// checkResult::UNKNOWN. Everything else is rejected — deliberately no
+/// substring matching, or a log line mentioning "unsat core" would become
+/// a verification verdict.
+std::optional<checkResult> parseOneShotVerdictLine(const std::string &Line);
+
+/// Facts about the last one-shot run, for the caller's diagnostics: the
+/// command after %f substitution, a decoded exit status ("exit code N" /
+/// "signal N"), and the last (up to) 20 lines of its stdout. Presentation
+/// is the caller's job — Camada reports, the host logs.
+struct OneShotDiagnostics {
+  std::string Command;
+  std::string ExitStatus;
+  std::string OutputTail;
+};
+
 /// Camada backend that emits SMT-LIB instead of calling a native solver.
 ///
 /// Two construction modes:
@@ -194,6 +227,51 @@ public:
   SMTLIBSolver(SMTLIBProcessTag, const std::vector<std::string> &Argv,
                const std::string &OutputPath,
                TupleEncoding TupleMode = TupleEncoding::Native);
+
+  /// One-shot constructor: serialize the script (including `(check-sat)`)
+  /// to FormulaPath, then run ShellCmd on it **via a shell** — every `%f`
+  /// is replaced by the shell-quoted formula path, or the path is appended
+  /// when no `%f` is present — scanning its stdout for a verdict with
+  /// parseOneShotVerdictLine (each line trimmed, the last verdict wins).
+  /// The child runs in its own process group; OnSpawn, when set, receives
+  /// the pgid immediately after the spawn so the caller can register it
+  /// for teardown on exit paths that skip destructors.
+  ///
+  /// When ModelArgv is non-empty, the same script is also streamed to that
+  /// interactive solver (execvp, no shell), which starts solving in
+  /// parallel at check() and serves get-value queries after a sat verdict;
+  /// its own answer is available via oneShotModelVerdict() so the caller
+  /// can detect a diverging model solver. A model solver that dies is
+  /// dropped silently — the one-shot run remains the verdict source and
+  /// only counterexample support is lost.
+  ///
+  /// check() may be called once; a second call aborts. On no verdict the
+  /// result is UNKNOWN and oneShotDiagnostics() carries the evidence.
+  ///
+  /// SECURITY: unlike every other SMTLIBSolver mode, ShellCmd is executed
+  /// by `$SHELL -c` (or `sh -c`) and must not be built from untrusted
+  /// input. FormulaPath is shell-quoted; the template is not.
+  SMTLIBSolver(SMTLIBOneShotTag, const std::string &FormulaPath,
+               const std::string &ShellCmd,
+               const std::vector<std::string> &ModelArgv = {},
+               PgidCallback OnSpawn = {},
+               TupleEncoding TupleMode = TupleEncoding::Native);
+
+  /// One-shot mode: the model solver's own answer to the shared query,
+  /// read only after a sat verdict from the one-shot run. Unset when no
+  /// model solver was configured, it died, or the verdict was not sat.
+  std::optional<checkResult> oneShotModelVerdict() const {
+    return OneShotModelVerdictValue;
+  }
+
+  /// One-shot mode: whether the interactive model solver is alive (it is
+  /// dropped when it dies, when the verdict is not sat, or when its own
+  /// answer was not sat).
+  bool oneShotModelSolverLive() const { return Proc != nullptr; }
+
+  /// One-shot mode: facts about the last run (command, exit status,
+  /// output tail) for the caller's diagnostics.
+  const OneShotDiagnostics &oneShotDiagnostics() const { return Diags; }
 
   ~SMTLIBSolver() override;
 
@@ -412,7 +490,7 @@ private:
                             bool OwnScope = false);
 
   // Emit a single line (newline appended) to the active emitter(s).
-  void emitLine(const std::string &Text) const;
+  void emitLine(const std::string &Text);
 
   // Emit a check command (a query: no `success` ack) and read the
   // sat/unsat/unknown verdict; UNKNOWN in write-only mode.
@@ -425,6 +503,18 @@ private:
 
   // Emit the standard preamble (set-option, set-logic, set-info).
   void emitPreamble();
+
+  // One-shot mode plumbing (see the SMTLIBOneShotTag constructor).
+  checkResult oneShotCheck();
+  checkResult runOneShotCommand();
+
+  bool OneShotMode = false;
+  bool OneShotCheckDone = false;
+  std::string OneShotFormulaPath;
+  std::string OneShotShellCmd;
+  PgidCallback OneShotOnSpawn;
+  std::optional<checkResult> OneShotModelVerdictValue;
+  OneShotDiagnostics Diags;
 
   std::unique_ptr<FileEmitter> File;
   std::unique_ptr<ProcessEmitter> Proc;


### PR DESCRIPTION
## Summary

Adds the fourth `SMTLIBSolver` mode ESBMC needs to move its `bitwuzllob` and `neurosym` backends onto Camada and delete `src/solvers/smtlib/` (3,030 lines): **one-shot** — serialize the whole script (including `(check-sat)`) to a formula file, run a shell command on it once, and scan its stdout for a verdict amid arbitrary log noise. Ports ESBMC's `oneshot_process.cpp` faithfully, per the contracts in its `PORT-ONESHOT-BACKENDS.md`.

### API

```cpp
SMTLIBSolver(SMTLIBOneShotTag, FormulaPath, ShellCmd,
             ModelArgv = {}, PgidCallback OnSpawn = {}, TupleMode = Native);
std::optional<checkResult> parseOneShotVerdictLine(const std::string &);  // public: ESBMC unit-tests it
oneShotModelVerdict() / oneShotModelSolverLive() / oneShotDiagnostics()
```

### Semantics (all ported line-for-line from the ESBMC original)

- `%f` in the command template → shell-quoted formula path (POSIX `'\''` escaping), every occurrence replaced, appended when absent. The command runs via `$SHELL -c` (or `sh`) — the one deliberate exception to this backend's no-shell rule, documented as a trust boundary.
- Strict per-line verdict scanner: exact-match `sat`/`unsat`/`unknown` and `s SATISFIABLE`/`s UNSATISFIABLE`/`s UNKNOWN` after trimming, everything else rejected (no substring matching — "unsat core" in a log line is not a verdict). **The last verdict wins.**
- A verdict from a signal-killed command is discarded — a truncated run must not become a verification verdict. Non-zero exit codes stay accepted (SAT-competition solvers exit 10/20).
- No verdict → UNKNOWN, with the substituted command, decoded exit status, and a ≤20-line output tail retrievable via `oneShotDiagnostics()`. Camada reports facts; presentation (logging, verbosity) stays in the caller.
- **Parallel model solver**: when `ModelArgv` is set, the same script streams to an interactive solver (execvp, no shell) that starts solving at `check()` and serves `get-value` after a sat verdict. Its own verdict is exposed via `oneShotModelVerdict()` — Camada never aborts on divergence, since the "refusing to build a counterexample from a diverging model" message is ESBMC's own regression-tested, per-backend contract. A model solver that dies at startup, mid-preamble, or mid-solve is dropped and the run continues file-only.
- **Pgid callback at spawn time**: the command runs in its own process group and `OnSpawn(pgid)` fires immediately after both `setpgid` calls, before any reads — ESBMC registers the group for its `_exit()`-path teardown (timeout/SIGINT), which library destructors cannot cover; without it a timed-out run orphans a live Mallob/mpirun subtree.
- **Single query enforced** through both `check()` and `checkSatAssuming` (the latter routes through the common-layer push/assert/check/pop fallback so assumptions land in the formula file).

## Test plan

Full suite passes 211/211 (205 + 6 new one-shot test cases, 100 assertions):
- The verdict-scanner contract replicated verbatim from ESBMC's `unit/solvers/oneshot_verdict.test.cpp` (14 cases).
- End-to-end sat with a real z3 model solver: parallel solving, model served, pgid delivered, formula file complete, second check aborts.
- Verdict handling: last-wins, SAT-competition style, no-verdict diagnostics (command/exit code/tail), signal-discard.
- `%f` substitution: multiple occurrences, append-when-absent, paths containing spaces and quotes.
- Diverging model solver returns both verdicts without aborting; dying model solvers (at startup and mid-`set-logic`-negotiation) degrade to file-only.
- `checkSatAssuming` routes through the one-shot flow (both found by the review pass, with regression tests).

Next steps (ESBMC repo, per the port doc): substitute the plain `smtlib` backend, re-parent `bitwuzllob` and `neurosym`, delete `src/solvers/smtlib/` — each verifiable against the 35-test baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)