### PR TITLE
Add a caller-chosen logic to the SMT-LIB backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,11 @@ answer),
 the scope caveat above), `(set-info :status unknown)`, and
 `(set-logic ALL)` (with one fallback attempt at `QF_AUFBV` for children
 that only accept concrete logic names) at startup, so any solver that
-honors the SMT-LIB option contract should work. Other solvers should be
+honors the SMT-LIB option contract should work. Every `SMTLIBSolver`
+constructor also accepts an optional `Logic` string: when non-empty it is
+emitted verbatim in place of `ALL`, with no negotiation — a child that
+rejects a caller-chosen logic is a fatal error rather than a silent
+downgrade. The choice survives `reset()`. Other solvers should be
 straightforward to plug in via the `createSMTLIBSolver(argv)` factory.
 
 Caveats:

--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -673,3 +673,108 @@ TEST_CASE("SMTLIB one-shot assumption checks and mid-negotiation death",
     std::remove(DyingModel.c_str());
   }
 }
+
+TEST_CASE("SMTLIB caller-chosen logic", "[SMTLIB][logic]") {
+  // Write-only: a non-empty Logic is emitted verbatim in place of ALL.
+  {
+    std::string Path = makeTempPath();
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        Path, camada::TupleEncoding::Native, "QF_BV");
+    solver->addConstraint(solver->mkBool(true));
+    (void)solver->check();
+    solver.reset();
+    std::string Written = readFile(Path);
+    REQUIRE(Written.find("(set-logic QF_BV)") != std::string::npos);
+    REQUIRE(Written.find("(set-logic ALL)") == std::string::npos);
+    std::remove(Path.c_str());
+  }
+  // Empty Logic keeps today's behaviour.
+  {
+    std::string Path = makeTempPath();
+    auto solver = std::make_unique<camada::SMTLIBSolver>(Path);
+    solver->addConstraint(solver->mkBool(true));
+    (void)solver->check();
+    solver.reset();
+    REQUIRE(readFile(Path).find("(set-logic ALL)") != std::string::npos);
+    std::remove(Path.c_str());
+  }
+  // One-shot: the formula file carries the caller's logic.
+  {
+    std::string Formula = makeTempPath();
+    std::string Script = makeScript("echo sat\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f",
+        std::vector<std::string>{}, camada::PgidCallback{},
+        camada::TupleEncoding::Native, "QF_BV");
+    solver->addConstraint(solver->mkBool(true));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(readFile(Formula).find("(set-logic QF_BV)") != std::string::npos);
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+  }
+  // One-shot with an override AND a model child that dies right before the
+  // set-logic read: the override branch must drop the child and still write
+  // the caller's logic to the formula file, not abort.
+  {
+    std::string Formula = makeTempPath();
+    std::string Script = makeScript("echo sat\n");
+    // Ack the five preamble reads before set-logic, then exit.
+    std::string DyingModel = makeScript("echo success\n"
+                                        "echo success\n"
+                                        "echo success\n"
+                                        "echo success\n"
+                                        "echo success\n");
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Script + " %f",
+        std::vector<std::string>{DyingModel}, camada::PgidCallback{},
+        camada::TupleEncoding::Native, "QF_BV");
+    REQUIRE_FALSE(solver->oneShotModelSolverLive());
+    solver->addConstraint(solver->mkBool(true));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(readFile(Formula).find("(set-logic QF_BV)") != std::string::npos);
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Script.c_str());
+    std::remove(DyingModel.c_str());
+  }
+}
+
+TEST_CASE("SMTLIB caller-chosen logic against a child", "[SMTLIB][logic]") {
+  auto ModelArgv = z3ModelArgv();
+  if (ModelArgv.empty())
+    SKIP("no staged z3 binary");
+
+  // An accepted explicit logic solves normally, and the tee file mirrors
+  // it — including after reset(), which re-runs the preamble from the
+  // stored member.
+  {
+    std::string Path = makeTempPath();
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBProcessTag{}, ModelArgv, Path,
+        camada::TupleEncoding::Native, "QF_AUFBV");
+    auto X = solver->mkSymbol("x", solver->mkBVSort(8));
+    solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(7, 8)));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    solver->reset();
+    auto Y = solver->mkSymbol("y", solver->mkBVSort(8));
+    solver->addConstraint(solver->mkEqual(Y, solver->mkBVFromDec(9, 8)));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    solver.reset();
+    std::string Written = readFile(Path);
+    REQUIRE(Written.find("(set-logic QF_AUFBV)") != std::string::npos);
+    REQUIRE(Written.find("(set-logic ALL)") == std::string::npos);
+    // Both preambles (construction and reset) carried the override.
+    auto First = Written.find("(set-logic QF_AUFBV)");
+    REQUIRE(Written.find("(set-logic QF_AUFBV)", First + 1) !=
+            std::string::npos);
+    std::remove(Path.c_str());
+  }
+  // A rejected explicit logic is a fatal error, not a silent downgrade.
+  requireAborts([&]() {
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBProcessTag{}, ModelArgv, camada::TupleEncoding::Native,
+        "NOT_A_LOGIC");
+    (void)solver->check();
+  });
+}

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -680,16 +680,18 @@ const std::string &textOf(const SMTSortRef &S) {
 } // namespace
 
 SMTLIBSolver::SMTLIBSolver(const std::string &OutputPath,
-                           TupleEncoding TupleMode)
-    : File(std::make_unique<FileEmitter>(OutputPath)), TupleMode(TupleMode) {
+                           TupleEncoding TupleMode, const std::string &Logic)
+    : File(std::make_unique<FileEmitter>(OutputPath)), TupleMode(TupleMode),
+      LogicOverride(Logic) {
   emitPreamble();
   initializeCommonSingletons();
 }
 
 SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
                            const std::vector<std::string> &Argv,
