### PR TITLE
Make the one-shot model solver fault-tolerant during negotiation

### DIFF
--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -501,6 +501,72 @@ TEST_CASE("SMTLIB one-shot sat with model solver", "[SMTLIB][oneshot]") {
   std::remove(Script.c_str());
 }
 
+TEST_CASE("SMTLIB one-shot silent model solver is dropped, not hung",
+          "[SMTLIB][oneshot]") {
+  // A model child that consumes input but never acks (it does not speak
+  // the :print-success protocol) used to deadlock the constructor:
+  // camada blocked reading an ack the child would never send, before the
+  // caller ever got control. It must instead be dropped at the first
+  // bounded read, costing only counterexample support.
+  const unsigned SavedTimeout = camada::SMTLIBSolver::OneShotModelAckTimeoutMs;
+  camada::SMTLIBSolver::OneShotModelAckTimeoutMs = 200;
+
+  // Two shapes of silence: a child that never answers anything, and a
+  // mono-style child that answers only (check-sat) and exits.
+  const std::string SilentBody = "while read line; do :; done\n";
+  const std::string MonoBody = "while read line; do\n"
+                               "  case \"$line\" in\n"
+                               "  '(check-sat)') echo sat; exit 0;;\n"
+                               "  esac\n"
+                               "done\n";
+  for (const std::string &Body : {SilentBody, MonoBody}) {
+    std::string Formula = makeTempPath();
+    std::string Verdict = makeScript("echo sat\n");
+    std::string Child = makeScript(Body);
+    auto solver = std::make_unique<camada::SMTLIBSolver>(
+        camada::SMTLIBOneShotTag{}, Formula, Verdict + " %f",
+        std::vector<std::string>{Child});
+    // Dropped during the preamble already.
+    REQUIRE_FALSE(solver->oneShotModelSolverLive());
+
+    auto X = solver->mkSymbol("x", solver->mkBVSort(8));
+    solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(5, 8)));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE_FALSE(solver->oneShotModelVerdict().has_value());
+
+    solver.reset();
+    std::remove(Formula.c_str());
+    std::remove(Verdict.c_str());
+    std::remove(Child.c_str());
+  }
+
+  camada::SMTLIBSolver::OneShotModelAckTimeoutMs = SavedTimeout;
+}
+
+TEST_CASE("SMTLIB one-shot garbled model solver is dropped, not fatal",
+          "[SMTLIB][oneshot]") {
+  // A model child that answers unparseable lines used to hit fatalError
+  // (killing the host process) at the first non-`success` ack. An
+  // auxiliary child's garbage must cost only counterexample support.
+  std::string Formula = makeTempPath();
+  std::string Verdict = makeScript("echo sat\n");
+  std::string Garbled = makeScript("while read line; do echo banana; done\n");
+  auto solver = std::make_unique<camada::SMTLIBSolver>(
+      camada::SMTLIBOneShotTag{}, Formula, Verdict + " %f",
+      std::vector<std::string>{Garbled});
+  REQUIRE_FALSE(solver->oneShotModelSolverLive());
+
+  auto X = solver->mkSymbol("x", solver->mkBVSort(8));
+  solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(5, 8)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE_FALSE(solver->oneShotModelVerdict().has_value());
+
+  solver.reset();
+  std::remove(Formula.c_str());
+  std::remove(Verdict.c_str());
+  std::remove(Garbled.c_str());
+}
+
 TEST_CASE("SMTLIB one-shot verdict handling", "[SMTLIB][oneshot]") {
   // Last verdict wins, and SAT-competition style is accepted.
   {

--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -508,7 +508,12 @@ TEST_CASE("SMTLIB one-shot silent model solver is dropped, not hung",
   // camada blocked reading an ack the child would never send, before the
   // caller ever got control. It must instead be dropped at the first
   // bounded read, costing only counterexample support.
-  const unsigned SavedTimeout = camada::SMTLIBSolver::OneShotModelAckTimeoutMs;
+  // RAII restore: a failing REQUIRE below must not leave the shortened
+  // process-global timeout behind for later tests.
+  struct TimeoutGuard {
+    unsigned Saved = camada::SMTLIBSolver::OneShotModelAckTimeoutMs;
+    ~TimeoutGuard() { camada::SMTLIBSolver::OneShotModelAckTimeoutMs = Saved; }
+  } Guard;
   camada::SMTLIBSolver::OneShotModelAckTimeoutMs = 200;
 
   // Two shapes of silence: a child that never answers anything, and a
@@ -539,8 +544,6 @@ TEST_CASE("SMTLIB one-shot silent model solver is dropped, not hung",
     std::remove(Verdict.c_str());
     std::remove(Child.c_str());
   }
-
-  camada::SMTLIBSolver::OneShotModelAckTimeoutMs = SavedTimeout;
 }
 
 TEST_CASE("SMTLIB one-shot garbled model solver is dropped, not fatal",

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -598,6 +598,23 @@ std::string ProcessEmitter::readResponse() const {
   return readOneSmtlibResponse(In);
 }
 
+std::optional<std::string>
+ProcessEmitter::readResponseWithin(unsigned TimeoutMs) const {
+  if (!In)
+    return std::string(); // no read side: same as EOF
+  int Fd = ::fileno(In);
+  fd_set ReadFds;
+  FD_ZERO(&ReadFds);
+  FD_SET(Fd, &ReadFds);
+  struct timeval Timeout;
+  Timeout.tv_sec = TimeoutMs / 1000;
+  Timeout.tv_usec = (TimeoutMs % 1000) * 1000;
+  int Ready = ::select(Fd + 1, &ReadFds, nullptr, nullptr, &Timeout);
+  if (Ready <= 0)
+    return std::nullopt; // silent child (or select error): caller drops it
+  return readOneSmtlibResponse(In);
+}
+
 unsigned ProcessEmitter::drainResponses(unsigned TimeoutMs) const {
   if (!In)
     return 0;
@@ -893,6 +910,21 @@ checkResult SMTLIBSolver::oneShotCheck() {
 
 SMTLIBSolver::~SMTLIBSolver() { invalidateGeneratedObjects(); }
 
+unsigned SMTLIBSolver::OneShotModelAckTimeoutMs = 5000;
+
+std::optional<std::string> SMTLIBSolver::oneShotModelReply() {
+  std::optional<std::string> Resp =
+      Proc->readResponseWithin(OneShotModelAckTimeoutMs);
+  if (!Resp || Resp->empty()) {
+    // Timeout (the child does not speak the ack protocol) or EOF (it
+    // died): drop it and continue file-only — the one-shot run is the
+    // verdict source, only counterexample support is lost.
+    Proc.reset();
+    return std::nullopt;
+  }
+  return Resp;
+}
+
 void SMTLIBSolver::emitPreamble() {
   // Interactive mode: the very first emitted command is
   // `(set-option :print-success true)`. Standard-conforming SMT-LIB solvers
@@ -919,7 +951,14 @@ void SMTLIBSolver::emitPreamble() {
   if (Proc) {
     Proc->emitRaw(UnsatAssumptionsOpt);
     Proc->flush();
-    UnsatAssumptionsSupported = Proc->readResponse() == "success";
+    if (OneShotMode) {
+      // Bounded read for the auxiliary model child; `unsupported` is a
+      // legitimate answer, so anything readable just records the bit.
+      std::optional<std::string> Resp = oneShotModelReply();
+      UnsatAssumptionsSupported = Resp && *Resp == "success";
+    } else {
+      UnsatAssumptionsSupported = Proc->readResponse() == "success";
+    }
   }
   // Without :global-declarations true, declarations made inside a (push) are
   // discarded on (pop). Camada's API lets a caller mkSymbol() inside a pushed
@@ -935,7 +974,10 @@ void SMTLIBSolver::emitPreamble() {
   if (Proc) {
     Proc->emitRaw(GlobalDeclsOpt);
     Proc->flush();
-    (void)Proc->readResponse();
+    if (OneShotMode)
+      (void)oneShotModelReply();
+    else
+      (void)Proc->readResponse();
   }
   emitLine("(set-info :status unknown)");
   // ALL covers BV/Bool/arrays/FP/Int/Real, which is the full Camada
@@ -955,10 +997,15 @@ void SMTLIBSolver::emitPreamble() {
     // died gets the usual drop-and-continue treatment instead).
     Proc->emitRaw("(set-logic " + LogicOverride + ")\n");
     Proc->flush();
-    const std::string Resp = Proc->readResponse();
-    if (OneShotMode && Resp.empty()) {
-      Proc.reset();
+    if (OneShotMode) {
+      // Auxiliary model child: a rejection (or any unusable reply) drops
+      // it instead of aborting — the caller's logic claim is only fatal
+      // when the child is the verdict source.
+      std::optional<std::string> Resp = oneShotModelReply();
+      if (Resp && *Resp != "success")
+        Proc.reset();
     } else {
+      const std::string Resp = Proc->readResponse();
       fatalErrorIf(Resp != "success",
                    ("SMTLIBSolver: child solver rejected the caller-chosen "
                     "(set-logic " +
@@ -971,13 +1018,25 @@ void SMTLIBSolver::emitPreamble() {
     std::string Logic = "ALL";
     Proc->emitRaw("(set-logic ALL)\n");
     Proc->flush();
-    const std::string FirstResp = Proc->readResponse();
-    if (OneShotMode && FirstResp.empty()) {
-      // The one-shot model solver died during startup; drop it and continue
-      // file-only (the emitLine death path, reachable here because this
-      // block reads responses by hand).
-      Proc.reset();
-    } else if (FirstResp != "success") {
+    if (OneShotMode) {
+      // Auxiliary model child: every read is bounded, and any unusable
+      // reply at the end of the negotiation drops the child. The tee file
+      // keeps the last logic actually offered.
+      std::optional<std::string> FirstResp = oneShotModelReply();
+      if (FirstResp && *FirstResp != "success") {
+        // stp-shaped two-line rejection (see the interactive branch
+        // below): consume the stray ack, then retry with QF_AUFBV.
+        if (oneShotModelReply()) {
+          Logic = "QF_AUFBV";
+          Proc->emitRaw("(set-logic QF_AUFBV)\n");
+          Proc->flush();
+          std::optional<std::string> Resp = oneShotModelReply();
+          if (Resp && *Resp != "success")
+            Proc.reset();
+        }
+      }
+    } else if (const std::string FirstResp = Proc->readResponse();
+               FirstResp != "success") {
       // stp rejects ALL with a stray diagnostic line and then still answers
       // `success` for the command; consume that stray ack or every later
       // response is off by one. ponytail: this two-line pairing is
@@ -988,18 +1047,11 @@ void SMTLIBSolver::emitPreamble() {
       Proc->emitRaw("(set-logic QF_AUFBV)\n");
       Proc->flush();
       std::string Resp = Proc->readResponse();
-      if (OneShotMode && Resp.empty()) {
-        // The one-shot model solver died mid-negotiation; drop it and
-        // continue file-only, same policy as everywhere else.
-        Proc.reset();
-      } else {
-        fatalErrorIf(
-            Resp != "success",
-            ("SMTLIBSolver: child solver rejected both (set-logic ALL) "
-             "and (set-logic QF_AUFBV): " +
-             Resp)
-                .c_str());
-      }
+      fatalErrorIf(Resp != "success",
+                   ("SMTLIBSolver: child solver rejected both (set-logic ALL) "
+                    "and (set-logic QF_AUFBV): " +
+                    Resp)
+                       .c_str());
     }
     if (File)
       File->emitRaw("(set-logic " + Logic + ")\n");
@@ -1017,21 +1069,22 @@ void SMTLIBSolver::emitLine(const std::string &Text) {
   if (Proc) {
     Proc->emitRaw(Line);
     Proc->flush();
-    // Discard the `success` ack. If the child returned `(error "...")`, abort
-    // with the message — there's no recovery from a malformed command in this
+    // A one-shot model solver is auxiliary: any unusable ack — timeout,
+    // EOF, garbage — drops it and continues file-only. The one-shot run
+    // is the verdict source, only counterexample support is lost.
+    if (OneShotMode) {
+      std::optional<std::string> Resp = oneShotModelReply();
+      if (Resp && *Resp != "success")
+        Proc.reset();
+      return;
+    }
+    // Interactive mode: the child IS the verdict source. Discard the
+    // `success` ack; if it returned `(error "...")`, abort with the
+    // message — there's no recovery from a malformed command in this
     // simple synchronous protocol.
     std::string Resp = Proc->readResponse();
-    if (Resp != "success") {
-      // A one-shot model solver is auxiliary: on child death (EOF reads as
-      // an empty response), drop it and continue file-only — the one-shot
-      // run is the verdict source, only counterexample support is lost.
-      if (OneShotMode && Resp.empty()) {
-        Proc.reset();
-        return;
-      }
-      fatalErrorIf(true,
-                   ("SMTLIBSolver: child solver returned: " + Resp).c_str());
-    }
+    fatalErrorIf(Resp != "success",
+                 ("SMTLIBSolver: child solver returned: " + Resp).c_str());
   }
 }
 

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -140,6 +140,20 @@ public:
   ///   - error: `(error "...")`
   std::string readResponse() const;
 
+  /// Like readResponse(), but waits at most `TimeoutMs` for the child to
+  /// start answering (select on the pipe, same technique as
+  /// drainResponses). Returns nullopt when nothing arrived in time and an
+  /// empty string on EOF. Used for protocol acks from the auxiliary
+  /// one-shot model solver, which must never block camada indefinitely.
+  ///
+  /// The select-vs-stdio-buffer caveat from drainResponses does not bite
+  /// here: a conforming child answers exactly one response per command, so
+  /// the stdio buffer is empty whenever this is called. Only a
+  /// nonconforming child can batch responses ahead, and for those the
+  /// resulting spurious timeout drops the child — exactly the intended
+  /// outcome.
+  std::optional<std::string> readResponseWithin(unsigned TimeoutMs) const;
+
   /// Best-effort non-blocking drain: read responses until none are pending
   /// within `TimeoutMs`. Used by resetImpl() to absorb solver-specific stray
   /// `success` lines emitted alongside the standard reset/option acks (e.g.
@@ -250,9 +264,11 @@ public:
   /// interactive solver (execvp, no shell), which starts solving in
   /// parallel at check() and serves get-value queries after a sat verdict;
   /// its own answer is available via oneShotModelVerdict() so the caller
-  /// can detect a diverging model solver. A model solver that dies is
-  /// dropped silently — the one-shot run remains the verdict source and
-  /// only counterexample support is lost.
+  /// can detect a diverging model solver. A model solver that misbehaves
+  /// in any way — dies, hangs, answers garbage, does not speak the
+  /// `:print-success` ack protocol — is dropped silently (acks are read
+  /// with a deadline, see OneShotModelAckTimeoutMs): the one-shot run
+  /// remains the verdict source and only counterexample support is lost.
   ///
   /// check() may be called once; a second call aborts. On no verdict the
   /// result is UNKNOWN and oneShotDiagnostics() carries the evidence.
@@ -282,6 +298,16 @@ public:
   /// One-shot mode: facts about the last run (command, exit status,
   /// output tail) for the caller's diagnostics.
   const OneShotDiagnostics &oneShotDiagnostics() const { return Diags; }
+
+  /// One-shot mode: deadline for each protocol ack from the auxiliary
+  /// model solver. Acks are instantaneous for any conforming child; a
+  /// child that does not answer within the deadline does not speak the
+  /// `:print-success` protocol and is dropped (only counterexample
+  /// support is lost). Does NOT apply to the read of the model solver's
+  /// own verdict after a sat one-shot run — that read can legitimately
+  /// take as long as the solve and stays blocking. Process-global;
+  /// tunable mainly so tests do not have to wait out the default.
+  static unsigned OneShotModelAckTimeoutMs;
 
   ~SMTLIBSolver() override;
 
@@ -501,6 +527,14 @@ private:
 
   // Emit a single line (newline appended) to the active emitter(s).
   void emitLine(const std::string &Text);
+
+  /// One-shot mode only: read one protocol ack from the auxiliary model
+  /// solver, bounded by OneShotModelAckTimeoutMs. On timeout or EOF the
+  /// child is dropped (Proc reset) and nullopt is returned; otherwise the
+  /// reply is returned for the caller to judge. Callers that require
+  /// `success` drop the child on anything else — an auxiliary child that
+  /// misbehaves in any way costs counterexample support, never the run.
+  std::optional<std::string> oneShotModelReply();
 
   // Emit a check command (a query: no `success` ack) and read the
   // sat/unsat/unknown verdict; UNKNOWN in write-only mode.


### PR DESCRIPTION
## Problem

ESBMC integration surfaced two ways a misbehaving auxiliary model solver could take down the host, both inside camada's constructor, before the caller ever gets control:

- **Hang** (mono-model-cutoff): a child that does not speak the `:print-success` ack protocol (e.g. answers only `(check-sat)`) never replies to the preamble options; camada blocked forever on the pipe.
- **Abort** (mono-model-garbled): a child answering unparseable lines hit `fatalError` at the first non-`success` ack, killing the host process.

The documented one-shot contract already says the model child is auxiliary — "dropped silently; the one-shot run remains the verdict source and only counterexample support is lost" — but only death (EOF) was implemented.

## Fix

Confined to the auxiliary one-shot model child; interactive-mode children (the verdict source) keep fatal semantics.

- `ProcessEmitter::readResponseWithin(TimeoutMs)`: select-bounded read (same technique as the existing `drainResponses`).
- `SMTLIBSolver::oneShotModelReply()`: bounded ack read that drops the child on timeout or EOF; callers drop it on any reply other than `success` — including a rejected caller-chosen logic, which is only fatal when the child is the verdict source.
- Applied to every negotiation read (preamble option acks, both `set-logic` branches, `emitLine` acks). The read of the model child's **own verdict** after a sat one-shot run stays blocking by design: it can legitimately take as long as the solve, and a deadline there would drop healthy-but-slow solvers; death at that point already reads as EOF and is handled.
- `OneShotModelAckTimeoutMs` (default 5000 ms) is a public static so tests don't wait out the default. Acks are instantaneous for any conforming child.

## Testing

Two new regressions with fake-solver scripts: a silent child and a mono-style child that answers only `(check-sat)` (both used to deadlock the constructor), and a garbage-answering child (used to abort). Each now constructs, keeps the one-shot verdict, and reports `oneShotModelSolverLive() == false`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3