### PR TITLE
Fix SIGSEGV in Bitwuzla dumpModel over Camada-owned symbols

### DIFF
--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -492,6 +492,20 @@ inline void dump_string_semantics(const camada::SMTSolverRef &solver) {
   solver->dumpModel(model_dump);
   REQUIRE(!model_dump.empty());
   REQUIRE(model_dump != "seed");
+
+  // Regression: dumpModel with Camada-owned symbols in the symbol cache
+  // (encoded tuples on backends without native datatypes carry no backend
+  // term). Bitwuzla's model dump used to cast every cache entry to its
+  // native expression type and SIGSEGV on the tuple node.
+  solver->reset();
+  auto tup = solver->mkSymbol(
+      "dmt", solver->mkTupleSort({solver->mkBVSort(8), solver->mkBoolSort()}));
+  solver->addConstraint(solver->mkEqual(solver->mkTupleSelect(tup, 0),
+                                        solver->mkBVFromDec(7, 8)));
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+  std::string tuple_model_dump = "seed";
+  solver->dumpModel(tuple_model_dump);
+  REQUIRE(tuple_model_dump != "seed");
 }
 
 inline void int_arithmetic_semantics(const camada::SMTSolverRef &solver) {

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -1129,9 +1129,22 @@ void BitwuzlaSolver::dumpImpl(std::string &Out) {
 void BitwuzlaSolver::dumpModelImpl(std::string &Out) {
   Out.clear();
   for (const auto &entry : SymbolExprCache) {
-    const BitwuzlaTerm term = toSolverExpr<BitwExpr>(*entry.second).Expr;
+    // The symbol cache also holds Camada-owned nodes (encoded tuples,
+    // tuple-array bundles, Ackermann arrays) that carry no bitwuzla term
+    // at all — casting one yields a garbage term and a SIGSEGV inside
+    // bitwuzla. Skip them: their backing per-field/per-read backend
+    // symbols are separate cache entries and print on their own.
+    const auto *BE = dynamic_cast<const BitwExpr *>(entry.second.get());
+    if (BE == nullptr)
+      continue;
+    const BitwuzlaTerm term = BE->Expr;
+    // A term without a symbol has nothing to name in a define-fun (and
+    // appending a null char* to std::string is undefined behavior).
+    const char *Symbol = bitwuzla_term_get_symbol(term);
+    if (Symbol == nullptr)
+      continue;
     Out += "(define-fun ";
-    Out += bitwuzla_term_get_symbol(term);
+    Out += Symbol;
     Out += " () ";
     Out += bitwuzla_sort_to_string(bitwuzla_term_get_sort(term));
     Out += " ";


### PR DESCRIPTION
## Problem (reported from ESBMC)

SIGSEGV inside camada at `bitwuzlasolver.cpp:1135`: `Out += bitwuzla_term_get_symbol(term)` in `dumpModelImpl`.

The reported line is where it detonates, but the root cause is one step earlier: `dumpModelImpl` iterates `SymbolExprCache` and `static_cast`s **every** entry to `BitwExpr`. On bitwuzla, tuple symbols are Camada-owned `CamadaTupleExpr` nodes (no backend term at all) that live in the same cache — the cast yields a garbage `BitwuzlaTerm` and `bitwuzla_term_get_symbol` crashes dereferencing it. Reproduced deterministically: bitwuzla + one tuple symbol + `check()` + `dumpModel()` → SIGSEGV. Tuple-array bundles and Ackermann array nodes hit the same path.

The literally-reported hazard is real too: for a genuine term without a symbol, `get_symbol` returns null and `std::string::operator+=(const char*)` on null is UB.

## Fix

Skip non-`BitwExpr` cache entries (`dynamic_cast`) — their backing per-field/per-read backend symbols are separate cache entries and print on their own — and skip symbol-less terms. Bitwuzla is the only backend that hand-rolls its model dump from the symbol cache; the rest use their solver's native model printer and are unaffected.

## Testing

The `dump_string_semantics` fixture now ends with a tuple-symbol `dumpModel` on every backend. Verified to SIGSEGV against the unfixed code (Catch2 fatal-signal: 362/363) and pass fixed. Full suite 231/231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3