-                           TupleEncoding TupleMode)
-    : Proc(std::make_unique<ProcessEmitter>(Argv)), TupleMode(TupleMode) {
+                           TupleEncoding TupleMode, const std::string &Logic)
+    : Proc(std::make_unique<ProcessEmitter>(Argv)), TupleMode(TupleMode),
+      LogicOverride(Logic) {
   emitPreamble();
   initializeCommonSingletons();
 }
@@ -697,9 +699,10 @@ SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
 SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
                            const std::vector<std::string> &Argv,
                            const std::string &OutputPath,
-                           TupleEncoding TupleMode)
+                           TupleEncoding TupleMode, const std::string &Logic)
     : File(std::make_unique<FileEmitter>(OutputPath)),
-      Proc(std::make_unique<ProcessEmitter>(Argv)), TupleMode(TupleMode) {
+      Proc(std::make_unique<ProcessEmitter>(Argv)), TupleMode(TupleMode),
+      LogicOverride(Logic) {
   emitPreamble();
   initializeCommonSingletons();
 }
@@ -707,13 +710,14 @@ SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
 SMTLIBSolver::SMTLIBSolver(SMTLIBOneShotTag, const std::string &FormulaPath,
                            const std::string &ShellCmd,
                            const std::vector<std::string> &ModelArgv,
-                           PgidCallback OnSpawn, TupleEncoding TupleMode)
+                           PgidCallback OnSpawn, TupleEncoding TupleMode,
+                           const std::string &Logic)
     : OneShotMode(true), OneShotFormulaPath(FormulaPath),
       OneShotShellCmd(ShellCmd), OneShotOnSpawn(std::move(OnSpawn)),
       File(std::make_unique<FileEmitter>(FormulaPath)),
       Proc(ModelArgv.empty() ? nullptr
                              : std::make_unique<ProcessEmitter>(ModelArgv)),
-      TupleMode(TupleMode) {
+      TupleMode(TupleMode), LogicOverride(Logic) {
   emitPreamble();
   initializeCommonSingletons();
 }
@@ -944,7 +948,26 @@ void SMTLIBSolver::emitPreamble() {
   // Children that only accept concrete logic names get one fallback attempt
   // with QF_AUFBV, the broadest quantifier-free fragment such children
   // implement. The tee file records whichever logic the child accepted.
-  if (Proc) {
+  if (Proc && !LogicOverride.empty()) {
+    // Caller-chosen logic: emitted verbatim, no negotiation. The caller is
+    // asserting it knows what the child accepts, so a rejection is a fatal
+    // error rather than a silent downgrade (a one-shot model child that
+    // died gets the usual drop-and-continue treatment instead).
+    Proc->emitRaw("(set-logic " + LogicOverride + ")\n");
+    Proc->flush();
+    const std::string Resp = Proc->readResponse();
+    if (OneShotMode && Resp.empty()) {
+      Proc.reset();
+    } else {
+      fatalErrorIf(Resp != "success",
+                   ("SMTLIBSolver: child solver rejected the caller-chosen "
+                    "(set-logic " +
+                    LogicOverride + "): " + Resp)
+                       .c_str());
+    }
+    if (File)
+      File->emitRaw("(set-logic " + LogicOverride + ")\n");
+  } else if (Proc) {
     std::string Logic = "ALL";
     Proc->emitRaw("(set-logic ALL)\n");
     Proc->flush();
@@ -981,7 +1004,9 @@ void SMTLIBSolver::emitPreamble() {
     if (File)
       File->emitRaw("(set-logic " + Logic + ")\n");
   } else if (File) {
-    File->emitRaw("(set-logic ALL)\n");
+    File->emitRaw("(set-logic " +
+                  (LogicOverride.empty() ? std::string("ALL") : LogicOverride) +
+                  ")\n");
   }
 }
 

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -209,8 +209,15 @@ public:
   /// Pass "-" for stdout. check() returns UNKNOWN; get* queries error.
   /// `TupleMode` selects how tuples are lowered on the wire — see the
   /// docstring on TupleEncoding.
+  /// `Logic` (all four constructors) overrides the emitted
+  /// `(set-logic ...)`. Empty (the default) keeps the built-in behaviour:
+  /// `ALL`, with a one-shot `QF_AUFBV` retry for interactive children that
+  /// reject it. A non-empty value is emitted verbatim and no negotiation is
+  /// attempted — the caller is asserting it knows what the child accepts,
+  /// and a child that rejects it is a fatal error, not a retry.
   explicit SMTLIBSolver(const std::string &OutputPath,
-                        TupleEncoding TupleMode = TupleEncoding::Native);
+                        TupleEncoding TupleMode = TupleEncoding::Native,
+                        const std::string &Logic = "");
 
   /// Interactive constructor: spawn a child solver via
   /// `execvp(Argv[0], Argv)`. The solver must speak standard SMT-LIB on
@@ -219,14 +226,16 @@ public:
   /// verbatim, so spaces, quotes, and other metacharacters in any entry
   /// carry no special meaning.
   SMTLIBSolver(SMTLIBProcessTag, const std::vector<std::string> &Argv,
-               TupleEncoding TupleMode = TupleEncoding::Native);
+               TupleEncoding TupleMode = TupleEncoding::Native,
+               const std::string &Logic = "");
 
   /// Combined constructor: spawn a child solver via execvp *and* log the
   /// script to a file. Useful when you want both an interactive answer
   /// and a reproducer to hand to another tool.
   SMTLIBSolver(SMTLIBProcessTag, const std::vector<std::string> &Argv,
                const std::string &OutputPath,
-               TupleEncoding TupleMode = TupleEncoding::Native);
+               TupleEncoding TupleMode = TupleEncoding::Native,
+               const std::string &Logic = "");
 
   /// One-shot constructor: serialize the script (including `(check-sat)`)
   /// to FormulaPath, then run ShellCmd on it **via a shell** — every `%f`
