### PR TITLE
Add an opt-in Ackermann array encoding (ArrayEncoding::Ackermann)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Current encoded/common-layer features:
 - fixed-point arithmetic (TR 18037-shaped: values plus undefined-behavior
   predicates for overflow and division by zero), encoded over bit-vectors
   in the common layer, so it works on every backend
-- an opt-in Ackermann array encoding (`ArrayEncoding::Ackermann` on
-  `createZ3Solver` and `createSMTLIBSolver`): arrays never reach the
+- an opt-in Ackermann array encoding (`ArrayEncoding::Ackermann`, accepted
+  by every `create*Solver()` factory): arrays never reach the
   backend — every select becomes a fresh element variable tied by
   congruence axioms, stores/ites are lowered structurally, and equality
   uses a witness-index encoding. Quantifier-free formulas only; the mode

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Current encoded/common-layer features:
 - fixed-point arithmetic (TR 18037-shaped: values plus undefined-behavior
   predicates for overflow and division by zero), encoded over bit-vectors
   in the common layer, so it works on every backend
+- an opt-in Ackermann array encoding (`ArrayEncoding::Ackermann` on
+  `createZ3Solver` and `createSMTLIBSolver`): arrays never reach the
+  backend — every select becomes a fresh element variable tied by
+  congruence axioms, stores/ites are lowered structurally, and equality
+  uses a witness-index encoding. Quantifier-free formulas only; the mode
+  forces the Camada tuple encoding, and rejects nested arrays and
+  array-sorted UF signatures. Useful where a backend's array decision
+  procedure is the bottleneck
 
 ## What Camada Is
 

