### PR TITLE
Support nested lazily-lowered constant arrays (take 2)

### DIFF
--- a/regression/array.test.h
+++ b/regression/array.test.h
@@ -457,6 +457,237 @@ inline void const_array_equality_semantics(
   REQUIRE(solver->check() == camada::checkResult::UNSAT);
 }
 
+// A symbol array equated to one lazy const array, then disequated from a
+// second — exercises the extensionality witness over an operand that is
+// itself a plain symbol equated (via a separate equality) to a lazy root.
+// The model must be free to exhibit a real difference at the witness, yet
+// a forced agreement at a concrete index must still hold.
+inline void lazy_array_transitive_equality(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto arrsort = solver->mkArraySort(bv8, bv8);
+
+  // B = array_of(7); C = array_of(9); B != C is satisfiable (they differ
+  // at every index, exhibitable at the disequality's own witness).
+  auto b = solver->mkSymbol("lat_b", arrsort);
+  auto c = solver->mkSymbol("lat_c", arrsort);
+  solver->addConstraint(
+      solver->mkEqual(b, solver->mkArrayConst(bv8, idx(7), Lowering)));
+  solver->addConstraint(
+      solver->mkEqual(c, solver->mkArrayConst(bv8, idx(9), Lowering)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(b, c)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // But B's value is still pinned: reading B at any index must be 7, even
+  // though B != C let the solver pick a witness where B and C differ.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  arrsort = solver->mkArraySort(bv8, bv8);
+  auto b2 = solver->mkSymbol("lat_b2", arrsort);
+  auto c2 = solver->mkSymbol("lat_c2", arrsort);
+  solver->addConstraint(
+      solver->mkEqual(b2, solver->mkArrayConst(bv8, idx(7), Lowering)));
+  solver->addConstraint(
+      solver->mkEqual(c2, solver->mkArrayConst(bv8, idx(9), Lowering)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(b2, c2)));
+  auto m = solver->mkSymbol("lat_m", bv8);
+  solver->addConstraint(
+      solver->mkNot(solver->mkEqual(solver->mkArraySelect(b2, m), idx(7))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Regression for the reverted #103: cross-equality congruence at a
+// disequality's witness. a = b and a = c must force b and c to agree at
+// the index where b != c claims its difference — which requires the
+// witness to participate in the other equalities' congruence (i.e. to be
+// an observed index). The unobserved-witness design wrongly answered SAT
+// on backends using the encoded equality (STP), with no lazy arrays
+// involved at all.
+inline void
+array_equality_witness_congruence(const camada::SMTSolverRef &solver) {
+  auto bv8 = solver->mkBVSort(8);
+  auto arrsort = solver->mkArraySort(bv8, bv8);
+  auto a = solver->mkSymbol("wc_a", arrsort);
+  auto b = solver->mkSymbol("wc_b", arrsort);
+  auto c = solver->mkSymbol("wc_c", arrsort);
+  solver->addConstraint(solver->mkEqual(a, b));
+  solver->addConstraint(solver->mkEqual(a, c));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(b, c)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Regression for the reverted #103: a lazy root reached only through an
+// equality must have its default pinned at a disequality's witness.
+// a = array_of(0), a = b, b != array_of(0)' is UNSAT — b is all-zeros by
+// propagation and so is the second root, so no difference is exhibitable
+// anywhere. The operand-scoped-defaults design wrongly answered SAT
+// (b has no syntactic lazy roots, so nothing pinned a's default at the
+// witness).
+inline void lazy_array_equality_reached_defaults(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto zero = solver->mkBVFromDec(0, 8);
+  auto a = solver->mkArrayConst(bv8, zero, Lowering);
+  auto c = solver->mkArrayConst(bv8, zero, Lowering);
+  auto b = solver->mkSymbol("erd_b", solver->mkArraySort(bv8, bv8));
+  solver->addConstraint(solver->mkEqual(a, b));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(b, c)));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// Constant array whose initializer is itself a constant array —
+// array_of(array_of(v)), ESBMC's multidimensional `array_of`. On native
+// constant-array backends the inner const array is just an array-sorted
+// element; on lazy backends both levels lower lazily, so the outer
+// default axiom is an array equality between select(outer, i) and the
+// inner lazy root. This pins read-through, store-over-inner, the
+// negative direction, equality propagation, and model round-trip.
+inline void nested_const_array_semantics(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto innerSort = solver->mkArraySort(bv8, bv8);
+
+  // Default read-through: every cell of the outer array is the inner
+  // const array, whose every cell is v. So select(select(outer,i),j)==v.
+  auto inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  auto outer = solver->mkArrayConst(bv8, inner, Lowering);
+  REQUIRE(outer->Sort->getElementSort() == innerSort);
+  auto i = solver->mkSymbol("i", bv8);
+  auto j = solver->mkSymbol("j", bv8);
+  auto deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(deep, idx(7))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Store into the inner array at a concrete index, read elsewhere: the
+  // written cell holds the stored value, every other cell the default.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  auto innerStored = solver->mkArrayStore(inner, idx(2), idx(99));
+  auto k = solver->mkSymbol("k", bv8);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(k, idx(2))));
+  auto ok = solver->mkAnd(
+      solver->mkEqual(solver->mkArraySelect(innerStored, idx(2)), idx(99)),
+      solver->mkEqual(solver->mkArraySelect(innerStored, k), idx(7)));
+  solver->addConstraint(solver->mkNot(ok));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Negative direction must stay satisfiable: a deep read equal to a
+  // value different from the default is impossible, but equal to the
+  // default is fine — no false UNSAT, and no spurious model either.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  outer = solver->mkArrayConst(bv8, inner, Lowering);
+  i = solver->mkSymbol("i2", bv8);
+  j = solver->mkSymbol("j2", bv8);
+  deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
+  solver->addConstraint(solver->mkEqual(deep, idx(7)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  outer = solver->mkArrayConst(bv8, inner, Lowering);
+  i = solver->mkSymbol("i3", bv8);
+  j = solver->mkSymbol("j3", bv8);
+  deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
+  solver->addConstraint(solver->mkEqual(deep, idx(8))); // != default 7
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Equality propagation: two equal nested const arrays agree on a deep
+  // read even when one side was derived before the equality.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  innerSort = solver->mkArraySort(bv8, bv8);
+  auto outerSort = solver->mkArraySort(bv8, innerSort);
+  auto a = solver->mkSymbol("a", outerSort);
+  i = solver->mkSymbol("i4", bv8);
+  j = solver->mkSymbol("j4", bv8);
+  auto aDeep = solver->mkArraySelect(solver->mkArraySelect(a, i), j);
+  solver->addConstraint(solver->mkEqual(
+      a, solver->mkArrayConst(bv8, solver->mkArrayConst(bv8, idx(5), Lowering),
+                              Lowering)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(aDeep, idx(5))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+
+  // Model round-trip: getArrayElement on the outer returns an inner
+  // array whose deep read matches the default.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  outer = solver->mkArrayConst(bv8, inner, Lowering);
+  // Touch a deep cell so the array is in the formula on every backend.
+  solver->addConstraint(solver->mkEqual(
+      solver->mkArraySelect(solver->mkArraySelect(outer, idx(0)), idx(0)),
+      idx(7)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  auto innerModel = solver->getArrayElement(outer, idx(1));
+  REQUIRE(innerModel->Sort == solver->mkArraySort(bv8, bv8));
+  auto cell = solver->getBV(solver->getArrayElement(innerModel, idx(3)));
+  REQUIRE(cell);
+  REQUIRE(cell.value() == 7);
+
+  // Adversarial: two independent inner-array disequalities must each be
+  // exhibitable at their OWN witness index — a shared witness would
+  // conflate them and force a spurious UNSAT. Each equality's negative
+  // witness is fresh, so this stays SAT.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  innerSort = solver->mkArraySort(bv8, bv8);
+  auto m1 = solver->mkSymbol("m1", innerSort);
+  auto n1 = solver->mkSymbol("n1", innerSort);
+  auto m2 = solver->mkSymbol("m2", innerSort);
+  auto n2 = solver->mkSymbol("n2", innerSort);
+  solver->addConstraint(solver->mkNot(solver->mkEqual(m1, n1)));
+  solver->addConstraint(solver->mkNot(solver->mkEqual(m2, n2)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+
+  // Adversarial negative direction with a lazy const array: a difference
+  // claimed against the default must be a real one. select(outer,i) is the
+  // inner const array (all 7s); claiming select(select(outer,i),j) == 4 is
+  // impossible, but the model must not fabricate a difference at an
+  // unobserved index — pinned by the witness default. UNSAT.
+  solver->reset();
+  bv8 = solver->mkBVSort(8);
+  inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  outer = solver->mkArrayConst(bv8, inner, Lowering);
+  auto sym = solver->mkSymbol("sym", solver->mkArraySort(bv8, bv8));
+  i = solver->mkSymbol("i5", bv8);
+  // sym equals the inner const array, but disagrees with it at j: UNSAT,
+  // because sym = select(outer,i) = inner forces agreement everywhere
+  // observed.
+  solver->addConstraint(solver->mkEqual(sym, solver->mkArraySelect(outer, i)));
+  auto j5 = solver->mkSymbol("j5", bv8);
+  solver->addConstraint(
+      solver->mkNot(solver->mkEqual(solver->mkArraySelect(sym, j5), idx(7))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
+// nested_const_array_semantics inside a pushed scope: the deep default
+// asserted in the scope must still bind handles that outlive the pop.
+inline void nested_const_array_survives_pop(
+    const camada::SMTSolverRef &solver,
+    camada::ConstArrayLowering Lowering = camada::ConstArrayLowering::Auto) {
+  auto bv8 = solver->mkBVSort(8);
+  auto idx = [&](int64_t V) { return solver->mkBVFromDec(V, 8); };
+  auto inner = solver->mkArrayConst(bv8, idx(7), Lowering);
+  auto outer = solver->mkArrayConst(bv8, inner, Lowering);
+  auto i = solver->mkSymbol("ncsp_i", bv8);
+  auto j = solver->mkSymbol("ncsp_j", bv8);
+
+  solver->push();
+  auto deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
+  solver->pop();
+
+  solver->addConstraint(solver->mkNot(solver->mkEqual(deep, idx(7))));
+  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+}
+
 inline void const_array_lowering_interop(const camada::SMTSolverRef &solver) {
   auto idx = solver->mkBVSort(8);
   auto elem = solver->mkBVSort(8);

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -222,16 +222,22 @@ TEST_CASE("Deep tuple/array nesting Bitwuzla test", "[Bitwuzla]") {
   tuple_array_deep_nesting(solver);
 }
 
-// Nested constant tuple arrays need every per-leaf constant array to
-// nest, and lazily lowered constant arrays cannot — pin the abort.
-TEST_CASE("Unsupported nested constant tuple arrays Bitwuzla test",
-          "[Bitwuzla]") {
+// Registered per backend: nested constant arrays now lower lazily too,
+// so the per-leaf constant arrays of a tuple-array initializer can nest.
+TEST_CASE("Nested constant tuple arrays Bitwuzla test", "[Bitwuzla]") {
   auto solver = camada::createBitwuzlaSolver();
-  require_abort([&]() {
-    auto bv4 = solver->mkBVSort(4);
-    auto init =
-        solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(5, 8)});
-    auto innerConst = solver->mkArrayConst(bv4, init);
-    (void)solver->mkArrayConst(bv4, innerConst);
-  });
+  tuple_array_const_nested(solver);
+}
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays Bitwuzla test", "[Bitwuzla]") {
+  auto solver = camada::createBitwuzlaSolver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
 }

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -211,3 +211,16 @@ TEST_CASE("Nested constant tuple arrays CVC5 test", "[CVC5]") {
   auto solver = camada::createCVC5Solver();
   tuple_array_const_nested(solver);
 }
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays CVC5 test", "[CVC5]") {
+  auto solver = camada::createCVC5Solver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
+}

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -272,3 +272,16 @@ TEST_CASE("Nested constant tuple arrays MathSAT test", "[MathSAT]") {
   auto solver = camada::createMathSATSolver();
   tuple_array_const_nested(solver);
 }
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays MathSAT test", "[MathSAT]") {
+  auto solver = camada::createMathSATSolver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
+}

--- a/regression/stp.test.cpp
+++ b/regression/stp.test.cpp
@@ -139,3 +139,8 @@ TEST_CASE("SMTLIB pipeline: ack_array_tests_flat [Ackermann] [stp]",
   ack_array_tests_flat(solver);
 }
 #endif
+
+TEST_CASE("Unsupported nested constant arrays STP test", "[STP]") {
+  auto stp = camada::createSTPSolver();
+  require_abort([&]() { nested_const_array_semantics(stp); });
+}

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -78,6 +78,11 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(array_model_values);
   RESETANDTEST(const_array_model_values);
   RESETANDARGTEST(const_array_model_values, LazyArrays);
+  RESETANDTEST(lazy_array_transitive_equality);
+  RESETANDARGTEST(lazy_array_transitive_equality, LazyArrays);
+  RESETANDTEST(array_equality_witness_congruence);
+  RESETANDTEST(lazy_array_equality_reached_defaults);
+  RESETANDARGTEST(lazy_array_equality_reached_defaults, LazyArrays);
   RESETANDTEST(const_array_lowering_interop);
   RESETANDTEST(tuple_semantics);
   RESETANDTEST(tuple_with_array_field);

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -263,15 +263,22 @@ TEST_CASE("Deep tuple/array nesting Yices test", "[Yices]") {
   tuple_array_deep_nesting(solver);
 }
 
-// Nested constant tuple arrays need every per-leaf constant array to
-// nest, and lazily lowered constant arrays cannot — pin the abort.
-TEST_CASE("Unsupported nested constant tuple arrays Yices test", "[Yices]") {
+// Registered per backend: nested constant arrays now lower lazily too,
+// so the per-leaf constant arrays of a tuple-array initializer can nest.
+TEST_CASE("Nested constant tuple arrays Yices test", "[Yices]") {
   auto solver = camada::createYicesSolver();
-  require_abort([&]() {
-    auto bv4 = solver->mkBVSort(4);
-    auto init =
-        solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(5, 8)});
-    auto innerConst = solver->mkArrayConst(bv4, init);
-    (void)solver->mkArrayConst(bv4, innerConst);
-  });
+  tuple_array_const_nested(solver);
+}
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays Yices test", "[Yices]") {
+  auto solver = camada::createYicesSolver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
 }

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -238,3 +238,16 @@ TEST_CASE("Nested constant tuple arrays Z3 test", "[Z3]") {
   auto solver = camada::createZ3Solver();
   tuple_array_const_nested(solver);
 }
+
+// Registered per backend, not in tests(): array_of(array_of(v)) needs a
+// nested array sort, which STP's BV-only array theory lacks.
+TEST_CASE("Nested constant arrays Z3 test", "[Z3]") {
+  auto solver = camada::createZ3Solver();
+  nested_const_array_semantics(solver);
+  solver->reset();
+  nested_const_array_semantics(solver, camada::ConstArrayLowering::Lazy);
+  solver->reset();
+  nested_const_array_survives_pop(solver);
+  solver->reset();
+  nested_const_array_survives_pop(solver, camada::ConstArrayLowering::Lazy);
+}

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -1339,9 +1339,16 @@ bool SMTSolverImpl::reachesLazyArray(const SMTExprRef &Exp) const {
 
 SMTExprRef SMTSolverImpl::mkLazyConstArray(const SMTSortRef &IndexSort,
                                            const SMTExprRef &InitValue) {
-  fatalErrorIf(InitValue->isArraySort() && reachesLazyArray(InitValue),
-               "Lazily lowered constant arrays cannot be nested inside one "
-               "another");
+  // Nesting (array_of(array_of(v))) is supported: the outer default axiom
+  // `select(Root, i) = Init` is an ASSERTED-TRUE array equality, which
+  // instantiateLazyDefaultAt lowers without an extensionality witness —
+  // known-true polarity has no negative direction to protect, and not
+  // minting a witness per default is exactly what makes nesting terminate
+  // (a witness would be observed, firing this same root's default at a
+  // fresh index, forever). Reads of the nested value observe the inner
+  // index, firing the inner root's default there, and the asserted
+  // equality propagates it. Model extraction returns the inner lazy array
+  // as the base; the consumer re-queries it via getArrayElement.
   SMTSortRef ArraySort = mkArraySort(IndexSort, InitValue->Sort);
   SMTExprRef Root = mkSymbolUnchecked(
       "__CAMADA_lazyarr" + std::to_string(LazyConstArrayCounter++), ArraySort);
@@ -1369,7 +1376,26 @@ void SMTSolverImpl::instantiateLazyDefaultAt(const SMTExpr *RootKey,
     return;
   // Copy: the maps may rehash while the constraint is built.
   const LazyConstArrayRoot Root = LazyConstArrayRoots.at(RootKey);
-  SMTExprRef Constraint = mkEqual(mkArraySelect(Root.Root, Index), Root.Init);
+  SMTExprRef Sel = mkArraySelect(Root.Root, Index);
+  SMTExprRef Constraint;
+  if (Root.Init->isArraySort()) {
+    // Nested lazy const array: the default is an ASSERTED-TRUE array
+    // equality, so it needs no extensionality witness — there is no
+    // negative direction a model could fake. Going through the public
+    // mkEqual would mint one, whose observation re-fires this same
+    // root's default at the fresh witness, unboundedly; the direct
+    // native equality is both sound (the backend enforces it
+    // extensionally, and Init's own defaults fire at every observed
+    // inner index) and what makes nesting terminate. STP cannot build
+    // nested array sorts at all, so the non-extensional case is
+    // unreachable here.
+    fatalErrorIf(!nativeArrayExtensionality(),
+                 "Nested lazy constant arrays require native array "
+                 "extensionality");
+    Constraint = mkEqualImpl(Sel, Root.Init);
+  } else {
+    Constraint = mkEqual(Sel, Root.Init);
+  }
   addConstraint(Constraint);
   LazyConstraintLevels.back().push_back(std::move(Constraint));
 }


### PR DESCRIPTION
Re-lands the nested `array_of(array_of(v))` support from #103 (reverted in #116) with a different mechanism.

## Why #103 was unsound

Its termination fix read encoded-equality witnesses **unobserved**, pinning only the two operands' lazy defaults there. Two consequences, both verified empirically during review:

- `a=b ∧ a=c ∧ ¬(b=c)` answered **SAT** on STP (plain arrays, no lazy involved) — the disequality's witness never participated in the other equalities' congruence.
- `a=array_of(0) ∧ a=b ∧ b≠array_of(0)'` answered **SAT** on bitwuzla — `b` has no syntactic lazy roots, so nothing pinned the defaults at the witness, contradicting the sort-global instantiation argument.

It also predated #114: its `mkArraySelectUnobserved` bypassed the Ackermann dispatch and segfaulted on any array equality in that mode.

## This design

Witnesses stay observed — that is what soundness needs. The non-termination is broken at its actual source instead: the default axiom `select(root, i) = Init` is asserted with **known-true polarity**, and only an equality's negative direction needs an extensionality witness. So when `Init` is an array, the default lowers directly through `mkEqualImpl` — the backend enforces it extensionally, `Init`'s own defaults fire at every observed inner index, and no witness is minted, so nothing cascades. STP cannot build nested array sorts at all, so the non-extensional case is unreachable (guarded with a fatal error).

Net implementation: ~25 lines in `instantiateLazyDefaultAt` plus removing the nesting guard, vs #103's 119.

## Testing

- #103's nested fixtures re-applied verbatim (read-through, store-over-inner, negative direction, equality propagation, transitive equality, model round-trip, push/pop survival) — they are semantic SAT/UNSAT checks, independent of the mechanism.
- Two new regressions pinning #103's soundness holes (`array_equality_witness_congruence`, `lazy_array_equality_reached_defaults`), running on every backend — both would fail under the reverted design.
- Full suite 231/231, including all `ArrayEncoding::Ackermann` tests (lazy roots never exist in that mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3