### PR TITLE
Key CI dependency caches on CamadaDependencies.cmake hash

### DIFF
--- a/.github/workflows/benchmark-master.yml
+++ b/.github/workflows/benchmark-master.yml
@@ -27,13 +27,13 @@ jobs:
             schedtool
 
       - name: Cache deps
-        id: cache-deps-bench-v3
+        id: cache-deps-bench
         uses: actions/cache@v4
         with:
           path: |
             build/deps
             build/_deps
-          key: ${{ runner.os }}-bench-deps-v3
+          key: ${{ runner.os }}-bench-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
 
       - name: Configure Camada
         run: >

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -37,13 +37,13 @@ jobs:
             schedtool
 
       - name: Cache deps
-        id: cache-deps-bench-v3
+        id: cache-deps-bench
         uses: actions/cache@v4
         with:
           path: |
             build/deps
             build/_deps
-          key: ${{ runner.os }}-bench-deps-v3
+          key: ${{ runner.os }}-bench-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
 
       - name: Download latest master baseline
         id: download-master-baseline

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,13 +19,13 @@ jobs:
 
       # Setup/cache dependencies
     - name: Cache deps
-      id: cache-deps-v9
+      id: cache-deps
       uses: actions/cache@v4
       with:
         path: |
           build/deps
           build/_deps
-        key: ${{ runner.os }}-deps-v9
+        key: ${{ runner.os }}-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
 
     - name: Configure Camada
       run: cmake -S . -B build -GNinja -DCAMADA_ENABLE_REGRESSION=ON -DBUILD_SHARED_LIBS=OFF -DCAMADA_DOWNLOAD_DEPENDENCIES=ALL -DCAMADA_SOLVER_BITWUZLA_ENABLE=ON -DCAMADA_SOLVER_CVC5_ENABLE=ON -DCAMADA_SOLVER_MATHSAT_ENABLE=ON -DCAMADA_SOLVER_STP_ENABLE=ON -DCAMADA_SOLVER_YICES_ENABLE=ON -DCAMADA_SOLVER_Z3_ENABLE=ON -DENABLE_WARNINGS=ON -DENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/release -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,13 +25,13 @@ jobs:
 
       # Setup/cache dependencies
     - name: Cache deps
-      id: cache-deps-v9
+      id: cache-deps
       uses: actions/cache@v4
       with:
         path: |
           build/deps
           build/_deps
-        key: ${{ runner.os }}-deps-v9
+        key: ${{ runner.os }}-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
 
     - name: Configure Camada
       run: cmake -S . -B build -GNinja -DCAMADA_ENABLE_REGRESSION=ON -DBUILD_SHARED_LIBS=OFF -DCAMADA_DOWNLOAD_DEPENDENCIES=ALL -DCAMADA_SOLVER_BITWUZLA_ENABLE=ON -DCAMADA_SOLVER_CVC5_ENABLE=ON -DCAMADA_SOLVER_MATHSAT_ENABLE=ON -DCAMADA_SOLVER_STP_ENABLE=ON -DCAMADA_SOLVER_YICES_ENABLE=ON -DCAMADA_SOLVER_Z3_ENABLE=ON -DENABLE_WARNINGS=ON -DENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/release -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,13 +24,13 @@ jobs:
 
       # Setup/cache dependencies
     - name: Cache deps
-      id: cache-deps-v9
+      id: cache-deps
       uses: actions/cache@v4
       with:
         path: |
           build/deps
           build/_deps
-        key: ${{ runner.os }}-deps-v9
+        key: ${{ runner.os }}-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
 
     - name: Configure Camada
       shell: pwsh


### PR DESCRIPTION
## Problem

All five workflows cache `build/deps` + `build/_deps` under a **static** key (`deps-v9`, `bench-deps-v3`), and `actions/cache` only saves when the primary key misses. So the cache content is frozen at whenever the key was first saved (July 30, the STP 2.4.0 era). Two failure modes since the STP 2.4.1 bump (#107):

- **macOS**: the restored install fails the STP staleness guard, so every run rebuilds the full CMS + cadical + cadiback + STP chain from source — and then discards it (`Cache hit occurred on the primary key macOS-deps-v9, not saving cache`).
- **Linux**: the restored install *passes* the guard (it can distinguish 2.3.x from 2.4.x via `libabc-pic.a`, but not 2.4.0 from 2.4.1), so CI has silently kept testing STP **2.4.0** since the bump.

## Fix

Key the cache on `hashFiles('scripts/cmake/CamadaDependencies.cmake')`. Any dependency change produces a new key → one cold full rebuild → the result is saved → later runs hit it exactly. No manual `v9`→`v10` bumps to remember.

Deliberately **no `restore-keys`**: a prefix fallback would restore the old deps on a bump, and most setup guards are existence-only (`z3.h` exists, `STPConfig.cmake` exists), so the old solver version would be silently reused — exactly the Linux failure above. A cold rebuild per dependency change is the same cost as the manual key bump, applied automatically.

First run of each workflow after merge misses the new key and does a full rebuild; that run also heals the stale-STP Linux cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3