--- a/regression/ackarray.test.h
+++ b/regression/ackarray.test.h
@@ -1,0 +1,272 @@
+#ifndef CAMADA_REGRESSION_ACKARRAY_TEST_H_
+#define CAMADA_REGRESSION_ACKARRAY_TEST_H_
+
+// Fixtures for the Ackermann array encoding (ArrayEncoding::Ackermann).
+// Every fixture expects a solver created WITH the Ackermann mode; each
+// one pins down a bug class found in the original prototype (constant-
+// index reads bypassing congruence, equality frozen at construction, no
+// disequality witness, model poisoning, name aliasing) plus the basic
+// select/store/const/ite semantics and model queries.
+
+#include "camada.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+// Prototype bug 1: a select at a BV-constant index and a select at a
+// symbolic index equal to it must alias.
+inline void ack_read_congruence(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto a = solver->mkSymbol("a", solver->mkArraySort(idxsort, elemsort));
+  auto i = solver->mkSymbol("i", idxsort);
+  auto c3 = solver->mkBVFromDec(3, 8);
+
+  solver->addConstraint(solver->mkEqual(i, c3));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(
+      solver->mkArraySelect(a, i), solver->mkArraySelect(a, c3))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Distinct index terms are free to hold different values — and forced
+// together the moment the indexes are equated.
+inline void ack_distinct_index_reads(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto a = solver->mkSymbol("a", solver->mkArraySort(idxsort, elemsort));
+  auto i = solver->mkSymbol("i", idxsort);
+  auto j = solver->mkSymbol("j", idxsort);
+
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(a, i), solver->mkBVFromDec(1, 8)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(a, j), solver->mkBVFromDec(2, 8)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  solver->push();
+  solver->addConstraint(solver->mkEqual(i, j));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  solver->pop();
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
+// Store/select semantics: a store is visible at its own index and
+// transparent at every other.
+inline void ack_store_select_semantics(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto a = solver->mkSymbol("a", solver->mkArraySort(idxsort, elemsort));
+  auto i = solver->mkSymbol("i", idxsort);
+  auto j = solver->mkSymbol("j", idxsort);
+  auto v = solver->mkBVFromDec(42, 8);
+  auto b = solver->mkArrayStore(a, i, v);
+
+  solver->push();
+  solver->addConstraint(
+      solver->mkNot(solver->mkEqual(solver->mkArraySelect(b, i), v)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  solver->pop();
+
+  solver->push();
+  solver->addConstraint(solver->mkNot(solver->mkEqual(i, j)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(
+      solver->mkArraySelect(b, j), solver->mkArraySelect(a, j))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  solver->pop();
+}
+
+// Prototype bug 2: an equality asserted before any reads exist must
+// still constrain reads created afterwards.
+inline void ack_equality_before_reads(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto arrsort = solver->mkArraySort(idxsort, elemsort);
+  auto a = solver->mkSymbol("a", arrsort);
+  auto b = solver->mkSymbol("b", arrsort);
+
+  solver->addConstraint(solver->mkEqual(a, b));
+  // Reads arrive only now.
+  auto k = solver->mkSymbol("k", idxsort);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(
+      solver->mkArraySelect(a, k), solver->mkArraySelect(b, k))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Prototype bug 3: `a != b` with no other constraints must be
+// satisfiable — a difference must be exhibitable at some index.
+inline void ack_disequality_witness(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto arrsort = solver->mkArraySort(idxsort, elemsort);
+  auto a = solver->mkSymbol("a", arrsort);
+  auto b = solver->mkSymbol("b", arrsort);
+
+  solver->addConstraint(solver->mkNot(solver->mkEqual(a, b)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
+// Prototype bug 7: equality over ite-arrays must decide the condition,
+// not compare both branches blindly.
+inline void ack_ite_array_semantics(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto a = solver->mkSymbol("a", solver->mkArraySort(idxsort, elemsort));
+  auto c = solver->mkSymbol("c", solver->mkBoolSort());
+  auto i = solver->mkBVFromDec(7, 8);
+  auto one = solver->mkBVFromDec(1, 8);
+  auto two = solver->mkBVFromDec(2, 8);
+  auto x = solver->mkIte(c, solver->mkArrayStore(a, i, one),
+                         solver->mkArrayStore(a, i, two));
+
+  solver->push();
+  solver->addConstraint(solver->mkEqual(solver->mkArraySelect(x, i), one));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  auto cval = solver->getBool(c);
+  REQUIRE(cval);
+  REQUIRE(cval.value());
+  solver->pop();
+
+  solver->addConstraint(solver->mkNot(c));
+  solver->addConstraint(solver->mkEqual(solver->mkArraySelect(x, i), one));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Prototype bug 5: model queries must not poison the assertion set — a
+// re-check after getArrayElement calls returns the same verdict.
+inline void ack_model_query_stability(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto a = solver->mkSymbol("a", solver->mkArraySort(idxsort, elemsort));
+  auto v = solver->mkBVFromDec(9, 8);
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(a, solver->mkBVFromDec(1, 8)), v));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // Constrained index: exact value. Unconstrained index: some stable
+  // value, the same on a repeated query against the same model.
+  auto at1 = solver->getArrayElement(a, solver->mkBVFromDec(1, 8));
+  auto at1val = solver->getBVInBin(at1);
+  REQUIRE(at1val);
+  REQUIRE(at1val.value() == "00001001");
+  auto at5a = solver->getArrayElement(a, solver->mkBVFromDec(5, 8));
+  auto at5b = solver->getArrayElement(a, solver->mkBVFromDec(5, 8));
+  auto at5aval = solver->getBVInBin(at5a);
+  auto at5bval = solver->getBVInBin(at5b);
+  REQUIRE(at5aval);
+  REQUIRE(at5bval);
+  REQUIRE(at5aval.value() == at5bval.value());
+
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
+// Prototype bug 6: a user symbol shaped like an internal leaf name must
+// not alias a read (internal reads live in the reserved __CAMADA_ name
+// space, which mkSymbol rejects for users).
+inline void ack_internal_name_no_alias(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto a = solver->mkSymbol("a", solver->mkArraySort(idxsort, elemsort));
+  auto user = solver->mkSymbol("a__at__00000011", elemsort);
+  auto read = solver->mkArraySelect(a, solver->mkBVFromDec(3, 8));
+
+  solver->addConstraint(solver->mkNot(solver->mkEqual(user, read)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
+// Constant arrays: every index reads the initializer; stores layer on
+// top; the ConstArrayLowering argument is moot in this mode but must be
+// accepted.
+inline void ack_const_array_semantics(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto init = solver->mkBVFromDec(5, 8);
+
+  for (auto lowering :
+       {camada::ConstArrayLowering::Auto, camada::ConstArrayLowering::Native,
+        camada::ConstArrayLowering::Lazy}) {
+    solver->push();
+    auto arr = solver->mkArrayConst(idxsort, init, lowering);
+    auto k = solver->mkSymbol("k", idxsort);
+    solver->addConstraint(
+        solver->mkNot(solver->mkEqual(solver->mkArraySelect(arr, k), init)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    solver->pop();
+  }
+
+  auto arr = solver->mkArrayConst(idxsort, init);
+  auto i = solver->mkBVFromDec(2, 8);
+  auto v = solver->mkBVFromDec(7, 8);
+  auto b = solver->mkArrayStore(arr, i, v);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(
+      solver->mkArraySelect(b, solver->mkBVFromDec(4, 8)), init)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// getArrayValues: stored indexes appear with their values; a constant
+// root reports its initializer as the base.
+inline void ack_array_model_values(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto a = solver->mkSymbol("a", solver->mkArraySort(idxsort, elemsort));
+  auto i = solver->mkBVFromDec(3, 8);
+  auto v = solver->mkBVFromDec(42, 8);
+  auto b = solver->mkArrayStore(a, i, v);
+  // Anchor one read on the root so it shows up as an entry too.
+  auto k = solver->mkBVFromDec(1, 8);
+  auto w = solver->mkBVFromDec(9, 8);
+  solver->addConstraint(solver->mkEqual(solver->mkArraySelect(a, k), w));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  auto model = solver->getArrayValues(b);
+  REQUIRE(model);
+  bool sawStore = false, sawRead = false;
+  for (const auto &entry : model.value().Entries) {
+    auto idxval = solver->getBVInBin(entry.first);
+    auto elemval = solver->getBVInBin(entry.second);
+    REQUIRE(idxval);
+    REQUIRE(elemval);
+    if (idxval.value() == "00000011") {
+      REQUIRE(elemval.value() == "00101010");
+      sawStore = true;
+    }
+    if (idxval.value() == "00000001") {
+      REQUIRE(elemval.value() == "00001001");
+      sawRead = true;
+    }
+  }
+  REQUIRE(sawStore);
+  REQUIRE(sawRead);
+  REQUIRE(!model.value().Base);
+
+  auto constArr = solver->mkArrayConst(idxsort, solver->mkBVFromDec(5, 8));
+  auto constModel = solver->getArrayValues(constArr);
+  REQUIRE(constModel);
+  REQUIRE(constModel.value().Base);
+  auto baseval = solver->getBVInBin(constModel.value().Base);
+  REQUIRE(baseval);
+  REQUIRE(baseval.value() == "00000101");
+}
+
+// Everything above, against one solver instance with resets in between —
+// the entry point backends instantiate.
+inline void ack_array_tests(const camada::SMTSolverRef &solver) {
+  ack_read_congruence(solver);
+  solver->reset();
+  ack_distinct_index_reads(solver);
+  solver->reset();
+  ack_store_select_semantics(solver);
+  solver->reset();
+  ack_equality_before_reads(solver);
+  solver->reset();
+  ack_disequality_witness(solver);
+  solver->reset();
+  ack_ite_array_semantics(solver);
+  solver->reset();
+  ack_model_query_stability(solver);
+  solver->reset();
+  ack_internal_name_no_alias(solver);
+  solver->reset();
+  ack_const_array_semantics(solver);
+  solver->reset();
+  ack_array_model_values(solver);
+}
+
+#endif

--- a/regression/ackarray.test.h
+++ b/regression/ackarray.test.h
@@ -245,28 +245,87 @@ inline void ack_array_model_values(const camada::SMTSolverRef &solver) {
   REQUIRE(baseval.value() == "00000101");
 }
 
-// Everything above, against one solver instance with resets in between —
-// the entry point backends instantiate.
-inline void ack_array_tests(const camada::SMTSolverRef &solver) {
+// FP-sorted elements compose: reads are ordinary FP variables and the
+// per-sort model getters evaluate them (BV-encoded FP works on every
+// backend, so that is what this exercises).
+inline void ack_fp_element_semantics(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkFP32Sort(camada::FPEncoding::BV);
+  auto a = solver->mkSymbol("a", solver->mkArraySort(idxsort, elemsort));
+  auto i = solver->mkBVFromDec(3, 8);
+  auto v = solver->mkFP32(1.5f, camada::FPEncoding::BV);
+
+  solver->addConstraint(solver->mkEqual(solver->mkArraySelect(a, i), v));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  auto at3 = solver->getArrayElement(a, solver->mkBVFromDec(3, 8));
+  auto fpval = solver->getFP32(at3);
+  REQUIRE(fpval);
+  REQUIRE(fpval.value() == 1.5f);
+  // Unconstrained index: the synthesized default must evaluate too.
+  auto at9 = solver->getArrayElement(a, solver->mkBVFromDec(9, 8));
+  REQUIRE(solver->getFP32(at9));
+}
+
+// checkSatAssuming over array constraints: congruence axioms are ordinary
+// journaled constraints, so they survive whichever mechanism the backend
+// uses (native assumptions or the push/assert/check/pop fallback).
+inline void ack_check_sat_assuming(const camada::SMTSolverRef &solver) {
+  auto idxsort = solver->mkBVSort(8);
+  auto elemsort = solver->mkBVSort(8);
+  auto a = solver->mkSymbol("a", solver->mkArraySort(idxsort, elemsort));
+  auto i = solver->mkSymbol("i", idxsort);
+  auto j = solver->mkSymbol("j", idxsort);
+
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(a, i), solver->mkBVFromDec(1, 8)));
+  solver->addConstraint(
+      solver->mkEqual(solver->mkArraySelect(a, j), solver->mkBVFromDec(2, 8)));
+  REQUIRE(solver->checkSatAssuming({solver->mkEqual(i, j)}) ==
+          camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->checkSatAssuming({solver->mkNot(solver->mkEqual(i, j))}) ==
+          camada::checkResult::SAT);
+}
+
+// The fixtures that never mint a read variable inside a (push) scope.
+// SMT-LIB children that answer `unsupported` to `:global-declarations
+// true` (stp) forget scoped declarations on (pop), so the journaled
+// congruence re-assert would reference an undeclared symbol — a
+// documented backend limitation (see emitPreamble in smtlibsolver.cpp),
+// not an encoding one. ack_distinct_index_reads and
+// ack_check_sat_assuming do push/pop but create all reads at the outer
+// level, which is safe.
+inline void ack_array_tests_flat(const camada::SMTSolverRef &solver) {
   ack_read_congruence(solver);
   solver->reset();
   ack_distinct_index_reads(solver);
-  solver->reset();
-  ack_store_select_semantics(solver);
   solver->reset();
   ack_equality_before_reads(solver);
   solver->reset();
   ack_disequality_witness(solver);
   solver->reset();
-  ack_ite_array_semantics(solver);
-  solver->reset();
   ack_model_query_stability(solver);
   solver->reset();
   ack_internal_name_no_alias(solver);
   solver->reset();
-  ack_const_array_semantics(solver);
-  solver->reset();
   ack_array_model_values(solver);
+  solver->reset();
+  ack_fp_element_semantics(solver);
+  solver->reset();
+  ack_check_sat_assuming(solver);
+}
+
+// Everything, including fixtures that mint reads inside (push) scopes —
+// the entry point for native backends and children with global
+// declarations.
+inline void ack_array_tests(const camada::SMTSolverRef &solver) {
+  ack_array_tests_flat(solver);
+  solver->reset();
+  ack_store_select_semantics(solver);
+  solver->reset();
+  ack_ite_array_semantics(solver);
+  solver->reset();
+  ack_const_array_semantics(solver);
 }
 
 #endif

--- a/regression/bench/main.cpp
+++ b/regression/bench/main.cpp
@@ -36,10 +36,14 @@ std::size_t readCurrentRSSKiB() {
   return (resident_pages * static_cast<std::size_t>(page_size)) / 1024;
 }
 
+// Array encoding applied to the chosen backend (--ack flag).
+camada::ArrayEncoding arrayMode = camada::ArrayEncoding::Native;
+
 camada::SMTSolverRef createSolver(const std::string &backend) {
   if (backend == "bitwuzla") {
 #if SOLVER_BITWUZLA_ENABLED
-    return camada::createBitwuzlaSolver();
+    return camada::createBitwuzlaSolver(camada::UnsatAssumptionsMode::Off,
+                                        arrayMode);
 #else
     throw std::runtime_error("Bitwuzla backend is not enabled");
 #endif
@@ -47,7 +51,8 @@ camada::SMTSolverRef createSolver(const std::string &backend) {
 
   if (backend == "cvc5") {
 #if SOLVER_CVC5_ENABLED
-    return camada::createCVC5Solver();
+    return camada::createCVC5Solver(camada::UnsatAssumptionsMode::Off,
+                                    arrayMode);
 #else
     throw std::runtime_error("CVC5 backend is not enabled");
 #endif
@@ -55,7 +60,7 @@ camada::SMTSolverRef createSolver(const std::string &backend) {
 
   if (backend == "mathsat") {
 #if SOLVER_MATHSAT_ENABLED
-    return camada::createMathSATSolver();
+    return camada::createMathSATSolver(arrayMode);
 #else
     throw std::runtime_error("MathSAT backend is not enabled");
 #endif
@@ -63,7 +68,7 @@ camada::SMTSolverRef createSolver(const std::string &backend) {
 
   if (backend == "stp") {
 #if SOLVER_STP_ENABLED
-    return camada::createSTPSolver();
+    return camada::createSTPSolver(arrayMode);
 #else
     throw std::runtime_error("STP backend is not enabled");
 #endif
@@ -71,7 +76,7 @@ camada::SMTSolverRef createSolver(const std::string &backend) {
 
   if (backend == "yices") {
 #if SOLVER_YICES_ENABLED
-    return camada::createYicesSolver();
+    return camada::createYicesSolver(arrayMode);
 #else
     throw std::runtime_error("Yices backend is not enabled");
 #endif
@@ -79,15 +84,7 @@ camada::SMTSolverRef createSolver(const std::string &backend) {
 
   if (backend == "z3") {
 #if SOLVER_Z3_ENABLED
-    return camada::createZ3Solver();
-#else
-    throw std::runtime_error("Z3 backend is not enabled");
-#endif
-  }
-
-  if (backend == "z3-ack") {
-#if SOLVER_Z3_ENABLED
-    return camada::createZ3Solver(camada::ArrayEncoding::Ackermann);
+    return camada::createZ3Solver(arrayMode);
 #else
     throw std::runtime_error("Z3 backend is not enabled");
 #endif
@@ -98,7 +95,8 @@ camada::SMTSolverRef createSolver(const std::string &backend) {
     // Write-only mode to /dev/null: measures the text-emission layer without
     // a child solver. The bench cases are construction-only, so the UNKNOWN
     // check() result in this mode is irrelevant.
-    return std::make_unique<camada::SMTLIBSolver>("/dev/null");
+    return std::make_unique<camada::SMTLIBSolver>(
+        "/dev/null", camada::TupleEncoding::Native, "", arrayMode);
 #else
     throw std::runtime_error("SMTLIB backend is not enabled");
 #endif
@@ -510,8 +508,10 @@ void benchmarkResetCycleExprChain(camada::SMTSolver &solver,
 
 void printUsage(const char *argv0) {
   std::fprintf(stderr,
-               "Usage: %s [backend] [iterations] [case-substring]\n"
-               "Backends: bitwuzla cvc5 mathsat stp yices z3 z3-ack smtlib\n",
+               "Usage: %s [--ack] [backend] [iterations] [case-substring]\n"
+               "Backends: bitwuzla cvc5 mathsat stp yices z3 smtlib\n"
+               "  --ack  use the Ackermann array encoding "
+               "(ArrayEncoding::Ackermann)\n",
                argv0);
 }
 
@@ -519,16 +519,25 @@ void printUsage(const char *argv0) {
 
 int main(int argc, char **argv) {
   try {
-    std::string backend = argc > 1 ? argv[1] : defaultBackend();
+    std::vector<std::string> args;
+    for (int i = 1; i < argc; ++i) {
+      if (std::string(argv[i]) == "--ack")
+        arrayMode = camada::ArrayEncoding::Ackermann;
+      else
+        args.emplace_back(argv[i]);
+    }
+
+    std::string backend = !args.empty() ? args[0] : defaultBackend();
     std::size_t iterations =
-        argc > 2 ? static_cast<std::size_t>(std::strtoull(argv[2], nullptr, 10))
-                 : 1000;
+        args.size() > 1 ? static_cast<std::size_t>(
+                              std::strtoull(args[1].c_str(), nullptr, 10))
+                        : 1000;
 
     if (iterations == 0)
       throw std::runtime_error("iterations must be greater than zero");
 
-    if (argc > 3)
-      caseFilter = argv[3];
+    if (args.size() > 2)
+      caseFilter = args[2];
 
     runCase(backend, "bv_sort_same", iterations, benchmarkBVSort);
     runCase(backend, "bv_const_same", iterations, benchmarkBVConstSame);

--- a/regression/bench/main.cpp
+++ b/regression/bench/main.cpp
@@ -85,6 +85,14 @@ camada::SMTSolverRef createSolver(const std::string &backend) {
 #endif
   }
 
+  if (backend == "z3-ack") {
+#if SOLVER_Z3_ENABLED
+    return camada::createZ3Solver(camada::ArrayEncoding::Ackermann);
+#else
+    throw std::runtime_error("Z3 backend is not enabled");
+#endif
+  }
+
   if (backend == "smtlib") {
 #if SOLVER_SMTLIB_ENABLED
     // Write-only mode to /dev/null: measures the text-emission layer without
@@ -238,6 +246,37 @@ void benchmarkArrayStoreChain(camada::SMTSolver &solver,
   auto last_idx = solver.mkBVFromDec(
       static_cast<int64_t>((iterations - 1) & 0xff), idx_sort);
   volatile std::size_t sink = solver.mkArraySelect(array, last_idx)->getWidth();
+  (void)sink;
+}
+
+// Unlike the construction-only cases, this one calls check(): the array
+// encoding trade (native theory vs Ackermann ground constraints) only
+// shows up in solve time. Each cycle builds a small store chain, a few
+// symbolic reads with equalities, solves, and resets.
+void benchmarkArraySolve(camada::SMTSolver &solver, std::size_t iterations) {
+  volatile std::size_t sink = 0;
+
+  for (std::size_t cycle = 0; cycle < iterations; ++cycle) {
+    auto idx_sort = solver.mkBVSort(8);
+    auto elem_sort = solver.mkBVSort(32);
+    auto array =
+        solver.mkSymbol("solve_a", solver.mkArraySort(idx_sort, elem_sort));
+    for (std::size_t i = 0; i < 16; ++i)
+      array = solver.mkArrayStore(
+          array, solver.mkBVFromDec(static_cast<int64_t>(i), idx_sort),
+          solver.mkBVFromDec(static_cast<int64_t>(i * 3), elem_sort));
+
+    for (std::size_t r = 0; r < 4; ++r) {
+      auto k = solver.mkSymbol("solve_k" + std::to_string(r), idx_sort);
+      solver.addConstraint(solver.mkBVUlt(
+          solver.mkArraySelect(array, k),
+          solver.mkBVFromDec(static_cast<int64_t>(40 + r), elem_sort)));
+    }
+
+    sink += solver.check() == camada::checkResult::SAT;
+    solver.reset();
+  }
+
   (void)sink;
 }
 
@@ -472,7 +511,7 @@ void benchmarkResetCycleExprChain(camada::SMTSolver &solver,
 void printUsage(const char *argv0) {
   std::fprintf(stderr,
                "Usage: %s [backend] [iterations] [case-substring]\n"
-               "Backends: bitwuzla cvc5 mathsat stp yices z3 smtlib\n",
+               "Backends: bitwuzla cvc5 mathsat stp yices z3 z3-ack smtlib\n",
                argv0);
 }
 
@@ -498,6 +537,10 @@ int main(int argc, char **argv) {
     runCase(backend, "expr_construction_only", iterations,
             benchmarkExprConstructionOnly);
     runCase(backend, "array_store_chain", iterations, benchmarkArrayStoreChain);
+    // Write-only smtlib never solves; array_solve would just measure text
+    // emission there.
+    if (backend != "smtlib")
+      runCase(backend, "array_solve", iterations, benchmarkArraySolve);
     if (backendSupportsUF(backend))
       runCase(backend, "function_sort_cache_hit", iterations,
               benchmarkFunctionSortCacheHit);

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -9,6 +9,12 @@
 #include <cstring>
 #include <random>
 
+TEST_CASE("Ackermann arrays Bitwuzla test", "[Bitwuzla]") {
+  auto bzla = camada::createBitwuzlaSolver(camada::UnsatAssumptionsMode::Off,
+                                           camada::ArrayEncoding::Ackermann);
+  ack_array_tests(bzla);
+}
+
 TEST_CASE("Simple Bitwuzla test", "[Bitwuzla]") {
   auto bitwuzla = camada::createBitwuzlaSolver();
   tests(bitwuzla);

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -7,6 +7,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cvc5solver.h>
 
+TEST_CASE("Ackermann arrays CVC5 test", "[CVC5]") {
+  auto cvc5 = camada::createCVC5Solver(camada::UnsatAssumptionsMode::Off,
+                                       camada::ArrayEncoding::Ackermann);
+  ack_array_tests(cvc5);
+}
+
 TEST_CASE("Simple CVC5 test", "[CVC5]") {
   // Create CVC5 Solver
   auto cvc5 = camada::createCVC5Solver();

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -8,6 +8,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <mathsatsolver.h>
 
+TEST_CASE("Ackermann arrays MathSAT test", "[MathSAT]") {
+  auto mathsat = camada::createMathSATSolver(camada::ArrayEncoding::Ackermann);
+  ack_array_tests(mathsat);
+}
+
 TEST_CASE("Simple MathSAT test", "[MathSAT]") {
   // Create Mathsat Solver
   auto mathsat = camada::createMathSATSolver();

--- a/regression/smtlib_pipeline.test.h
+++ b/regression/smtlib_pipeline.test.h
@@ -151,6 +151,15 @@ makeSMTLIBSolverCamadaTuples(const std::vector<std::string> &Argv) {
   return camada::createSMTLIBSolver(Argv, camada::TupleEncoding::Camada);
 }
 
+// Same, but arrays use the Ackermann encoding: the wire carries no array
+// sorts or select/store terms at all, only the fresh read variables and
+// their congruence axioms.
+inline camada::SMTSolverRef
+makeSMTLIBSolverAckermannArrays(const std::vector<std::string> &Argv) {
+  return camada::createSMTLIBSolver(Argv, camada::TupleEncoding::Native,
+                                    camada::ArrayEncoding::Ackermann);
+}
+
 // Skip the test if the binary isn't reachable.
 #define CAMADA_SMTLIB_REQUIRE_BINARY(CmdExpr, Name)                            \
   std::vector<std::string> Cmd = (CmdExpr);                                    \

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -116,4 +116,21 @@ CAMADA_STP_SMTLIB_SHARED_TEST("fxp_model_and_constructs",
                               fxp_model_and_constructs(solver))
 
 #undef CAMADA_STP_SMTLIB_SHARED_TEST
+
+// The Ackermann array encoding is aimed exactly at solvers like STP,
+// whose array support is its weakest theory: with it, the wire carries
+// no array sorts or select/store terms at all. checkSatAssuming inside
+// the fixture exercises the push/assert/check/pop fallback (the STP
+// child has no unsat-assumptions support), which replays the journaled
+// congruence axioms. Only the flat driver runs here: stp answers
+// `unsupported` to `:global-declarations true`, so fixtures that mint
+// read variables inside a (push) scope hit the documented
+// scoped-declaration limitation of such children.
+TEST_CASE("SMTLIB pipeline: ack_array_tests_flat [Ackermann] [stp]",
+          "[STP][SMTLIB][pipeline]") {
+  CAMADA_SMTLIB_REQUIRE_BINARY(camada_smtlib_pipeline::stpCommand(), "stp");
+  camada::SMTSolverRef solver =
+      camada_smtlib_pipeline::makeSMTLIBSolverAckermannArrays(Cmd);
+  ack_array_tests_flat(solver);
+}
 #endif

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -7,6 +7,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <stpsolver.h>
 
+TEST_CASE("Ackermann arrays STP test", "[STP]") {
+  auto stp = camada::createSTPSolver(camada::ArrayEncoding::Ackermann);
+  ack_array_tests(stp);
+}
+
 TEST_CASE("Simple STP test", "[STP]") {
   // Create STP Solver
   auto stp = camada::createSTPSolver();

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -1,4 +1,5 @@
 
+#include "ackarray.test.h"
 #include "array.test.h"
 #include "fp.test.h"
 #include "fxp.test.h"

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -7,6 +7,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <yicessolver.h>
 
+TEST_CASE("Ackermann arrays Yices test", "[YICES]") {
+  auto yices = camada::createYicesSolver(camada::ArrayEncoding::Ackermann);
+  ack_array_tests(yices);
+}
+
 TEST_CASE("Simple Yices test", "[YICES]") {
   // Create Yices Solver
   auto yices = camada::createYicesSolver();

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -48,6 +48,15 @@ TEST_CASE("Ackermann arrays Z3 test", "[Z3]") {
   ack_array_tests(z3);
 }
 
+// The full shared fixture suite under the Ackermann encoding — the same
+// coverage the native-array mode gets, so every composition (const
+// arrays, tuples, FP, FXP, push/pop, models) is proven against the
+// encoding, not just the targeted ack_* fixtures.
+TEST_CASE("Ackermann full fixture suite Z3 test", "[Z3]") {
+  auto z3 = camada::createZ3Solver(camada::ArrayEncoding::Ackermann);
+  tests(z3);
+}
+
 TEST_CASE("Ackermann arrays reject quantifiers Z3 test", "[Z3]") {
   auto z3 = camada::createZ3Solver(camada::ArrayEncoding::Ackermann);
   require_abort([&]() {

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -43,6 +43,19 @@ TEST_CASE("Tuple-with-Int Z3 test", "[Z3]") {
   tuple_semantics_with_int(z3);
 }
 
+TEST_CASE("Ackermann arrays Z3 test", "[Z3]") {
+  auto z3 = camada::createZ3Solver(camada::ArrayEncoding::Ackermann);
+  ack_array_tests(z3);
+}
+
+TEST_CASE("Ackermann arrays reject quantifiers Z3 test", "[Z3]") {
+  auto z3 = camada::createZ3Solver(camada::ArrayEncoding::Ackermann);
+  require_abort([&]() {
+    auto x = z3->mkSymbol("x", z3->mkBVSort(4));
+    (void)z3->mkForall({x}, z3->mkEqual(x, x));
+  });
+}
+
 TEST_CASE("Override Z3 Solver", "[Z3]") {
 
   class myZ3Solver : public camada::Z3Solver {
@@ -179,6 +192,12 @@ CAMADA_Z3_SMTLIB_SHARED_TEST("fxp_rounding_semantics",
                              fxp_rounding_semantics(solver), makeSMTLIBSolver)
 CAMADA_Z3_SMTLIB_SHARED_TEST("fxp_model_and_constructs",
                              fxp_model_and_constructs(solver), makeSMTLIBSolver)
+
+// Ackermann array encoding over the pipe: the wire carries no array
+// theory at all — only the read variables and their congruence axioms.
+CAMADA_Z3_SMTLIB_SHARED_TEST("ack_array_tests [Ackermann]",
+                             ack_array_tests(solver),
+                             makeSMTLIBSolverAckermannArrays)
 
 #undef CAMADA_Z3_SMTLIB_SHARED_TEST
 #endif // SOLVER_SMTLIB_ENABLED

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ set(LIBRARY_TARGET_NAME ${PROJECT_NAME})
 # List of CPP (source) library files.
 set(${LIBRARY_TARGET_NAME}_SRC
     camada.cpp
+    camadaarray.cpp
     camadaexpr.cpp
     camadafp.cpp
     camadafxp.cpp

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -121,8 +121,9 @@ void BitwExpr::dump(std::string &Out) const {
   Out = bitwuzla_term_to_string(Expr);
 }
 
-BitwuzlaSolver::BitwuzlaSolver(UnsatAssumptionsMode Mode)
+BitwuzlaSolver::BitwuzlaSolver(UnsatAssumptionsMode Mode, ArrayEncoding Arrays)
     : ProduceUnsatAssumptions(Mode == UnsatAssumptionsMode::On) {
+  ArrayMode = Arrays;
   initializeContext();
   initializeCommonSingletons();
 }

--- a/src/bitwuzlasolver.h
+++ b/src/bitwuzlasolver.h
@@ -66,8 +66,8 @@ public:
 
 class BitwuzlaSolver : public SMTSolverImpl {
 public:
-  explicit BitwuzlaSolver(
-      UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off);
+  explicit BitwuzlaSolver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off,
+                          ArrayEncoding Arrays = ArrayEncoding::Native);
   ~BitwuzlaSolver() override;
 
 protected:

--- a/src/camada.cpp
+++ b/src/camada.cpp
@@ -67,48 +67,55 @@ SMTSolverRef createZ3Solver(ArrayEncoding ArrayMode) {
 #endif
 }
 
-SMTSolverRef createMathSATSolver() {
+SMTSolverRef createMathSATSolver(ArrayEncoding ArrayMode) {
 #if SOLVER_MATHSAT_ENABLED
-  return std::make_unique<MathSATSolver>();
+  return std::make_unique<MathSATSolver>(ArrayMode);
 #else
+  (void)ArrayMode;
   fatalError("Camada was not compiled with MathSAT support, rebuild with "
              "-DCAMADA_ENABLE_SOLVER_MATHSAT=ON");
 #endif
 }
 
-SMTSolverRef createCVC5Solver(UnsatAssumptionsMode Mode) {
+SMTSolverRef createCVC5Solver(UnsatAssumptionsMode Mode,
+                              ArrayEncoding ArrayMode) {
 #if SOLVER_CVC5_ENABLED
-  return std::make_unique<CVC5Solver>(Mode);
+  return std::make_unique<CVC5Solver>(Mode, ArrayMode);
 #else
   (void)Mode;
+  (void)ArrayMode;
   fatalError("Camada was not compiled with CVC5 support, rebuild with "
              "-DCAMADA_ENABLE_SOLVER_CVC5=ON");
 #endif
 }
 
-SMTSolverRef createBitwuzlaSolver(UnsatAssumptionsMode Mode) {
+SMTSolverRef createBitwuzlaSolver(UnsatAssumptionsMode Mode,
+                                  ArrayEncoding ArrayMode) {
 #if SOLVER_BITWUZLA_ENABLED
-  return std::make_unique<BitwuzlaSolver>(Mode);
+  return std::make_unique<BitwuzlaSolver>(Mode, ArrayMode);
 #else
   (void)Mode;
+  (void)ArrayMode;
   fatalError("Camada was not compiled with Bitwuzla support, rebuild with "
              "-DCAMADA_ENABLE_SOLVER_BITWUZLA=ON");
 #endif
 }
 
-SMTSolverRef createYicesSolver() {
+SMTSolverRef createYicesSolver(ArrayEncoding ArrayMode) {
 #if SOLVER_YICES_ENABLED
-  return std::make_unique<YicesSolver>();
+  return std::make_unique<YicesSolver>(ArrayMode);
 #else
+  (void)ArrayMode;
   fatalError("Camada was not compiled with YICES support, rebuild with "
              "-DCAMADA_ENABLE_SOLVER_YICES=ON");
 #endif
 }
 
-SMTSolverRef createSTPSolver() {
+SMTSolverRef createSTPSolver(ArrayEncoding ArrayMode) {
 #if SOLVER_STP_ENABLED
-  return std::make_unique<STPSolver>();
+  return std::make_unique<STPSolver>(ArrayMode);
 #else
+  (void)ArrayMode;
   fatalError("Camada was not compiled with STP support, rebuild with "
              "-DCAMADA_ENABLE_SOLVER_STP=ON");
 #endif

--- a/src/camada.cpp
+++ b/src/camada.cpp
@@ -57,10 +57,11 @@ namespace camada {
 
 std::string getCamadaVersion() { return CAMADA_VERSION; }
 
-SMTSolverRef createZ3Solver() {
+SMTSolverRef createZ3Solver(ArrayEncoding ArrayMode) {
 #if SOLVER_Z3_ENABLED
-  return std::make_unique<Z3Solver>();
+  return std::make_unique<Z3Solver>(ArrayMode);
 #else
+  (void)ArrayMode;
   fatalError("Camada was not compiled with Z3 support, rebuild with "
              "-DCAMADA_ENABLE_SOLVER_Z3=ON");
 #endif
@@ -114,12 +115,15 @@ SMTSolverRef createSTPSolver() {
 }
 
 SMTSolverRef createSMTLIBSolver(const std::vector<std::string> &Argv,
-                                TupleEncoding TupleMode) {
+                                TupleEncoding TupleMode,
+                                ArrayEncoding ArrayMode) {
 #if SOLVER_SMTLIB_ENABLED
-  return std::make_unique<SMTLIBSolver>(SMTLIBProcessTag{}, Argv, TupleMode);
+  return std::make_unique<SMTLIBSolver>(SMTLIBProcessTag{}, Argv, TupleMode, "",
+                                        ArrayMode);
 #else
   (void)Argv;
   (void)TupleMode;
+  (void)ArrayMode;
   fatalError("Camada was not compiled with the SMT-LIB pipeline backend "
              "(unsupported on this platform)");
 #endif
@@ -127,14 +131,16 @@ SMTSolverRef createSMTLIBSolver(const std::vector<std::string> &Argv,
 
 SMTSolverRef createSMTLIBSolver(const std::vector<std::string> &Argv,
                                 const std::string &OutputPath,
-                                TupleEncoding TupleMode) {
+                                TupleEncoding TupleMode,
+                                ArrayEncoding ArrayMode) {
 #if SOLVER_SMTLIB_ENABLED
   return std::make_unique<SMTLIBSolver>(SMTLIBProcessTag{}, Argv, OutputPath,
-                                        TupleMode);
+                                        TupleMode, "", ArrayMode);
 #else
   (void)Argv;
   (void)OutputPath;
   (void)TupleMode;
+  (void)ArrayMode;
   fatalError("Camada was not compiled with the SMT-LIB pipeline backend "
              "(unsupported on this platform)");
 #endif

--- a/src/camada.h
+++ b/src/camada.h
@@ -125,6 +125,23 @@ enum class TupleEncoding { Native, Camada };
 /// and always support core extraction.
 enum class UnsatAssumptionsMode { Off, On };
 
+/// Selects how arrays are encoded, on the backends that accept it.
+///
+/// - Native (default): the backend's theory of arrays, unchanged.
+/// - Ackermann: arrays never reach the backend. Every select becomes a
+///   fresh element variable tied to the array's other reads by congruence
+///   axioms (`i = j => a[i] = a[j]`); stores and ites are lowered
+///   structurally, and array equality uses a witness-index encoding. The
+///   trade: array-theory work moves into the core solver as ground
+///   constraints, quadratic in the number of reads per array.
+///
+/// Restrictions in Ackermann mode: quantifier-free formulas only (any
+/// mkForall/mkExists call is rejected), no nested arrays, no array-sorted
+/// UF arguments/returns, and model queries need bool/BV index sorts. The
+/// mode forces the Camada tuple encoding — a native datatype cannot hold
+/// an array member that has no backend representation.
+enum class ArrayEncoding { Native, Ackermann };
+
 enum class RM {
   ROUND_TO_EVEN = 0,
   ROUND_TO_AWAY = 1,
@@ -1066,8 +1083,10 @@ public:
 /// Unique pointer for SMTSolvers.
 using SMTSolverRef = std::unique_ptr<SMTSolver>;
 
-/// Convenience method to create a Z3Solver object
-SMTSolverRef createZ3Solver();
+/// Convenience method to create a Z3Solver object. `ArrayMode` selects the
+/// array encoding (see ArrayEncoding); the default keeps Z3's native theory
+/// of arrays.
+SMTSolverRef createZ3Solver(ArrayEncoding ArrayMode = ArrayEncoding::Native);
 
 /// Convenience method to create a MathSATSolver object
 SMTSolverRef createMathSATSolver();
@@ -1107,7 +1126,8 @@ SMTSolverRef createSTPSolver();
 /// honors that contract works.
 SMTSolverRef
 createSMTLIBSolver(const std::vector<std::string> &Argv,
-                   TupleEncoding TupleMode = TupleEncoding::Native);
+                   TupleEncoding TupleMode = TupleEncoding::Native,
+                   ArrayEncoding ArrayMode = ArrayEncoding::Native);
 
 /// Same as `createSMTLIBSolver(Argv)` but also tees the emitted SMT-LIB
 /// script to OutputPath (or stdout if OutputPath is "-") for offline
@@ -1115,7 +1135,8 @@ createSMTLIBSolver(const std::vector<std::string> &Argv,
 SMTSolverRef
 createSMTLIBSolver(const std::vector<std::string> &Argv,
                    const std::string &OutputPath,
-                   TupleEncoding TupleMode = TupleEncoding::Native);
+                   TupleEncoding TupleMode = TupleEncoding::Native,
+                   ArrayEncoding ArrayMode = ArrayEncoding::Native);
 
 } // namespace camada
 

--- a/src/camada.h
+++ b/src/camada.h
@@ -1088,24 +1088,33 @@ using SMTSolverRef = std::unique_ptr<SMTSolver>;
 /// of arrays.
 SMTSolverRef createZ3Solver(ArrayEncoding ArrayMode = ArrayEncoding::Native);
 
-/// Convenience method to create a MathSATSolver object
-SMTSolverRef createMathSATSolver();
+/// Convenience method to create a MathSATSolver object. `ArrayMode`
+/// selects the array encoding (see ArrayEncoding).
+SMTSolverRef
+createMathSATSolver(ArrayEncoding ArrayMode = ArrayEncoding::Native);
 
 /// Convenience method to create a CVC5Solver object. Core extraction via
-/// getUnsatAssumptions() is opt-in (see UnsatAssumptionsMode).
+/// getUnsatAssumptions() is opt-in (see UnsatAssumptionsMode); `ArrayMode`
+/// selects the array encoding (see ArrayEncoding).
 SMTSolverRef
-createCVC5Solver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off);
+createCVC5Solver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off,
+                 ArrayEncoding ArrayMode = ArrayEncoding::Native);
 
 /// Convenience method to create a BitwuzlaSolver object. Core extraction
-/// via getUnsatAssumptions() is opt-in (see UnsatAssumptionsMode).
+/// via getUnsatAssumptions() is opt-in (see UnsatAssumptionsMode);
+/// `ArrayMode` selects the array encoding (see ArrayEncoding).
 SMTSolverRef
-createBitwuzlaSolver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off);
+createBitwuzlaSolver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off,
+                     ArrayEncoding ArrayMode = ArrayEncoding::Native);
 
-/// Convenience method to create a YicesSolver object
-SMTSolverRef createYicesSolver();
+/// Convenience method to create a YicesSolver object. `ArrayMode` selects
+/// the array encoding (see ArrayEncoding).
+SMTSolverRef createYicesSolver(ArrayEncoding ArrayMode = ArrayEncoding::Native);
 
-/// Convenience method to create a STPSolver object
-SMTSolverRef createSTPSolver();
+/// Convenience method to create a STPSolver object. `ArrayMode` selects
+/// the array encoding (see ArrayEncoding); Ackermann mode keeps arrays out
+/// of STP entirely, replacing its non-extensional array theory.
+SMTSolverRef createSTPSolver(ArrayEncoding ArrayMode = ArrayEncoding::Native);
 
 /// Create an SMT-LIB-backed solver that drives an external solver process.
 ///

--- a/src/camadaarray.cpp
+++ b/src/camadaarray.cpp
@@ -1,0 +1,531 @@
+/**************************************************************************
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ **************************************************************************/
+
+// Ackermann-style array encoding (ArrayEncoding::Ackermann). Array terms
+// are Camada-owned nodes with no backend representation; every select on
+// a symbol root becomes a fresh element variable (a "read") tied to the
+// root's other reads by pairwise congruence axioms
+//   i = j  =>  r(root, i) = r(root, j)
+// so the theory of arrays never reaches the backend. Stores and ites are
+// lowered structurally at select time; array equality goes through the
+// shared mkEncodedArrayEqual machinery (witness index + observed-index
+// congruence), whose selects re-enter this encoding. Sound and complete
+// for quantifier-free formulas only — see the guards in camadaimpl.cpp.
+
+#include "camadacommon.h"
+#include "camadaimpl.h"
+
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace camada {
+
+namespace {
+
+/// Array sort owned by the Camada layer rather than any backend. Behaves
+/// as a normal array sort through the generic accessors.
+class CamadaAckArraySort : public SMTSort {
+public:
+  CamadaAckArraySort(SMTBackendKind BackendKind, const SMTSortRef &IndexSort,
+                     const SMTSortRef &ElemSort)
+      : SMTSort(SMTSortKind::Array, ArraySortData{IndexSort, ElemSort}),
+        BackendKind(BackendKind) {}
+
+  SMTBackendKind getBackendKind() const override { return BackendKind; }
+
+  unsigned getWidthFromSolver() const override {
+    fatalError("Width query on Camada-managed Ackermann array sort");
+  }
+
+  void dump(std::string &Out) const override {
+    Out = "(CamadaAckArray";
+    std::string SubOut;
+    getIndexSort()->dump(SubOut);
+    if (!SubOut.empty() && SubOut.back() == '\n')
+      SubOut.pop_back();
+    Out += " " + SubOut;
+    getElementSort()->dump(SubOut);
+    if (!SubOut.empty() && SubOut.back() == '\n')
+      SubOut.pop_back();
+    Out += " " + SubOut + ")\n";
+  }
+
+private:
+  SMTBackendKind BackendKind;
+};
+
+/// Array expression owned by the Camada layer. The SMTExpr::Kind
+/// discriminates the four shapes:
+///   - SMTExprKind::Symbol: a root — selects mint per-index reads with
+///     congruence axioms (state lives in SMTSolverImpl::AckArrayRoots)
+///   - SMTExprKind::ArrayConst: selects return the initializer
+///   - SMTExprKind::ArrayStore: selects lower to ite(i = idx, elem, base[i])
+///   - SMTExprKind::Ite: selects distribute over the branches
+class CamadaAckArrayExpr : public SMTExpr {
+public:
+  // Symbol form
+  CamadaAckArrayExpr(SMTExprKind ExprKind, SMTBackendKind BackendKind,
+                     const SMTSortRef &Sort, std::string SymbolName)
+      : SMTExpr(ExprKind, Sort), SymbolName(std::move(SymbolName)),
+        BackendKind(BackendKind) {}
+
+  // Const form
+  CamadaAckArrayExpr(SMTExprKind ExprKind, SMTBackendKind BackendKind,
+                     const SMTSortRef &Sort, SMTExprRef Init)
+      : SMTExpr(ExprKind, Sort), Init(std::move(Init)),
+        BackendKind(BackendKind) {}
+
+  // Store form (ArrayStore: base/index/element) and Ite form (Ite:
+  // cond/true/false) share an arity, so one ctor assigns by kind.
+  CamadaAckArrayExpr(SMTExprKind ExprKind, SMTBackendKind BackendKind,
+                     const SMTSortRef &Sort, SMTExprRef A, SMTExprRef B,
+                     SMTExprRef C)
+      : SMTExpr(ExprKind, Sort), BackendKind(BackendKind) {
+    if (ExprKind == SMTExprKind::ArrayStore) {
+      Base = std::move(A);
+      Index = std::move(B);
+      Element = std::move(C);
+    } else {
+      Cond = std::move(A);
+      TrueArr = std::move(B);
+      FalseArr = std::move(C);
+    }
+  }
+
+  SMTBackendKind getBackendKind() const override { return BackendKind; }
+
+  void dump(std::string &Out) const override {
+    switch (getKind()) {
+    case SMTExprKind::Symbol:
+      Out = "(CamadaAckArraySymbol " + SymbolName + ")\n";
+      return;
+    case SMTExprKind::ArrayConst:
+      Out = "(CamadaAckArrayConst ...)\n";
+      return;
+    case SMTExprKind::ArrayStore:
+      Out = "(CamadaAckArrayStore ...)\n";
+      return;
+    case SMTExprKind::Ite:
+      Out = "(CamadaAckArrayIte ...)\n";
+      return;
+    default:
+      fatalError("Invalid CamadaAckArrayExpr SMTExprKind");
+    }
+  }
+
+  std::string SymbolName;
+  SMTExprRef Init;
+  SMTExprRef Base;
+  SMTExprRef Index;
+  SMTExprRef Element;
+  SMTExprRef Cond;
+  SMTExprRef TrueArr;
+  SMTExprRef FalseArr;
+
+protected:
+  // Structural host-side equality, matching the Camada tuple nodes'
+  // convention. Nothing interns these nodes, so pointer identity is only
+  // syntactic identity — no correctness argument relies on structurally
+  // equal nodes being the same object. SMT-level equality goes through
+  // mkEncodedArrayEqual.
+  bool equal_to(SMTExpr const &Other) const override {
+    if (Sort != Other.Sort || Other.getBackendKind() != getBackendKind() ||
+        getKind() != Other.getKind())
+      return false;
+    auto const &Rhs = static_cast<const CamadaAckArrayExpr &>(Other);
+    switch (getKind()) {
+    case SMTExprKind::Symbol:
+      return SymbolName == Rhs.SymbolName;
+    case SMTExprKind::ArrayConst:
+      return *Init == *Rhs.Init;
+    case SMTExprKind::ArrayStore:
+      return *Base == *Rhs.Base && *Index == *Rhs.Index &&
+             *Element == *Rhs.Element;
+    case SMTExprKind::Ite:
+      return *Cond == *Rhs.Cond && *TrueArr == *Rhs.TrueArr &&
+             *FalseArr == *Rhs.FalseArr;
+    default:
+      return false;
+    }
+  }
+
+private:
+  SMTBackendKind BackendKind;
+};
+
+const CamadaAckArrayExpr *toAckArrayExpr(const SMTExprRef &Exp) {
+  if (!Exp || !Exp->Sort->isArraySort())
+    return nullptr;
+  return dynamic_cast<const CamadaAckArrayExpr *>(Exp.get());
+}
+
+const CamadaAckArrayExpr *requireAckArrayExpr(const SMTExprRef &Exp) {
+  const CamadaAckArrayExpr *AE = toAckArrayExpr(Exp);
+  fatalErrorIf(AE == nullptr,
+               "Native array expression reached the Ackermann array "
+               "encoding; array terms must be built through this solver");
+  return AE;
+}
+
+} // namespace
+
+SMTSortRef SMTSolverImpl::mkAckArraySort(const SMTSortRef &IndexSort,
+                                         const SMTSortRef &ElemSort) {
+  fatalErrorIf(IndexSort->isArraySort(),
+               "Array-sorted indexes are not supported with the Ackermann "
+               "array encoding");
+  fatalErrorIf(ElemSort->isArraySort(),
+               "Nested arrays are not supported with the Ackermann array "
+               "encoding");
+  return makeSortRef(
+      CamadaAckArraySort(IndexSort->getBackendKind(), IndexSort, ElemSort));
+}
+
+SMTExprRef SMTSolverImpl::mkAckArraySymbol(const std::string &Name,
+                                           const SMTSortRef &Sort) {
+  assert(dynamic_cast<const CamadaAckArraySort *>(Sort.get()) != nullptr);
+  return makeExprRef<CamadaAckArrayExpr>(SMTExprKind::Symbol,
+                                         Sort->getBackendKind(), Sort, Name);
+}
+
+SMTExprRef SMTSolverImpl::mkAckArrayStore(const SMTExprRef &Array,
+                                          const SMTExprRef &Index,
+                                          const SMTExprRef &Element) {
+  requireAckArrayExpr(Array);
+  return makeExprRef<CamadaAckArrayExpr>(SMTExprKind::ArrayStore,
+                                         Array->getBackendKind(), Array->Sort,
+                                         Array, Index, Element);
+}
+
+SMTExprRef SMTSolverImpl::mkAckArrayIte(const SMTExprRef &Cond,
+                                        const SMTExprRef &T,
+                                        const SMTExprRef &F) {
+  requireAckArrayExpr(T);
+  requireAckArrayExpr(F);
+  return makeExprRef<CamadaAckArrayExpr>(SMTExprKind::Ite, T->getBackendKind(),
+                                         T->Sort, Cond, T, F);
+}
+
+SMTExprRef SMTSolverImpl::mkAckArrayConst(const SMTSortRef &IndexSort,
+                                          const SMTExprRef &InitValue) {
+  // The public mkArraySort routes back to mkAckArraySort (and caches).
+  SMTSortRef Sort = mkArraySort(IndexSort, InitValue->Sort);
+  return makeExprRef<CamadaAckArrayExpr>(
+      SMTExprKind::ArrayConst, Sort->getBackendKind(), Sort, InitValue);
+}
+
+SMTExprRef SMTSolverImpl::mkAckArraySelect(const SMTExprRef &Array,
+                                           const SMTExprRef &Index) {
+  const CamadaAckArrayExpr *AE = requireAckArrayExpr(Array);
+  switch (AE->getKind()) {
+  case SMTExprKind::ArrayStore:
+    return mkIte(mkEqual(Index, AE->Index), AE->Element,
+                 mkAckArraySelect(AE->Base, Index));
+  case SMTExprKind::Ite:
+    return mkIte(AE->Cond, mkAckArraySelect(AE->TrueArr, Index),
+                 mkAckArraySelect(AE->FalseArr, Index));
+  case SMTExprKind::ArrayConst:
+    return AE->Init;
+  case SMTExprKind::Symbol:
+    break;
+  default:
+    fatalError("Invalid CamadaAckArrayExpr SMTExprKind");
+  }
+
+  // Symbol root: mint (or reuse) the Ackermann read for this index.
+  // BV-constant indexes are canonicalized by value so equal constants
+  // share one read; every other index term keys by object identity —
+  // structurally equal terms built separately get distinct reads, which
+  // is sound (their congruence guard is trivially true) if redundant.
+  AckArrayRootState &Root = AckArrayRoots[&*Array];
+  auto BitsIt = AckBVConstBits.find(&*Index);
+  const bool IndexIsConst = BitsIt != AckBVConstBits.end();
+  if (IndexIsConst) {
+    if (auto It = Root.ReadsByConstBits.find(BitsIt->second);
+        It != Root.ReadsByConstBits.end())
+      return Root.Reads[It->second].Value;
+  } else {
+    if (auto It = Root.ReadsByIndex.find(&*Index);
+        It != Root.ReadsByIndex.end())
+      return Root.Reads[It->second].Value;
+  }
+
+  SMTExprRef Read =
+      mkSymbolUnchecked("__CAMADA_ackread" + std::to_string(AckArrayCounter++),
+                        Array->Sort->getElementSort());
+  // Cache-insert before emitting axioms, and iterate over a copy: the
+  // constraints below go through public wrappers, matching the existing
+  // lazy-machinery discipline against re-entrant construction.
+  const std::size_t Pos = Root.Reads.size();
+  Root.Reads.push_back(
+      AckArrayRead{Index, Read, IndexIsConst,
+                   IndexIsConst ? BitsIt->second : std::string()});
+  if (IndexIsConst)
+    Root.ReadsByConstBits.emplace(BitsIt->second, Pos);
+  else
+    Root.ReadsByIndex.emplace(&*Index, Pos);
+
+  const std::vector<AckArrayRead> Prior(Root.Reads.begin(),
+                                        Root.Reads.end() - 1);
+  for (const AckArrayRead &P : Prior) {
+    // Two distinct BV-constant indexes cannot alias (equal values share
+    // one read by construction), so their congruence axiom is skipped.
+    if (IndexIsConst && P.IndexIsConst)
+      continue;
+    SMTExprRef Constraint =
+        mkImplies(mkEqual(Index, P.Index), mkEqual(Read, P.Value));
+    addConstraint(Constraint);
+    // Congruence is a scope-independent fact; journal it so pop()
+    // re-asserts it at the outer level (see LazyConstraintLevels).
+    LazyConstraintLevels.back().push_back(std::move(Constraint));
+  }
+  return Read;
+}
+
+// --- Model queries -------------------------------------------------------
+//
+// Everything below runs after a SAT check and must not mint reads, emit
+// axioms, or count as formula observations — the model would be
+// invalidated. Resolution canonicalizes indexes by model value
+// (lazyIndexModelBits), walks store/ite chains under the model, and at
+// symbol roots consults the reads of the whole equality class: roots
+// connected by an ArrayEqualLink whose EqVar is true in the model must
+// answer consistently.
+
+struct AckClassWalk {
+  // Terminal symbol roots reached by any chain in the class.
+  std::vector<const SMTExpr *> Roots;
+  // First constant-root initializer reached, if any.
+  SMTExprRef ConstInit;
+  // Value found at the queried index by a store step, if any.
+  SMTExprRef StoreHit;
+  // Store entries seen along the walked chains, outermost first per
+  // chain, deduped by index model value (for getArrayValues).
+  std::vector<std::pair<SMTExprRef, SMTExprRef>> StoreEntries;
+  std::set<std::string> SeenStoreBits;
+  bool Failed = false;
+};
+
+// Walk one chain to its terminal under the current model, recording store
+// entries. QueryBits is empty for getArrayValues-style walks (collect
+// everything) and non-empty for point queries (stop at a store hit).
+void SMTSolverImpl::ackWalkChain(const SMTExpr *Node,
+                                 const std::string &QueryBits,
+                                 AckClassWalk &Walk) {
+  while (true) {
+    const auto *AE = dynamic_cast<const CamadaAckArrayExpr *>(Node);
+    if (AE == nullptr) {
+      Walk.Failed = true;
+      return;
+    }
+    switch (AE->getKind()) {
+    case SMTExprKind::ArrayStore: {
+      const std::string StepBits = lazyIndexModelBits(AE->Index);
+      if (StepBits.empty()) {
+        Walk.Failed = true;
+        return;
+      }
+      if (!QueryBits.empty() && StepBits == QueryBits && !Walk.StoreHit) {
+        Walk.StoreHit = AE->Element;
+        return;
+      }
+      if (Walk.SeenStoreBits.insert(StepBits).second)
+        Walk.StoreEntries.emplace_back(AE->Index, AE->Element);
+      Node = &*AE->Base;
+      continue;
+    }
+    case SMTExprKind::Ite: {
+      SMTResult<bool> Cond = getBool(AE->Cond);
+      if (!Cond) {
+        Walk.Failed = true;
+        return;
+      }
+      Node = Cond.value() ? &*AE->TrueArr : &*AE->FalseArr;
+      continue;
+    }
+    case SMTExprKind::ArrayConst:
+      if (!Walk.ConstInit)
+        Walk.ConstInit = AE->Init;
+      return;
+    case SMTExprKind::Symbol:
+      Walk.Roots.push_back(Node);
+      return;
+    default:
+      Walk.Failed = true;
+      return;
+    }
+  }
+}
+
+// Expand Walk to the full equality class of the array it started from:
+// every ArrayEqualLink of the same sort whose EqVar is true in the model
+// and whose sides reach a root already in the class pulls both sides'
+// chains in. Iterates to a fixpoint.
+void SMTSolverImpl::ackExpandEqualityClass(const SMTSortRef &ArraySort,
+                                           const std::string &QueryBits,
+                                           AckClassWalk &Walk) {
+  std::set<const SMTExpr *> InClass(Walk.Roots.begin(), Walk.Roots.end());
+  std::set<std::size_t> UsedLinks;
+  bool Changed = true;
+  while (Changed && !Walk.Failed && !Walk.StoreHit) {
+    Changed = false;
+    for (std::size_t LinkId = 0; LinkId < ArrayEqualLinks.size(); ++LinkId) {
+      if (UsedLinks.count(LinkId) != 0)
+        continue;
+      const ArrayEqualLink &Link = ArrayEqualLinks[LinkId];
+      if (Link.LHS->Sort != ArraySort)
+        continue;
+      // Roots of each side under the model, computed with a throwaway
+      // walk so a side's store entries only join the class walk when the
+      // link is actually taken.
+      AckClassWalk L, R;
+      ackWalkChain(&*Link.LHS, std::string(), L);
+      ackWalkChain(&*Link.RHS, std::string(), R);
+      if (L.Failed || R.Failed)
+        continue;
+      const auto Touches = [&InClass](const AckClassWalk &Side) {
+        for (const SMTExpr *Root : Side.Roots)
+          if (InClass.count(Root) != 0)
+            return true;
+        return false;
+      };
+      if (!Touches(L) && !Touches(R))
+        continue;
+      SMTResult<bool> EqVal = getBool(Link.EqVar);
+      if (!EqVal || !EqVal.value()) {
+        UsedLinks.insert(LinkId);
+        continue;
+      }
+      UsedLinks.insert(LinkId);
+      Changed = true;
+      for (const SMTExprRef &Side : {Link.LHS, Link.RHS}) {
+        ackWalkChain(&*Side, QueryBits, Walk);
+        if (Walk.Failed || Walk.StoreHit)
+          return;
+      }
+      for (const SMTExpr *Root : Walk.Roots)
+        InClass.insert(Root);
+    }
+  }
+}
+
+SMTExprRef SMTSolverImpl::ackDefaultElementValue(const SMTSortRef &Sort) {
+  if (Sort->isBoolSort())
+    return mkBool(false);
+  // FP first: BVFP sorts answer true to isBVSort() too.
+  if (Sort->isFPSort())
+    return mkFPFromBin(
+        std::string(Sort->getWidth(), '0'), Sort->getFPExponentWidth(),
+        Sort->isBVFPSort() ? FPEncoding::BV : FPEncoding::Native);
+  if (Sort->isBVSort())
+    return mkBVFromBin(std::string(Sort->getWidth(), '0'), Sort);
+  if (Sort->isIntSort())
+    return mkInt(0);
+  if (Sort->isRealSort())
+    return mkReal("0");
+  fatalError("Cannot synthesize a default model value for this element "
+             "sort under the Ackermann array encoding");
+}
+
+SMTExprRef SMTSolverImpl::resolveAckArrayElement(const SMTExprRef &Array,
+                                                 const SMTExprRef &Index) {
+  const std::string QueryBits = lazyIndexModelBits(Index);
+  fatalErrorIf(QueryBits.empty(),
+               "Cannot evaluate the queried index against the model under "
+               "the Ackermann array encoding (bool/BV index sorts only)");
+
+  AckClassWalk Walk;
+  ackWalkChain(&*Array, QueryBits, Walk);
+  if (!Walk.StoreHit && !Walk.Failed)
+    ackExpandEqualityClass(Array->Sort, QueryBits, Walk);
+  fatalErrorIf(Walk.Failed,
+               "Could not walk the array derivation chain against the "
+               "model under the Ackermann array encoding");
+  if (Walk.StoreHit)
+    return Walk.StoreHit;
+
+  // Match the queried value against the class's reads.
+  for (const SMTExpr *Root : Walk.Roots) {
+    auto RootIt = AckArrayRoots.find(Root);
+    if (RootIt == AckArrayRoots.end())
+      continue;
+    for (const AckArrayRead &R : RootIt->second.Reads) {
+      const std::string ReadBits =
+          R.IndexIsConst ? R.ConstBits : lazyIndexModelBits(R.Index);
+      if (!ReadBits.empty() && ReadBits == QueryBits)
+        return R.Value;
+    }
+  }
+
+  if (Walk.ConstInit)
+    return Walk.ConstInit;
+
+  // Genuinely unconstrained: hand out a stable default, memoized per
+  // (primary root, index value) for the lifetime of the current model.
+  const SMTExpr *MemoKey = Walk.Roots.empty() ? &*Array : Walk.Roots.front();
+  auto [It, Inserted] = AckModelDefaults.try_emplace(
+      std::make_pair(MemoKey, QueryBits), SMTExprRef{});
+  if (Inserted)
+    It->second = ackDefaultElementValue(Array->Sort->getElementSort());
+  return It->second;
+}
+
+SMTResult<ArrayModel> SMTSolverImpl::ackArrayModel(const SMTExprRef &Array) {
+  AckClassWalk Walk;
+  ackWalkChain(&*Array, std::string(), Walk);
+  if (!Walk.Failed)
+    ackExpandEqualityClass(Array->Sort, std::string(), Walk);
+  if (Walk.Failed)
+    return SMTError{SMTErrorCode::BackendError,
+                    CachedBoolExprs[0]->getBackendKind(),
+                    "Could not walk the array derivation chain against the "
+                    "model under the Ackermann array encoding"};
+
+  ArrayModel Model;
+  // Store entries first (outermost first per chain, own chain walked
+  // first, deduped by index value in ackWalkChain), then the class's
+  // reads at still-unseen index values.
+  for (auto &Entry : Walk.StoreEntries)
+    Model.Entries.emplace_back(Entry.first, Entry.second);
+  for (const SMTExpr *Root : Walk.Roots) {
+    auto RootIt = AckArrayRoots.find(Root);
+    if (RootIt == AckArrayRoots.end())
+      continue;
+    for (const AckArrayRead &R : RootIt->second.Reads) {
+      const std::string ReadBits =
+          R.IndexIsConst ? R.ConstBits : lazyIndexModelBits(R.Index);
+      if (ReadBits.empty())
+        return SMTError{SMTErrorCode::BackendError,
+                        CachedBoolExprs[0]->getBackendKind(),
+                        "Could not evaluate a read index while walking an "
+                        "Ackermann array model"};
+      if (Walk.SeenStoreBits.insert(ReadBits).second)
+        Model.Entries.emplace_back(R.Index, R.Value);
+    }
+  }
+  Model.Base = Walk.ConstInit; // null for symbol roots: unconstrained off
+                               // the listed entries
+  return Model;
+}
+
+} // namespace camada

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -211,9 +211,32 @@ void SMTSolverImpl::clearSortCaches() {
   TupleSortCache.clear();
 }
 
+void SMTSolverImpl::noteAckBVConstBits(const SMTExprRef &Exp,
+                                       const std::string &Bits) {
+  // Only the Ackermann array encoding needs build-time constant values
+  // (for read canonicalization); keep the default mode overhead-free.
+  if (ArrayMode == ArrayEncoding::Ackermann)
+    AckBVConstBits.emplace(&*Exp, Bits);
+}
+
+static std::string int64ToBits(int64_t Value, unsigned Width) {
+  std::string Bits(Width, '0');
+  for (unsigned I = 0; I < Width; ++I) {
+    // Arithmetic shift on the signed value sign-extends, matching the
+    // two's-complement semantics of mkBVFromDec for widths beyond 64.
+    const int64_t Bit = I < 64 ? (Value >> I) & 1 : (Value < 0 ? 1 : 0);
+    Bits[Width - 1 - I] = Bit ? '1' : '0';
+  }
+  return Bits;
+}
+
 void SMTSolverImpl::invalidateUnsatAssumptions() {
   LastAssumptions.clear();
   UnsatAssumptionsValid = false;
+  // Fires on everything that invalidates the current model (constraint,
+  // check, push, pop, reset), which is exactly the lifetime of the
+  // default values handed out for unconstrained Ackermann-array queries.
+  AckModelDefaults.clear();
 }
 
 void SMTSolverImpl::clearExprCaches() {
@@ -238,6 +261,8 @@ void SMTSolverImpl::clearExprCaches() {
   ArrayEqualLinks.clear();
   ArrayEqualLinksByIndexSort.clear();
   ArrayEqualCongruenceDone.clear();
+  AckArrayRoots.clear();
+  AckBVConstBits.clear();
   invalidateUnsatAssumptions();
 }
 
@@ -388,6 +413,17 @@ SMTSortRef SMTSolverImpl::mkArraySort(const SMTSortRef &IndexSort,
     return theSort;
   }
 
+  // Ackermann mode: arrays are Camada-owned nodes with no backend sort
+  // (see camadaarray.cpp). Tuple-involving element sorts were dissolved
+  // above (the mode forces the Camada tuple encoding), so only scalar
+  // element sorts reach this point.
+  if (ArrayMode == ArrayEncoding::Ackermann) {
+    SMTSortRef theSort = mkAckArraySort(IndexSort, ElemSort);
+    assert(theSort->isArraySort());
+    ArraySortCache.emplace(Key, theSort);
+    return theSort;
+  }
+
   SMTSortRef theSort = mkArraySortImpl(IndexSort, ElemSort);
   assert(theSort->isArraySort());
   assert(theSort->getIndexSort() == IndexSort);
@@ -413,6 +449,17 @@ SMTSolverImpl::mkFunctionSort(const std::vector<SMTSortRef> &DomainSorts,
                    "Functions taking tuple (or tuple-involving array) "
                    "arguments are not yet supported on this backend; see "
                    "issue #17");
+  }
+  // Ackermann-mode arrays have no backend term to pass to or return from
+  // an uninterpreted function.
+  if (ArrayMode == ArrayEncoding::Ackermann) {
+    fatalErrorIf(CodomainSort->isArraySort(),
+                 "Functions returning arrays are not supported with the "
+                 "Ackermann array encoding");
+    for (const auto &D : DomainSorts)
+      fatalErrorIf(D->isArraySort(),
+                   "Functions taking array arguments are not supported "
+                   "with the Ackermann array encoding");
   }
   if (DomainSorts.size() <= 4) {
     SmallFunctionSortCacheKey SmallKey{};
@@ -691,6 +738,11 @@ SMTExprRef SMTSolverImpl::mkEqual(const SMTExprRef &LHS,
     // normal array-equality machinery (lazy witness, STP encoding).
     if (!nativeTupleSupport() && sortContainsTuple(LHS->Sort->getElementSort()))
       return mkCamadaTupleArrayEqual(*this, LHS, RHS);
+    // Ackermann-mode arrays have no backend term to hand to mkEqualImpl;
+    // equality is always the witness + observed-index congruence
+    // encoding, whose selects re-enter the Ackermann lowering.
+    if (ArrayMode == ArrayEncoding::Ackermann)
+      return mkEncodedArrayEqual(LHS, RHS);
     const bool LazyInvolved = !LazyConstArrayRoots.empty() &&
                               (reachesLazyArray(LHS) || reachesLazyArray(RHS));
     // Backends without native array extensionality (STP) cannot decide
@@ -928,6 +980,8 @@ SMTExprRef SMTSolverImpl::mkIte(const SMTExprRef &Cond, const SMTExprRef &T,
   if (!nativeTupleSupport() && T->Sort->isArraySort() &&
       sortContainsTuple(T->Sort->getElementSort()))
     return mkCamadaTupleArrayIte(*this, Cond, T, F);
+  if (ArrayMode == ArrayEncoding::Ackermann && T->Sort->isArraySort())
+    return mkAckArrayIte(Cond, T, F);
   SMTExprRef theExp = mkIteImpl(Cond, T, F);
   assert(theExp->Sort == F->Sort);
   if (!LazyConstArrayRoots.empty() && T->Sort->isArraySort()) {
@@ -1223,6 +1277,14 @@ SMTExprRef SMTSolverImpl::mkArraySelect(const SMTExprRef &Array,
     return mkCamadaTupleArraySelect(*this, Array, Index);
   if (!InLazyModelQuery)
     observeArrayIndex(Index);
+  if (ArrayMode == ArrayEncoding::Ackermann) {
+    // Selects built for model evaluation must not mint reads or emit
+    // axioms; resolve them against the model instead.
+    SMTExprRef theExp = InLazyModelQuery ? resolveAckArrayElement(Array, Index)
+                                         : mkAckArraySelect(Array, Index);
+    assert(theExp->Sort == Array->Sort->getElementSort());
+    return theExp;
+  }
   SMTExprRef theExp = mkArraySelectImpl(Array, Index);
   assert(theExp->Sort == Array->Sort->getElementSort());
   return theExp;
@@ -1243,6 +1305,11 @@ SMTExprRef SMTSolverImpl::mkArrayStore(const SMTExprRef &Array,
   fatalErrorIf(!LazyConstArrayRoots.empty() && reachesLazyArray(Element),
                "Storing a lazily lowered constant array inside another array "
                "is not supported");
+  if (ArrayMode == ArrayEncoding::Ackermann) {
+    SMTExprRef theExp = mkAckArrayStore(Array, Index, Element);
+    assert(theExp->Sort == Array->Sort);
+    return theExp;
+  }
   SMTExprRef theExp = mkArrayStoreImpl(Array, Index, Element);
   assert(theExp->Sort == Array->Sort);
   if (!LazyConstArrayRoots.empty()) {
@@ -1512,6 +1579,13 @@ SMTExprRef SMTSolverImpl::mkApplyImpl(const SMTExprRef &,
 SMTExprRef SMTSolverImpl::mkForall(const std::vector<SMTExprRef> &Vars,
                                    const SMTExprRef &Body) {
   requireBoolSort(Body, "Expected boolean quantifier body");
+  // Every quantifier is rejected in Ackermann mode, not just those over
+  // array terms: a select at a bound index lowers to a nullary read
+  // variable, silently losing the dependence on the bound variable, and
+  // the body's provenance cannot be inspected here.
+  fatalErrorIf(ArrayMode == ArrayEncoding::Ackermann,
+               "Quantifiers are not supported with the Ackermann array "
+               "encoding (quantifier-free formulas only)");
   // Encoded tuple variables would reach the backend's mkForallImpl as a
   // CamadaTupleExpr without a backend term, which the backend would
   // then static_cast as one of its own expressions. Reject up front.
@@ -1534,6 +1608,9 @@ SMTExprRef SMTSolverImpl::mkForallImpl(const std::vector<SMTExprRef> &,
 SMTExprRef SMTSolverImpl::mkExists(const std::vector<SMTExprRef> &Vars,
                                    const SMTExprRef &Body) {
   requireBoolSort(Body, "Expected boolean quantifier body");
+  fatalErrorIf(ArrayMode == ArrayEncoding::Ackermann,
+               "Quantifiers are not supported with the Ackermann array "
+               "encoding (quantifier-free formulas only)");
   if (!nativeTupleSupport())
     for (const auto &V : Vars)
       fatalErrorIf(sortContainsTuple(V->Sort),
@@ -1632,6 +1709,10 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
   // per-leaf values into a tuple; the per-leaf reads re-enter this wrapper.
   if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
     return getCamadaTupleArrayElement(*this, Array, Index);
+  // Ackermann-mode arrays have no backend term to evaluate; resolve from
+  // the tracked derivation chain and the reads of the equality class.
+  if (ArrayMode == ArrayEncoding::Ackermann)
+    return resolveAckArrayElement(Array, Index);
   if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
     if (SMTExprRef Resolved = resolveLazyArrayElement(Array, Index))
       return Resolved;
@@ -1655,6 +1736,8 @@ SMTResult<ArrayModel> SMTSolverImpl::getArrayValues(const SMTExprRef &Array) {
   // tuple-valued model; the per-leaf queries re-enter this wrapper.
   if (!nativeTupleSupport() && sortContainsTuple(Array->Sort->getElementSort()))
     return getCamadaTupleArrayValues(*this, Array);
+  if (ArrayMode == ArrayEncoding::Ackermann)
+    return ackArrayModel(Array);
   if (!LazyConstArrayRoots.empty() && reachesLazyArray(Array))
     return lazyArrayModel(Array);
   return getArrayValuesImpl(Array);
@@ -1790,6 +1873,7 @@ SMTExprRef SMTSolverImpl::mkBVFromDec(const int64_t Int,
       SMTExprRef theExp = mkBVFromDecImpl(Int, Sort);
       assert(theExp->isBVSort());
       assert(theExp->getWidth() == Width);
+      noteAckBVConstBits(theExp, int64ToBits(Int, Width));
       CachedExpr = theExp;
       return CachedExpr;
     }
@@ -1798,6 +1882,7 @@ SMTExprRef SMTSolverImpl::mkBVFromDec(const int64_t Int,
   SMTExprRef theExp = mkBVFromDecImpl(Int, Sort);
   assert(theExp->isBVSort());
   assert(theExp->getWidth() == Sort->getWidth());
+  noteAckBVConstBits(theExp, int64ToBits(Int, Sort->getWidth()));
   return theExp;
 }
 
@@ -1817,6 +1902,7 @@ SMTExprRef SMTSolverImpl::mkBVFromBin(const std::string &Int,
   SMTExprRef theExp = mkBVFromBinImpl(Int, Sort);
   assert(theExp->isBVSort());
   assert(theExp->getWidth() == Sort->getWidth());
+  noteAckBVConstBits(theExp, Int);
   return theExp;
 }
 
@@ -1861,6 +1947,13 @@ SMTExprRef SMTSolverImpl::mkSymbolUnchecked(const std::string &Name,
   if (!nativeTupleSupport() && Sort->isArraySort() &&
       sortContainsTuple(Sort->getElementSort())) {
     SMTExprRef theExp = mkCamadaTupleArraySymbol(*this, Name, Sort);
+    SymbolExprCache.emplace(Key, theExp);
+    return theExp;
+  }
+  // Ackermann mode: array symbols are roots of the read/congruence
+  // encoding, never backend terms.
+  if (ArrayMode == ArrayEncoding::Ackermann && Sort->isArraySort()) {
+    SMTExprRef theExp = mkAckArraySymbol(Name, Sort);
     SymbolExprCache.emplace(Key, theExp);
     return theExp;
   }
@@ -1985,6 +2078,16 @@ SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
   // lowering (and its lazy machinery) applies per leaf.
   if (!nativeTupleSupport() && sortContainsTuple(InitValue->Sort))
     return mkCamadaTupleArrayConst(*this, IndexSort, InitValue, Lowering);
+  // Ackermann mode: the lowering choice is moot — a Const node's selects
+  // return the initializer directly, which is exactly what both Native
+  // and Lazy promise.
+  if (ArrayMode == ArrayEncoding::Ackermann) {
+    SMTExprRef theExp = mkAckArrayConst(IndexSort, InitValue);
+    assert(theExp->isArraySort());
+    assert(theExp->Sort->getIndexSort() == IndexSort);
+    assert(theExp->Sort->getElementSort() == InitValue->Sort);
+    return theExp;
+  }
   SMTExprRef theExp = Lowering == ConstArrayLowering::Native
                           ? mkArrayConstImpl(IndexSort, InitValue)
                           : mkLazyConstArray(IndexSort, InitValue);

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -2070,8 +2070,12 @@ SMTExprRef SMTSolverImpl::mkArrayConst(const SMTSortRef &IndexSort,
   if (Lowering == ConstArrayLowering::Auto)
     Lowering = nativeConstArraySupport() ? ConstArrayLowering::Native
                                          : ConstArrayLowering::Lazy;
+  // In Ackermann mode the lowering choice is moot (see below), so an
+  // explicit Native request is not an error on backends without native
+  // constant arrays.
   fatalErrorIf(Lowering == ConstArrayLowering::Native &&
-                   !nativeConstArraySupport(),
+                   !nativeConstArraySupport() &&
+                   ArrayMode != ArrayEncoding::Ackermann,
                "Native constant arrays are not supported by this backend");
   // Tuple-involving initializers decompose into one constant array per
   // scalar leaf; the per-leaf calls re-enter this wrapper, so the resolved

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -25,6 +25,7 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -39,6 +40,10 @@
 #include "camadasort.h"
 
 namespace camada {
+
+// Model-walk scratch state for the Ackermann array encoding; defined in
+// camadaarray.cpp.
+struct AckClassWalk;
 
 class SMTSolverImpl : public SMTSolver {
 public:
@@ -220,6 +225,65 @@ protected:
 
   SMTExprRef mkEncodedArrayEqual(const SMTExprRef &LHS, const SMTExprRef &RHS);
   void assertArrayEqualCongruence(std::size_t LinkId, const SMTExprRef &Index);
+
+  // --- Ackermann array encoding (opt-in, see ArrayEncoding) ---
+  // Array terms are Camada-owned nodes with no backend representation
+  // (see camadaarray.cpp); selects on symbol roots become fresh element
+  // variables ("reads") tied by pairwise congruence axioms, so the theory
+  // of arrays never reaches the backend. Array equality reuses the
+  // encoded-equality machinery above; the congruence axioms are journaled
+  // in LazyConstraintLevels like every other scope-independent fact.
+  // Sound and complete for quantifier-free formulas only; the mode also
+  // forces the Camada tuple encoding (native tuples cannot hold a
+  // no-backend-term array member).
+  ArrayEncoding ArrayMode = ArrayEncoding::Native;
+  struct AckArrayRead {
+    SMTExprRef Index;
+    SMTExprRef Value;
+    // BV-constant index with bits known at build time (see
+    // AckBVConstBits): canonicalized by value so equal constants share a
+    // read and distinct constants skip the congruence axiom.
+    bool IndexIsConst;
+    std::string ConstBits;
+  };
+  struct AckArrayRootState {
+    // Ordered: each new read emits congruence against all prior ones, so
+    // every unordered pair is related exactly once.
+    std::vector<AckArrayRead> Reads;
+    std::unordered_map<const SMTExpr *, std::size_t> ReadsByIndex;
+    std::unordered_map<std::string, std::size_t> ReadsByConstBits;
+  };
+  std::unordered_map<const SMTExpr *, AckArrayRootState> AckArrayRoots;
+  // Bits of BV constants built through mkBVFromBin/mkBVFromDec, tracked
+  // only in Ackermann mode (general expressions are not hash-consed, so
+  // the value is otherwise unrecoverable at build time).
+  std::unordered_map<const SMTExpr *, std::string> AckBVConstBits;
+  uint64_t AckArrayCounter = 0;
+  // Default values handed out for unconstrained (root, index value) model
+  // queries, so repeated queries agree; cleared with the model (see
+  // invalidateUnsatAssumptions).
+  std::map<std::pair<const SMTExpr *, std::string>, SMTExprRef>
+      AckModelDefaults;
+
+  SMTSortRef mkAckArraySort(const SMTSortRef &IndexSort,
+                            const SMTSortRef &ElemSort);
+  SMTExprRef mkAckArraySymbol(const std::string &Name, const SMTSortRef &Sort);
+  SMTExprRef mkAckArraySelect(const SMTExprRef &Array, const SMTExprRef &Index);
+  SMTExprRef mkAckArrayStore(const SMTExprRef &Array, const SMTExprRef &Index,
+                             const SMTExprRef &Element);
+  SMTExprRef mkAckArrayIte(const SMTExprRef &Cond, const SMTExprRef &T,
+                           const SMTExprRef &F);
+  SMTExprRef mkAckArrayConst(const SMTSortRef &IndexSort,
+                             const SMTExprRef &InitValue);
+  void ackWalkChain(const SMTExpr *Node, const std::string &QueryBits,
+                    AckClassWalk &Walk);
+  void ackExpandEqualityClass(const SMTSortRef &ArraySort,
+                              const std::string &QueryBits, AckClassWalk &Walk);
+  SMTExprRef ackDefaultElementValue(const SMTSortRef &Sort);
+  SMTExprRef resolveAckArrayElement(const SMTExprRef &Array,
+                                    const SMTExprRef &Index);
+  SMTResult<ArrayModel> ackArrayModel(const SMTExprRef &Array);
+  void noteAckBVConstBits(const SMTExprRef &Exp, const std::string &Bits);
 
   /// Lower a constant array as a fresh backend array symbol whose
   /// "every element equals InitValue" semantics are enforced lazily: the

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -104,9 +104,12 @@ void CVC5Expr::dump(std::string &Out) const {
   Out += "\n";
 }
 
-CVC5Solver::CVC5Solver(UnsatAssumptionsMode Mode)
+CVC5Solver::CVC5Solver(UnsatAssumptionsMode Mode, ArrayEncoding Arrays)
     : ProduceUnsatAssumptions(Mode == UnsatAssumptionsMode::On),
       Context(Terms) {
+  // Before the singletons: constant tracking (AckBVConstBits) must cover
+  // the cached small bit-vectors.
+  ArrayMode = Arrays;
   Context.setOption("arrays-exp", "true");
   Context.setOption("produce-models", "true");
   Context.setOption("produce-assertions", "true");

--- a/src/cvc5solver.h
+++ b/src/cvc5solver.h
@@ -66,7 +66,8 @@ public:
 
 class CVC5Solver : public SMTSolverImpl {
 public:
-  explicit CVC5Solver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off);
+  explicit CVC5Solver(UnsatAssumptionsMode Mode = UnsatAssumptionsMode::Off,
+                      ArrayEncoding Arrays = ArrayEncoding::Native);
   ~CVC5Solver() override;
 
 protected:
@@ -107,7 +108,12 @@ protected:
   SMTSortRef
   mkTupleSortImpl(const std::vector<SMTSortRef> &ElementSorts) override;
 
-  bool nativeTupleSupport() const override { return true; }
+  // Native datatypes cannot hold an Ackermann-encoded array member (it
+  // has no backend term), so the Ackermann array mode forces the Camada
+  // tuple encoding.
+  bool nativeTupleSupport() const override {
+    return ArrayMode != ArrayEncoding::Ackermann;
+  }
 
   SMTExprRef mkBVNegImpl(const SMTExprRef &Exp) override;
 

--- a/src/mathsatsolver.cpp
+++ b/src/mathsatsolver.cpp
@@ -137,14 +137,17 @@ void MathSATExpr::dump(std::string &Out) const {
   msat_free(ast);
 }
 
-MathSATSolver::MathSATSolver() {
+MathSATSolver::MathSATSolver(ArrayEncoding Arrays) {
+  ArrayMode = Arrays;
   Config = msat_create_default_config("AUFBV");
   msat_set_option(Config, "model_generation", "true");
   initializeContext();
   initializeCommonSingletons();
 }
 
-MathSATSolver::MathSATSolver(msat_config Config) : Config(Config) {
+MathSATSolver::MathSATSolver(msat_config Config, ArrayEncoding Arrays)
+    : Config(Config) {
+  ArrayMode = Arrays;
   initializeContext();
   initializeCommonSingletons();
 }

--- a/src/mathsatsolver.h
+++ b/src/mathsatsolver.h
@@ -90,10 +90,11 @@ public:
 
 class MathSATSolver : public SMTSolverImpl {
 public:
-  MathSATSolver();
+  explicit MathSATSolver(ArrayEncoding Arrays = ArrayEncoding::Native);
 
   /// Take ownership of a MathSAT configuration and reuse it across resets.
-  explicit MathSATSolver(msat_config Config);
+  explicit MathSATSolver(msat_config Config,
+                         ArrayEncoding Arrays = ArrayEncoding::Native);
   ~MathSATSolver() override;
 
 protected:

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -680,18 +680,24 @@ const std::string &textOf(const SMTSortRef &S) {
 } // namespace
 
 SMTLIBSolver::SMTLIBSolver(const std::string &OutputPath,
-                           TupleEncoding TupleMode, const std::string &Logic)
+                           TupleEncoding TupleMode, const std::string &Logic,
+                           ArrayEncoding Arrays)
     : File(std::make_unique<FileEmitter>(OutputPath)), TupleMode(TupleMode),
       LogicOverride(Logic) {
+  // Before the singletons: constant tracking (AckBVConstBits) must cover
+  // the cached small bit-vectors.
+  ArrayMode = Arrays;
   emitPreamble();
   initializeCommonSingletons();
 }
 
 SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
                            const std::vector<std::string> &Argv,
-                           TupleEncoding TupleMode, const std::string &Logic)
+                           TupleEncoding TupleMode, const std::string &Logic,
+                           ArrayEncoding Arrays)
     : Proc(std::make_unique<ProcessEmitter>(Argv)), TupleMode(TupleMode),
       LogicOverride(Logic) {
+  ArrayMode = Arrays;
   emitPreamble();
   initializeCommonSingletons();
 }
@@ -699,10 +705,12 @@ SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
 SMTLIBSolver::SMTLIBSolver(SMTLIBProcessTag,
                            const std::vector<std::string> &Argv,
                            const std::string &OutputPath,
-                           TupleEncoding TupleMode, const std::string &Logic)
+                           TupleEncoding TupleMode, const std::string &Logic,
+                           ArrayEncoding Arrays)
     : File(std::make_unique<FileEmitter>(OutputPath)),
       Proc(std::make_unique<ProcessEmitter>(Argv)), TupleMode(TupleMode),
       LogicOverride(Logic) {
+  ArrayMode = Arrays;
   emitPreamble();
   initializeCommonSingletons();
 }
@@ -711,13 +719,14 @@ SMTLIBSolver::SMTLIBSolver(SMTLIBOneShotTag, const std::string &FormulaPath,
                            const std::string &ShellCmd,
                            const std::vector<std::string> &ModelArgv,
                            PgidCallback OnSpawn, TupleEncoding TupleMode,
-                           const std::string &Logic)
+                           const std::string &Logic, ArrayEncoding Arrays)
     : OneShotMode(true), OneShotFormulaPath(FormulaPath),
       OneShotShellCmd(ShellCmd), OneShotOnSpawn(std::move(OnSpawn)),
       File(std::make_unique<FileEmitter>(FormulaPath)),
       Proc(ModelArgv.empty() ? nullptr
                              : std::make_unique<ProcessEmitter>(ModelArgv)),
       TupleMode(TupleMode), LogicOverride(Logic) {
+  ArrayMode = Arrays;
   emitPreamble();
   initializeCommonSingletons();
 }

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -215,9 +215,13 @@ public:
   /// reject it. A non-empty value is emitted verbatim and no negotiation is
   /// attempted — the caller is asserting it knows what the child accepts,
   /// and a child that rejects it is a fatal error, not a retry.
+  /// `Arrays` (all four constructors) selects the array encoding — see the
+  /// docstring on ArrayEncoding. Ackermann mode keeps the theory of arrays
+  /// off the wire entirely and forces the Camada tuple encoding.
   explicit SMTLIBSolver(const std::string &OutputPath,
                         TupleEncoding TupleMode = TupleEncoding::Native,
-                        const std::string &Logic = "");
+                        const std::string &Logic = "",
+                        ArrayEncoding Arrays = ArrayEncoding::Native);
 
   /// Interactive constructor: spawn a child solver via
   /// `execvp(Argv[0], Argv)`. The solver must speak standard SMT-LIB on
@@ -227,7 +231,8 @@ public:
   /// carry no special meaning.
   SMTLIBSolver(SMTLIBProcessTag, const std::vector<std::string> &Argv,
                TupleEncoding TupleMode = TupleEncoding::Native,
-               const std::string &Logic = "");
+               const std::string &Logic = "",
+               ArrayEncoding Arrays = ArrayEncoding::Native);
 
   /// Combined constructor: spawn a child solver via execvp *and* log the
   /// script to a file. Useful when you want both an interactive answer
@@ -235,7 +240,8 @@ public:
   SMTLIBSolver(SMTLIBProcessTag, const std::vector<std::string> &Argv,
                const std::string &OutputPath,
                TupleEncoding TupleMode = TupleEncoding::Native,
-               const std::string &Logic = "");
+               const std::string &Logic = "",
+               ArrayEncoding Arrays = ArrayEncoding::Native);
 
   /// One-shot constructor: serialize the script (including `(check-sat)`)
   /// to FormulaPath, then run ShellCmd on it **via a shell** — every `%f`
@@ -265,7 +271,8 @@ public:
                const std::vector<std::string> &ModelArgv = {},
                PgidCallback OnSpawn = {},
                TupleEncoding TupleMode = TupleEncoding::Native,
-               const std::string &Logic = "");
+               const std::string &Logic = "",
+               ArrayEncoding Arrays = ArrayEncoding::Native);
 
   /// One-shot mode: the model solver's own answer to the shared query,
   /// read only after a sat verdict from the one-shot run. Unset when no
@@ -309,8 +316,11 @@ protected:
   SMTSortRef
   mkTupleSortImpl(const std::vector<SMTSortRef> &ElementSorts) override;
 
+  // The Ackermann array mode forces the Camada tuple encoding: a native
+  // datatype cannot hold an array member that has no backend term.
   bool nativeTupleSupport() const override {
-    return TupleMode == TupleEncoding::Native;
+    return TupleMode == TupleEncoding::Native &&
+           ArrayMode != ArrayEncoding::Ackermann;
   }
 
   // --- expressions ---

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -78,12 +78,15 @@ void STPExpr::dump(std::string &Out) const {
   free(s);
 }
 
-STPSolver::STPSolver() : Context(STP::vc_createValidityChecker()) {
+STPSolver::STPSolver(ArrayEncoding Arrays)
+    : Context(STP::vc_createValidityChecker()) {
+  ArrayMode = Arrays;
   STP::vc_registerErrorHandler(STPErrorHandler);
   initializeCommonSingletons();
 }
 
-STPSolver::STPSolver(STP::VC C) : Context(C) {
+STPSolver::STPSolver(STP::VC C, ArrayEncoding Arrays) : Context(C) {
+  ArrayMode = Arrays;
   STP::vc_registerErrorHandler(STPErrorHandler);
   initializeCommonSingletons();
 }

--- a/src/stpsolver.h
+++ b/src/stpsolver.h
@@ -74,8 +74,8 @@ public:
 
 class STPSolver : public SMTSolverImpl {
 public:
-  STPSolver();
-  explicit STPSolver(STP::VC C);
+  explicit STPSolver(ArrayEncoding Arrays = ArrayEncoding::Native);
+  explicit STPSolver(STP::VC C, ArrayEncoding Arrays = ArrayEncoding::Native);
   ~STPSolver() override;
 
 protected:

--- a/src/yicessolver.cpp
+++ b/src/yicessolver.cpp
@@ -186,7 +186,8 @@ void YicesExpr::dump(std::string &Out) const {
   yices_free_string(term_str);
 }
 
-YicesSolver::YicesSolver() {
+YicesSolver::YicesSolver(ArrayEncoding Arrays) {
+  ArrayMode = Arrays;
   acquireYicesLibrary();
   recreateContext("QF_AUFBV");
   initializeCommonSingletons();

--- a/src/yicessolver.h
+++ b/src/yicessolver.h
@@ -69,7 +69,7 @@ public:
 
 class YicesSolver : public SMTSolverImpl {
 public:
-  YicesSolver();
+  explicit YicesSolver(ArrayEncoding Arrays = ArrayEncoding::Native);
   ~YicesSolver() override;
 
 protected:

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -103,13 +103,18 @@ void Z3Expr::dump(std::string &Out) const {
   Out += "\n";
 }
 
-Z3Solver::Z3Solver() : Solver(Context) {
+Z3Solver::Z3Solver(ArrayEncoding Arrays) : Solver(Context) {
+  // The mode must be set before the singletons are built so constant
+  // tracking (AckBVConstBits) covers the cached small bit-vectors.
+  ArrayMode = Arrays;
   // Needs to be set in order to convert NaN to bitvector
   z3::set_param("rewriter.hi_fp_unspecified", true);
   initializeCommonSingletons();
 }
 
-Z3Solver::Z3Solver(z3::context C) : Context(std::move(C)), Solver(Context) {
+Z3Solver::Z3Solver(z3::context C, ArrayEncoding Arrays)
+    : Context(std::move(C)), Solver(Context) {
+  ArrayMode = Arrays;
   z3::set_param("rewriter.hi_fp_unspecified", true);
   initializeCommonSingletons();
 }

--- a/src/z3solver.h
+++ b/src/z3solver.h
@@ -67,8 +67,9 @@ public:
 
 class Z3Solver : public SMTSolverImpl {
 public:
-  Z3Solver();
-  explicit Z3Solver(z3::context C);
+  explicit Z3Solver(ArrayEncoding Arrays = ArrayEncoding::Native);
+  explicit Z3Solver(z3::context C,
+                    ArrayEncoding Arrays = ArrayEncoding::Native);
   // There is deliberately no (context, solver) constructor: z3::solver
   // holds a pointer to the context *object* it was built against, and
   // z3::context is move-only, so any solver a caller could pass would
@@ -116,7 +117,12 @@ protected:
   SMTSortRef
   mkTupleSortImpl(const std::vector<SMTSortRef> &ElementSorts) override;
 
-  bool nativeTupleSupport() const override { return true; }
+  // Native datatypes cannot hold an Ackermann-encoded array member (it
+  // has no backend term), so the Ackermann array mode forces the Camada
+  // tuple encoding.
+  bool nativeTupleSupport() const override {
+    return ArrayMode != ArrayEncoding::Ackermann;
+  }
 
   SMTExprRef mkBVNegImpl(const SMTExprRef &Exp) override;
 


### PR DESCRIPTION
## What

An opt-in array encoding that removes the theory of arrays from the backend query entirely, reviving the `tuples`-branch prototype as a reimplementation on master (the prototype had six correctness bugs; each is a regression test here).

- **Encoding** (`src/camadaarray.cpp`): array terms are Camada-owned nodes with no backend representation. Selects on symbol roots mint fresh element variables tied by pairwise congruence axioms (`i = j => a[i] = a[j]`); BV-constant indexes are canonicalized by value so equal constants share one read and distinct constants skip the axiom. Stores/ites lower structurally at select time. Equality reuses the existing `mkEncodedArrayEqual` witness + observed-index machinery, whose selects re-enter this encoding. Congruence axioms are journaled in `LazyConstraintLevels`, so they survive `pop()` like every other scope-independent fact.
- **Models**: queries never mint reads or emit axioms. Resolution canonicalizes by model value, walks store/ite chains under the model, and looks up reads across the whole equality class (links whose `EqVar` is true), so `a = b` answers consistently on both sides. Unconstrained indexes get a stable memoized default.
- **Knob**: every `create*Solver()` factory takes an `ArrayEncoding`, default `Native` — no change for existing users. Ackermann mode forces the Camada tuple encoding (a native datatype cannot hold an array member that has no backend term) and rejects quantifiers (all of them — a select at a bound index would silently lose the dependence), nested arrays, and array-sorted UF signatures.

## Testing

- Every backend (bitwuzla, cvc5, mathsat, stp, yices, z3) runs the Ackermann fixture set natively; Z3 additionally runs the **full shared fixture suite (661 assertions) under Ackermann mode unmodified**, plus pipe variants against z3 and stp children.
- 11 targeted fixtures (`regression/ackarray.test.h`), one per prototype bug plus composition: constant/symbolic index aliasing, equality asserted before reads exist, disequality witness, ite-array equality deciding the condition, model-query re-check stability, internal-name aliasing, const arrays under every `ConstArrayLowering`, `getArrayValues`, FP-over-BV elements, `checkSatAssuming`.
- STP children lack `:global-declarations` support (documented limitation), so only fixtures that mint no reads inside a `(push)` scope run there. Teaching the SMT-LIB backend to re-declare journaled symbols after pop is a possible follow-up.
- Full suite: 223/223.

## Benchmark

New `array_solve` bench case (the first that calls `check()` — the encoding trade only shows up in solve time) and a `--ack` flag that applies the encoding to whichever backend is chosen:

```
hyperfine --warmup 3 --runs 20 'camada-bench z3 200 array_solve' 'camada-bench --ack z3 200 array_solve'
  ackermann ran 1.23 ± 0.09 times faster than native
```

Small store chains with symbolic reads favor the encoding even on Z3; solvers with weaker array theories (STP) are the real target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3
