### PR TITLE
Slim SMTExprRef/SMTSortRef: 24 bytes checked, 8 bytes opt-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+__pycache__/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Build test related commands
 option(CAMADA_ENABLE_REGRESSION "Enable regression testing" OFF)
+
+option(
+  CAMADA_CHECKED_HANDLES
+  "Runtime stale-handle detection: SMTExprRef/SMTSortRef carry a generation \
+tag (24 bytes) and abort on use after solver reset/destruction. OFF makes \
+handles a single raw pointer (8 bytes); stale use becomes undefined \
+behavior. Baked into the installed camadafeatures.h — the library and its \
+consumers must be built with the same value."
+  ON)
 if(CAMADA_ENABLE_REGRESSION)
   include(CTest)
   find_package(Catch2 3 QUIET)

--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -400,6 +400,12 @@ inline void symbol_cache_survives_push_pop(const camada::SMTSolverRef &solver) {
 
 inline void
 handle_invalidation_after_reset(const camada::SMTSolverRef &solver) {
+#if !CAMADA_CHECKED_HANDLES
+  // Unchecked handles are a raw pointer: reset cannot be detected and
+  // stale use is undefined behavior by contract.
+  (void)solver;
+  SKIP("stale-handle detection is compiled out (CAMADA_CHECKED_HANDLES=OFF)");
+#else
   auto sort = solver->mkBVSort(8);
   auto expr = solver->mkSymbol("stale", sort);
 
@@ -415,7 +421,15 @@ handle_invalidation_after_reset(const camada::SMTSolverRef &solver) {
   auto fresh_expr = solver->mkSymbol("fresh", fresh_sort);
   REQUIRE(fresh_sort.isValid());
   REQUIRE(fresh_expr.isValid());
+#endif
 }
+
+// Pin the size contract ESBMC cares about: checked handles are pointer +
+// state + generation; unchecked handles are exactly one pointer.
+static_assert(sizeof(camada::SMTExprRef) == (CAMADA_CHECKED_HANDLES ? 24 : 8),
+              "SMTExprRef size drifted from the documented layout");
+static_assert(sizeof(camada::SMTSortRef) == (CAMADA_CHECKED_HANDLES ? 24 : 8),
+              "SMTSortRef size drifted from the documented layout");
 
 inline void quantifier_semantics(const camada::SMTSolverRef &solver) {
   auto x = solver->mkSymbol("x", solver->mkBVSort(4));

--- a/scripts/cmake/camadafeatures.in
+++ b/scripts/cmake/camadafeatures.in
@@ -1,5 +1,14 @@
 /* Generated backend feature macros for Camada. */
 
+/* Runtime stale-handle detection. When 1 (the default), SMTExprRef and
+   SMTSortRef carry a generation tag (24 bytes) and dereferencing a handle
+   after the owning solver was reset or destroyed aborts with a clear
+   message. When 0, handles are a single raw pointer (8 bytes) and stale
+   use is undefined behavior. Baked in at library configure time
+   (-DCAMADA_CHECKED_HANDLES=OFF); the library and its consumers must
+   agree, which including this generated header guarantees. */
+#cmakedefine01 CAMADA_CHECKED_HANDLES
+
 #cmakedefine01 CAMADA_HAVE_BITWUZLA
 #cmakedefine01 CAMADA_HAVE_CVC5
 #cmakedefine01 CAMADA_HAVE_MATHSAT

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -95,6 +95,12 @@ if __name__ == '__main__':
         "-DCMAKE_BUILD_TYPE=Release",
         "-DCMAKE_INSTALL_PREFIX=../release/",
         "-DRELEASE_MODE=ON",
+        # Release artifacts ship lean 8-byte handles (raw pointers, old
+        # ESBMC semantics: stale use is UB). The flag is baked into the
+        # installed camadafeatures.h, so consumers of these tarballs get
+        # the matching layout automatically. Debug/CI builds keep the
+        # default checked 24-byte handles with stale-use detection.
+        "-DCAMADA_CHECKED_HANDLES=OFF",
     ]
 
     if is_windows:

--- a/src/camadahandle.h
+++ b/src/camadahandle.h
@@ -25,10 +25,9 @@
 #include <atomic>
 #include <cstdint>
 #include <limits>
-#include <memory>
-#include <utility>
 
 #include "camadacommon.h"
+#include "camadafeatures.h"
 
 namespace camada {
 
@@ -57,13 +56,26 @@ struct SMTHandleState {
   }
 };
 
+/// Allocate a handle state that lives for the rest of the process. Handles
+/// keep a raw pointer to their solver's state, so the state must stay
+/// readable even after the solver is destroyed — that is what lets a
+/// dangling handle abort with "stale" instead of reading freed memory. The
+/// cost is ~one allocation per solver ever constructed, reachable from a
+/// static registry (so leak checkers see it as still-reachable, not lost).
+SMTHandleState *makeProcessLifetimeHandleState();
+
 /// Shared implementation for public solver-owned object handles.
 ///
 /// Handles are lightweight, copyable references to objects owned by a solver's
-/// arena. They do not own the pointed-to object. Instead, they keep a shared
-/// generation state from the owning solver so dereferencing a handle after
-/// reset or destruction fails deterministically instead of reading freed arena
-/// memory.
+/// arena. They do not own the pointed-to object.
+///
+/// With CAMADA_CHECKED_HANDLES (the default) a handle also carries a pointer
+/// to the owning solver's generation state plus the generation it was created
+/// under (24 bytes total), so dereferencing it after reset or destruction
+/// fails deterministically instead of reading freed arena memory. Configured
+/// with -DCAMADA_CHECKED_HANDLES=OFF, a handle is a single raw pointer
+/// (8 bytes) and stale use is undefined behavior, exactly like a raw
+/// `const SMTExpr *`.
 ///
 /// The non-ownership invariant is load-bearing: handle destruction must not
 /// touch the pointed-to object, because cached handles inside the owning
@@ -72,13 +84,12 @@ struct SMTHandleState {
 /// (ref-counting, RAII cleanup) to this base without auditing the reset and
 /// destructor paths in SMTSolverImpl.
 
-// GCC 13+ emits a false-positive -Wmaybe-uninitialized for SMTRefBase's
-// implicitly-generated move constructor when CAMADA_ALWAYS_INLINE causes the
-// inliner to expand SMTRefBase moves through std::variant<..., SortData, ...>
-// templates deeply enough that flow analysis loses track of the source object's
-// initialized state. The data members all have NSDMIs (Generation = 0, Ptr =
-// nullptr, State = default-constructed) so the warning is bogus, but it would
-// otherwise turn into an error under -Werror. Suppress narrowly here.
+// GCC 13+ has emitted false-positive -Wmaybe-uninitialized for SMTRefBase's
+// implicitly-generated copy/move when CAMADA_ALWAYS_INLINE expands them
+// through std::variant<..., SortData, ...> templates deeply enough that flow
+// analysis loses track of the source object's initialized state. The data
+// members all have NSDMIs, so the warning is bogus, but it would otherwise
+// turn into an error under -Werror. Suppress narrowly here.
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -99,40 +110,62 @@ public:
 
   explicit operator bool() const { return isValid(); }
 
+#if CAMADA_CHECKED_HANDLES
   CAMADA_ALWAYS_INLINE bool isValid() const {
     return Ptr != nullptr && State &&
            State->Generation.load(std::memory_order_relaxed) == Generation;
   }
+#else
+  /// Unchecked mode cannot see resets: a non-null handle answers valid
+  /// even when the solver it came from is gone.
+  CAMADA_ALWAYS_INLINE bool isValid() const { return Ptr != nullptr; }
+#endif
 
 protected:
   /// Construct a live handle. Kept protected so only concrete handle wrappers
   /// can decide which solver internals are allowed to create valid handles.
-  SMTRefBase(const T *ThePtr, std::shared_ptr<const SMTHandleState> TheState,
-             uint64_t TheGeneration)
-      : Ptr(ThePtr), State(std::move(TheState)), Generation(TheGeneration) {}
+  /// The state/generation arguments are accepted (and ignored) in unchecked
+  /// mode so construction sites compile identically under both layouts.
+SMTRefBase(const T *ThePtr, const SMTHandleState *TheState,
+           uint64_t TheGeneration)
+#if CAMADA_CHECKED_HANDLES
+    : Ptr(ThePtr), State(TheState), Generation(TheGeneration){}
+#else
+      : Ptr(ThePtr) {
+    (void)TheState;
+    (void)TheGeneration;
+  }
+#endif
 
-private:
-  CAMADA_ALWAYS_INLINE void validate() const {
+      private : CAMADA_ALWAYS_INLINE void validate() const {
+#if CAMADA_CHECKED_HANDLES
     if (Ptr && State &&
         State->Generation.load(std::memory_order_relaxed) == Generation)
       return;
+#else
+    if (Ptr)
+      return;
+#endif
     reportInvalid();
   }
 
   // Cold slow path — kept out of the inlined fast path so every dereference
-  // site only pays for the hot Ptr/State/Generation check, not the three
-  // diagnostic branches.
+  // site only pays for the hot liveness check, not the diagnostic branches.
   CAMADA_COLD_NOINLINE void reportInvalid() const {
     fatalErrorIf(!Ptr, Traits::nullMessage());
+#if CAMADA_CHECKED_HANDLES
     fatalErrorIf(!State, Traits::movedFromMessage());
     fatalErrorIf(State->Generation.load(std::memory_order_relaxed) !=
                      Generation,
                  Traits::staleMessage());
+#endif
   }
 
   const T *Ptr = nullptr;
-  std::shared_ptr<const SMTHandleState> State;
+#if CAMADA_CHECKED_HANDLES
+  const SMTHandleState *State = nullptr;
   uint64_t Generation = 0;
+#endif
 };
 
 #if defined(__GNUC__) && !defined(__clang__)

--- a/src/camadahandle.h
+++ b/src/camadahandle.h
@@ -126,18 +126,23 @@ protected:
   /// can decide which solver internals are allowed to create valid handles.
   /// The state/generation arguments are accepted (and ignored) in unchecked
   /// mode so construction sites compile identically under both layouts.
-SMTRefBase(const T *ThePtr, const SMTHandleState *TheState,
-           uint64_t TheGeneration)
+  /// Each branch is a complete declaration — clang-format mis-parses a
+  /// preprocessor conditional inside a member-initializer list.
 #if CAMADA_CHECKED_HANDLES
-    : Ptr(ThePtr), State(TheState), Generation(TheGeneration){}
+  SMTRefBase(const T *ThePtr, const SMTHandleState *TheState,
+             uint64_t TheGeneration)
+      : Ptr(ThePtr), State(TheState), Generation(TheGeneration) {}
 #else
+  SMTRefBase(const T *ThePtr, const SMTHandleState *TheState,
+             uint64_t TheGeneration)
       : Ptr(ThePtr) {
     (void)TheState;
     (void)TheGeneration;
   }
 #endif
 
-      private : CAMADA_ALWAYS_INLINE void validate() const {
+private:
+  CAMADA_ALWAYS_INLINE void validate() const {
 #if CAMADA_CHECKED_HANDLES
     if (Ptr && State &&
         State->Generation.load(std::memory_order_relaxed) == Generation)

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -26,8 +26,24 @@
 #include <algorithm>
 #include <cstdio>
 #include <limits>
+#include <memory>
+#include <mutex>
 
 namespace camada {
+
+SMTHandleState *makeProcessLifetimeHandleState() {
+  // The registry itself is a deliberately immortal heap allocation: states
+  // must stay readable for the whole process (a handle can outlive its
+  // solver, and even static-storage solvers bump their state's generation
+  // during exit teardown, after any static registry would already be
+  // destroyed). It stays reachable through this static pointer, so leak
+  // checkers classify it as still-reachable rather than lost.
+  static std::mutex RegistryMutex;
+  static auto *Registry = new std::vector<std::unique_ptr<SMTHandleState>>();
+  std::lock_guard<std::mutex> Lock(RegistryMutex);
+  Registry->push_back(std::make_unique<SMTHandleState>());
+  return Registry->back().get();
+}
 
 namespace {
 

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -26,7 +26,6 @@
 #include <cassert>
 #include <cstdint>
 #include <map>
-#include <memory>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -333,8 +332,9 @@ protected:
   /// were never instantiated).
   SMTResult<ArrayModel> lazyArrayModel(const SMTExprRef &Array);
 
-  std::shared_ptr<SMTHandleState> HandleState =
-      std::make_shared<SMTHandleState>();
+  /// Process-lifetime (see makeProcessLifetimeHandleState): handles keep a
+  /// raw pointer to it, so it must stay readable after this solver dies.
+  SMTHandleState *HandleState = makeProcessLifetimeHandleState();
 
 public:
   SMTExprRef getBVZero1Expr() const;


### PR DESCRIPTION
ESBMC reported the 32-byte `SMTExprRef`/`SMTSortRef` as a regression against its old 8-byte raw `smt_ast*`. The 32 bytes were: object pointer (8) + `shared_ptr` to the solver's generation state (16) + generation snapshot (8) — the machinery that makes stale-handle use abort deterministically instead of reading freed arena memory.

## 32 → 24, no semantics change (always on)

The `shared_ptr` becomes a raw `const SMTHandleState *`. States come from a new process-lifetime registry (`makeProcessLifetimeHandleState()`): every state stays readable after its solver dies, so a dangling handle still aborts with "stale" — including solvers destroyed during exit teardown. The registry is a deliberately immortal allocation reachable from a static, so leak checkers classify it as still-reachable. Cost: one ~8-byte allocation per solver ever constructed.

Handles become **trivially copyable** — no atomic refcount per copy — which likely matters more than the 8 bytes for ESBMC's handle-heavy caches, and for camada's own term structures (SMT-LIB args, tuple elements, lazy-array maps) that store handles by value.

## 24 → 8, opt-in (`-DCAMADA_CHECKED_HANDLES=OFF`)

A new CMake option (default **ON**) compiles the detection out entirely: the handle is a single raw pointer, `isValid()` degrades to a null check, and stale use is undefined behavior — exactly the old ESBMC contract. The flag is baked into the generated-and-installed `camadafeatures.h` (now included by `camadahandle.h`), so the library and its consumers cannot disagree silently. Same philosophy as standard-library iterator debugging.

**`scripts/release.py` now ships the 8-byte configuration** — release tarball consumers get raw-pointer handles automatically; source/CI/debug builds keep the checked default.

## Testing

- `static_assert`s pin `sizeof(SMTExprRef/SMTSortRef)` to 24 (checked) / 8 (unchecked).
- `handle_invalidation_after_reset` SKIPs in unchecked mode (reset detection is compiled out by contract).
- Full suite green in **both** configurations: 225/225 checked, 225/225 unchecked.
- Benchmark comparison (master vs both modes) running; numbers to follow as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3