### PR TITLE
Bump version to 0.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 set(CAMADA_VER_MAJOR 0)
-set(CAMADA_VER_MINOR 12)
+set(CAMADA_VER_MINOR 13)
 
 project(
   camada

--- a/regression/main.cpp
+++ b/regression/main.cpp
@@ -13,5 +13,5 @@ int main(int argc, char *argv[]) {
 // a quoting mistake there once shipped the literal macro names as the
 // version string, and nothing noticed.
 TEST_CASE("Camada version string", "[Camada]") {
-  REQUIRE(camada::getCamadaVersion() == "0.12");
+  REQUIRE(camada::getCamadaVersion() == "0.13");
 }


### PR DESCRIPTION
Version bump for the release carrying:

- the custom tuple subsystem: tuple updates, tuple arrays, const arrays, models (#102)
- Z3 5.0.0 (#106)
- STP 2.4.0/2.4.1: native overflow predicates, per-check timeouts, and STP as an SMT-LIB pipeline child (#105, #107)
- fixed-point arithmetic encoded over bit-vectors, TR 18037-shaped (#108)
- Int↔BV conversions: `mkInt2BV` / `mkBV2Int` (#109)
- opt-in unsat-assumption production on Bitwuzla and cvc5 (`UnsatAssumptionsMode`, #110)
- SMT-LIB one-shot mode for file-based solvers (#111), with fault-tolerant auxiliary model solvers (#115)
- caller-chosen `(set-logic ...)` on the SMT-LIB backend (#112)
- the opt-in Ackermann array encoding (`ArrayEncoding::Ackermann`, #114)

`getCamadaVersion()` regression updated; library builds as `libcamada.so.0.13`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3