### PR TITLE
Return a plain BV sort from mkIEEEFPToBV on every backend

### DIFF
--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -308,6 +308,31 @@ inline void fp_bv_conversions(const camada::SMTSolverRef &solver,
   REQUIRE(solver->check() == camada::checkResult::SAT);
 }
 
+// Regression: mkIEEEFPToBV must return a PLAIN BV sort, not BVFP. The
+// native backends used to tag the bit pattern with the BVFP sort, which
+// leaked into caller sort comparisons — ESBMC's float→int bitcast
+// produced a term whose sort disagreed with its own BV type, aborting on
+// the first mkEqual against an ordinary bit-vector.
+inline void fp_ieee_bv_sort_identity(const camada::SMTSolverRef &solver,
+                                     camada::FPEncoding Encoding) {
+  auto fp = solver->mkSymbol("ibv_f", solver->mkFP32Sort(Encoding));
+  auto bits = solver->mkIEEEFPToBV(fp);
+
+  // Exactly the sort mkBVSort(32) hands out — this is what callers compare
+  // against, and BVFP would fail requireSameSort below.
+  REQUIRE(bits->Sort == solver->mkBVSort(32));
+
+  // ESBMC's bitcast pattern: equate the bit pattern with a plain BV
+  // symbol, then pin the round-trip semantics.
+  auto ibv = solver->mkSymbol("ibv_i", solver->mkBVSort(32));
+  solver->addConstraint(solver->mkEqual(bits, ibv));
+  solver->addConstraint(solver->mkEqual(fp, solver->mkFP32(1.5f, Encoding)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  auto v = solver->getBVInBin(ibv);
+  REQUIRE(v);
+  REQUIRE(v.value() == "00111111110000000000000000000000"); // 1.5f
+}
+
 inline void fp_to_signed_bv_multiple_widths(const camada::SMTSolverRef &solver,
                                             camada::FPEncoding Encoding) {
   auto fp = solver->mkFP32(42.0f, Encoding);

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -109,6 +109,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDARGTEST(fp_round_to_away, BVFP);
   RESETANDARGTEST(fp_bv_conversions, NativeFP);
   RESETANDARGTEST(fp_bv_conversions, BVFP);
+  RESETANDARGTEST(fp_ieee_bv_sort_identity, NativeFP);
+  RESETANDARGTEST(fp_ieee_bv_sort_identity, BVFP);
   RESETANDARGTEST(fp_to_signed_bv_multiple_widths, BVFP);
   RESETANDARGTEST(fp_denormal_round_to_integral, NativeFP);
   RESETANDARGTEST(fp_denormal_round_to_integral, BVFP);

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -1007,10 +1007,11 @@ SMTExprRef BitwuzlaSolver::mkBVToIEEEFPImpl(const SMTExprRef &Exp,
 
 SMTExprRef BitwuzlaSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
   const std::string name = "__CAMADA_ieeebv" + std::to_string(ToBVCounter++);
-  const SMTSortRef &to =
-      mkFPSort(Exp->Sort->getFPExponentWidth(),
-               Exp->Sort->getFPSignificandWidth(), FPEncoding::BV);
-  const SMTExprRef &newSymbol = mkSymbolUnchecked(name, to);
+  // Plain BV, not BVFP: the contract is "give me the bit pattern", and a
+  // BVFP-sorted result leaks into caller sort comparisons (a float→int
+  // bitcast would carry a BVFP sort where the caller's type says BV).
+  const SMTExprRef &newSymbol =
+      mkSymbolUnchecked(name, mkBVSort(Exp->getWidth()));
   addConstraint(mkEqual(Exp, mkBVToIEEEFP(newSymbol, Exp->Sort)));
   return newSymbol;
 }

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -2162,7 +2162,9 @@ SMTExprRef SMTSolverImpl::mkIEEEFPToBV(const SMTExprRef &Exp) {
   SMTExprRef theExp = usesBVFPEncoding(Exp)
                           ? SMTSolverImpl::mkIEEEFPToBVImpl(Exp)
                           : mkIEEEFPToBVImpl(Exp);
-  assert(theExp->isBVSort());
+  // Exactly a plain BV sort: isBVSort() also answers true for BVFP, and a
+  // BVFP-sorted result would leak into caller sort comparisons.
+  assert(theExp->Sort->getSortKind() == SMTSortKind::BV);
   assert(theExp->getWidth() == Exp->getWidth());
   return theExp;
 }

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -1193,10 +1193,11 @@ SMTExprRef CVC5Solver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
   // to bv, so we create a new symbol
   const std::string name = "__CAMADA_ieeebv" + std::to_string(ToBVCounter++);
 
-  const SMTSortRef &to =
-      mkFPSort(Exp->Sort->getFPExponentWidth(),
-               Exp->Sort->getFPSignificandWidth(), FPEncoding::BV);
-  const SMTExprRef &newSymbol = mkSymbolUnchecked(name, to);
+  // Plain BV, not BVFP: the contract is "give me the bit pattern", and a
+  // BVFP-sorted result leaks into caller sort comparisons (a float→int
+  // bitcast would carry a BVFP sort where the caller's type says BV).
+  const SMTExprRef &newSymbol =
+      mkSymbolUnchecked(name, mkBVSort(Exp->getWidth()));
 
   // and constraint it to be the conversion of the fp, since
   // (fp_matches_bv f bv) <-> (= f ((_ to_fp E S) bv))

--- a/src/mathsatsolver.cpp
+++ b/src/mathsatsolver.cpp
@@ -713,7 +713,7 @@ SMTExprRef MathSATSolver::mkFPRemImpl(const SMTExprRef &LHS,
   // We can call the conversion API directly here because the arguments were
   // already checked
   const SMTExprRef &rem =
-      SMTSolverImpl::mkFPRemImpl(mkIEEEFPToBVImpl(LHS), mkIEEEFPToBVImpl(RHS));
+      SMTSolverImpl::mkFPRemImpl(bvfpView(LHS), bvfpView(RHS));
 
   // And convert it back the right type
   SMTExprRef result = mkBVToIEEEFP(rem, LHS->Sort);
@@ -769,9 +769,8 @@ SMTExprRef MathSATSolver::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
 
   // We can call the conversion API directly here because the arguments were
   // already checked
-  const SMTExprRef &fma =
-      SMTSolverImpl::mkFPFMAImpl(mkIEEEFPToBVImpl(X), mkIEEEFPToBVImpl(Y),
-                                 mkIEEEFPToBVImpl(Z), roundingMode);
+  const SMTExprRef &fma = SMTSolverImpl::mkFPFMAImpl(bvfpView(X), bvfpView(Y),
+                                                     bvfpView(Z), roundingMode);
 
   // And convert it back the right type
   SMTExprRef result = mkBVToIEEEFP(fma, X->Sort);
@@ -1136,13 +1135,22 @@ SMTExprRef MathSATSolver::mkBVToIEEEFPImpl(const SMTExprRef &Exp,
                                toMathSATTerm(Exp)));
 }
 
-SMTExprRef MathSATSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
+SMTExprRef MathSATSolver::bvfpView(const SMTExprRef &Exp) {
   const SMTSortRef &to =
       mkFPSort(Exp->Sort->getFPExponentWidth(),
                Exp->Sort->getFPSignificandWidth(), FPEncoding::BV);
   return makeExprRef<MathSATExpr>(
       SMTExprKind::IEEEFPToBV, &Context, to,
       msat_make_fp_as_ieeebv(Context, toMathSATTerm(Exp)));
+}
+
+SMTExprRef MathSATSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
+  // Plain BV, not BVFP: msat_make_fp_as_ieeebv already returns a
+  // bit-vector term, and a BVFP-sorted wrapper leaks into caller sort
+  // comparisons (a float→int bitcast would carry a BVFP sort where the
+  // caller's type says BV).
+  return rewrapExprImpl(*bvfpView(Exp), mkBVSort(Exp->getWidth()),
+                        SMTExprKind::IEEEFPToBV);
 }
 
 SMTExprRef MathSATSolver::mkArrayConstImpl(const SMTSortRef &IndexSort,

--- a/src/mathsatsolver.h
+++ b/src/mathsatsolver.h
@@ -332,6 +332,12 @@ protected:
 
   SMTExprRef mkIEEEFPToBVImpl(const SMTExprRef &Exp) override;
 
+  /// View a native FP term as a Camada BVFP-encoded expression: the raw
+  /// IEEE bits carrying the BVFP sort, which is what the common-layer FP
+  /// bit-blasts (mkFPRemImpl, mkFPFMAImpl) operate on. Distinct from
+  /// mkIEEEFPToBVImpl, whose public contract is a PLAIN BV bit pattern.
+  SMTExprRef bvfpView(const SMTExprRef &Exp);
+
   SMTExprRef mkArrayConstImpl(const SMTSortRef &IndexSort,
                               const SMTExprRef &InitValue) override;
 

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -1071,10 +1071,12 @@ SMTExprRef Z3Solver::mkBVToIEEEFPImpl(const SMTExprRef &Exp,
 }
 
 SMTExprRef Z3Solver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
-  const SMTSortRef &to =
-      mkFPSort(Exp->Sort->getFPExponentWidth(),
-               Exp->Sort->getFPSignificandWidth(), FPEncoding::BV);
-  return makeExprRef<Z3Expr>(SMTExprKind::IEEEFPToBV, &Context, to,
+  // Plain BV, not BVFP: z3's mk_to_ieee_bv already returns a bit-vector
+  // term, and a BVFP-sorted wrapper leaks into caller sort comparisons (a
+  // float→int bitcast would carry a BVFP sort where the caller's type
+  // says BV).
+  return makeExprRef<Z3Expr>(SMTExprKind::IEEEFPToBV, &Context,
+                             mkBVSort(Exp->getWidth()),
                              toZ3Expr(Exp).mk_to_ieee_bv());
 }
 


### PR DESCRIPTION
## Problem (reported from ESBMC)

A float→int bitcast yields a term whose sort is **BVFP** while the caller's type says plain BV — the first `mkEqual` against an ordinary bit-vector aborts on `requireSameSort`.

All four native-FP backends had the same defect: `mkIEEEFPToBVImpl` tagged its result with `mkFPSort(..., FPEncoding::BV)` instead of `mkBVSort(width)`. The common BV-encoded fallback retags to plain BV (with a comment saying exactly why), and the SMT-LIB backend mints a plain-BV symbol — only the native paths leaked. The wrapper's `assert(theExp->isBVSort())` never fired because `isBVSort()` deliberately answers true for BVFP (the whole FP-over-BV machinery depends on that; the predicate answers "is a bitvector at the term level", not "is exactly the plain BV type").

## Fix

- z3 / cvc5 / bitwuzla / mathsat: result sort is `mkBVSort(Exp->getWidth())`.
- MathSAT's internal `fp.rem`/`fp.fma` bridge — where the BVFP sort **is** the point (it feeds the common bit-blast, which reads FP widths off the sort) — keeps it via a private `bvfpView()` helper, clearly separated from the public contract.
- The wrapper now asserts the exact sort kind (`SMTSortKind::BV`), so a future regression trips in Debug/CI instead of leaking.

## Testing

New `fp_ieee_bv_sort_identity` fixture (both FP encodings, every backend via `tests()`): pins `bits->Sort == mkBVSort(32)`, then reproduces ESBMC's bitcast pattern — equate the bit pattern with a plain BV symbol and check the IEEE bits of 1.5f round-trip. Verified to fail against the unfixed Z3 impl (478/479) and pass fixed. Full suite 231/231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3