@@ -255,7 +264,8 @@ public:
                const std::string &ShellCmd,
                const std::vector<std::string> &ModelArgv = {},
                PgidCallback OnSpawn = {},
-               TupleEncoding TupleMode = TupleEncoding::Native);
+               TupleEncoding TupleMode = TupleEncoding::Native,
+               const std::string &Logic = "");
 
   /// One-shot mode: the model solver's own answer to the shared query,
   /// read only after a sat verdict from the one-shot run. Unset when no
@@ -523,6 +533,12 @@ private:
   // wire; Camada decomposes tuples into per-field BV/Bool symbols before
   // anything reaches the wire. Default is Native.
   TupleEncoding TupleMode = TupleEncoding::Native;
+
+  // Caller-chosen (set-logic ...) override; empty selects the built-in
+  // ALL-with-QF_AUFBV-fallback behaviour. A member (not a constructor
+  // local) because resetImpl() re-runs emitPreamble() and must re-emit
+  // the same logic.
+  std::string LogicOverride;
 
   // Counter for fresh symbols introduced by mkIEEEFPToBVImpl. SMT-LIB has no
   // portable fp→bv same-encoding op, so we materialize a fresh BV symbol


### PR DESCRIPTION
## Summary

Implements ESBMC's `CAMADA-LOGIC-PARAMETER.md` request: `SMTLIBSolver` chose the SMT-LIB logic itself with no override, which blocked porting ESBMC's SMT-LIB-family backends — ESBMC derives the logic from its encoding options (`pick_logic`: int mode → `[QF_]AUFLIRA`, bit-blasted floats → `[QF_]AUFBV`, native FP → `[QF_]AUFBVFP`), NeuroSym natively parses only QF_BV/QF_LIA and rejects `ALL` outright, and five CORE regression tests grep the emitted `(set-logic ...)` line verbatim (two of them on the default path with no solver flag at all).

## Design

All four constructors (write-only, interactive, combined, one-shot) take a defaulted trailing `const std::string &Logic = ""`:

- **Empty (default)**: existing behavior byte for byte — `(set-logic ALL)` with the one-shot `QF_AUFBV` retry for interactive children that reject it, plain `ALL` in write-only mode. No emitted-output change for any current caller.
- **Non-empty**: emitted verbatim, **no negotiation**. The caller is asserting it knows what the child accepts, so a child rejecting the chosen logic is a `fatalError` carrying the child's response — a caller passing `QF_BV` for NeuroSym must not be silently downgraded. Per the request doc's validation note.
- **Survives `reset()`**: stored as a member (`LogicOverride`), re-emitted by every `emitPreamble()` run, since `resetImpl()` replays the preamble.
- **One-shot interplay**: a model child that dies at the set-logic read gets the established drop-and-continue treatment in the override branch too, and the formula file still carries the caller's logic.

This brings the SMT-LIB backend in line with the MathSAT and Yices backends, which ESBMC already constructs with a `pick_logic`-chosen logic string.

## Test plan

Full suite passes 213/213 (211 + 2 new test cases, 36 assertions): verbatim emission in write-only mode with `ALL` absent; empty-Logic behavior unchanged; the one-shot formula file carrying the override; an accepted override solving against a real z3 child with the tee file showing the logic **twice** (construction + post-`reset()` preamble); a rejected override aborting rather than downgrading; and the one-shot dead-model-child sub-path inside the override branch (a review-pass coverage catch). Emission is a raw `"(set-logic " + Logic + ")\n"` write, matching ESBMC's anchored `^\(set-logic QF_BV\)$` greps.

ESBMC-side verification once picked up: the 5 logic-pinning tests plus the 35-test SMT-LIB family baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)