### PR TITLE
Bit-exact mkIEEEFPToBV where provenance is known

### DIFF
--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -308,6 +308,79 @@ inline void fp_bv_conversions(const camada::SMTSolverRef &solver,
   REQUIRE(solver->check() == camada::checkResult::SAT);
 }
 
+// Regression for the ESBMC fp.to_ieee_bv round-trip report: bit-exact
+// fp<->bv correspondence wherever camada can prove the bits.
+inline void fp_ieee_bv_bitexact_roundtrip(const camada::SMTSolverRef &solver,
+                                          camada::FPEncoding Encoding) {
+  auto fp32 = [&]() { return solver->mkFP32Sort(Encoding); };
+  auto bv32 = [&]() { return solver->mkBVSort(32); };
+
+  // 1. Direct round-trip is exact for EVERY pattern, NaN payloads
+  // included: bits(to_fp(b)) == b universally. fp.to_ieee_bv alone cannot
+  // provide this (it is underspecified at NaN); the provenance shadow
+  // makes it a term-level identity.
+  {
+    auto b = solver->mkSymbol("rt_b", bv32());
+    auto f = solver->mkBVToIEEEFP(b, fp32());
+    solver->addConstraint(
+        solver->mkNot(solver->mkEqual(solver->mkIEEEFPToBV(f), b)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
+  solver->reset();
+
+  // 2. ESBMC's byte-write laundering chain: an uninitialized float
+  // written byte-by-byte (0x40490FDB, little-endian), each step
+  // round-tripping the partial state through the FP sort via a fresh SSA
+  // symbol tied by an asserted equality. Before the shadow, any
+  // partial-write state encoding NaN let the solver discard the bytes
+  // already written; the final byte read must nevertheless be exact.
+  {
+    auto byteAt = [&](const camada::SMTExprRef &bits, unsigned lo) {
+      return solver->mkBVExtract(lo + 7, lo, bits);
+    };
+    const uint64_t Bytes[4] = {0xDB, 0x0F, 0x49, 0x40};
+    auto f = solver->mkSymbol("lc_f0", fp32());
+    for (unsigned i = 0; i < 4; ++i) {
+      auto bits = solver->mkIEEEFPToBV(f);
+      auto wr = solver->mkBVFromDec(static_cast<int64_t>(Bytes[i]), 8);
+      // Rebuild the 32-bit pattern with byte i replaced.
+      camada::SMTExprRef nbits;
+      if (i == 0)
+        nbits = solver->mkBVConcat(solver->mkBVExtract(31, 8, bits), wr);
+      else if (i == 3)
+        nbits = solver->mkBVConcat(wr, solver->mkBVExtract(23, 0, bits));
+      else
+        nbits = solver->mkBVConcat(
+            solver->mkBVConcat(solver->mkBVExtract(31, 8 * (i + 1), bits), wr),
+            solver->mkBVExtract(8 * i - 1, 0, bits));
+      auto next = solver->mkSymbol("lc_f" + std::to_string(i + 1), fp32());
+      solver->addConstraint(
+          solver->mkEqual(solver->mkBVToIEEEFP(nbits, fp32()), next));
+      f = next;
+    }
+    auto finalBits = solver->mkIEEEFPToBV(f);
+    solver->addConstraint(solver->mkNot(
+        solver->mkEqual(byteAt(finalBits, 0), solver->mkBVFromDec(0xDB, 8))));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
+  solver->reset();
+
+  // 3. Assert-derived provenance dies with its push scope: after the
+  // tying equality is popped, the bits are unconstrained again, so a
+  // divergent pattern must be satisfiable.
+  {
+    auto g = solver->mkSymbol("sc_g", fp32());
+    auto pat = solver->mkBVFromDec(0x40490FDB, 32);
+    solver->push();
+    solver->addConstraint(
+        solver->mkEqual(g, solver->mkBVToIEEEFP(pat, fp32())));
+    solver->pop();
+    solver->addConstraint(
+        solver->mkNot(solver->mkEqual(solver->mkIEEEFPToBV(g), pat)));
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+}
+
 // Regression: mkIEEEFPToBV must return a PLAIN BV sort, not BVFP. The
 // native backends used to tag the bit pattern with the BVFP sort, which
 // leaked into caller sort comparisons — ESBMC's float→int bitcast

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -111,6 +111,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDARGTEST(fp_bv_conversions, BVFP);
   RESETANDARGTEST(fp_ieee_bv_sort_identity, NativeFP);
   RESETANDARGTEST(fp_ieee_bv_sort_identity, BVFP);
+  RESETANDARGTEST(fp_ieee_bv_bitexact_roundtrip, NativeFP);
+  RESETANDARGTEST(fp_ieee_bv_bitexact_roundtrip, BVFP);
   RESETANDARGTEST(fp_to_signed_bv_multiple_widths, BVFP);
   RESETANDARGTEST(fp_denormal_round_to_integral, NativeFP);
   RESETANDARGTEST(fp_denormal_round_to_integral, BVFP);

--- a/src/camada.h
+++ b/src/camada.h
@@ -1017,13 +1017,33 @@ public:
 
   /// Reinterpret a floating-point as a bitvector, using the IEEE format.
   ///
+  /// NaN caveat: the underlying operation (fp.to_ieee_bv) is
+  /// underspecified for NaN inputs — the FP sort has a single NaN value
+  /// while the bit-vector encoding has many NaN patterns, so no function
+  /// out of the sort can recover which pattern produced a NaN, and a
+  /// backend may answer with any of them. Camada compensates where it can
+  /// PROVE the bits: when Exp was built by mkBVToIEEEFP or an FP-constant
+  /// constructor, or a top-level asserted equality ties it to such a
+  /// term, the original bit pattern is returned exactly (a term-level
+  /// rewrite, uniform across backends, exact for round-trips like
+  /// byte-level memory models). The trade: with that rewrite the result
+  /// is a function of the TERM's provenance, not only of the FP value —
+  /// two value-equal NaN terms may report different patterns, which is
+  /// C's memory semantics rather than SMT-LIB's functional one.
+  ///
+  /// IMPORTANT: a term whose provenance camada cannot prove falls back to
+  /// the underspecified backend operation SILENTLY — there is no
+  /// diagnostic. Callers that need unconditional bit-exactness must use
+  /// FPEncoding::BV, where FP values ARE their bit patterns.
+  ///
   /// Scope caveat: bitwuzla, cvc5, and the SMT-LIB pipeline backend implement
-  /// this by materializing a fresh BV symbol and binding it to the FP value
-  /// through an asserted equality. That equality is tied to the current
+  /// the fallback by materializing a fresh BV symbol and binding it to the FP
+  /// value through an asserted equality. That equality is tied to the current
   /// (push) level, so the returned bitvector is only meaningful at the
   /// nesting level where this method was called — using it after a (pop)
   /// that crosses the call site leaves the result effectively unconstrained.
-  /// Z3's native backend uses fp.to_ieee_bv directly and is not affected.
+  /// (Provenance-derived results are immune: nothing is asserted for them.
+  /// Assert-derived provenance itself dies with its scope on pop.)
   virtual SMTExprRef mkIEEEFPToBV(const SMTExprRef &Exp) = 0;
 
   /// Check if the constraints are satisfiable

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -279,6 +279,9 @@ void SMTSolverImpl::clearExprCaches() {
   ArrayEqualCongruenceDone.clear();
   AckArrayRoots.clear();
   AckBVConstBits.clear();
+  IEEEBVShadow.clear();
+  PendingShadowLinks.clear();
+  ShadowScopeLevels.assign(1, {});
   invalidateUnsatAssumptions();
 }
 
@@ -563,7 +566,18 @@ SMTSortRef SMTSolverImpl::mkFunctionSortImpl(const std::vector<SMTSortRef> &,
 void SMTSolverImpl::addConstraint(const SMTExprRef &Exp) {
   requireBoolSort(Exp, "Expected boolean constraint");
   invalidateUnsatAssumptions();
+  commitShadowLink(Exp);
   return addConstraintImpl(Exp);
+}
+
+void SMTSolverImpl::commitShadowLink(const SMTExprRef &Constraint) {
+  auto It = PendingShadowLinks.find(&*Constraint);
+  if (It == PendingShadowLinks.end())
+    return;
+  // Keep the first (outermost) entry on collision so a pop cannot erase a
+  // fact established in an outer scope; only journal what was inserted.
+  if (IEEEBVShadow.emplace(It->second.Target, It->second.Bits).second)
+    ShadowScopeLevels.back().push_back(It->second.Target);
 }
 
 #define CAMADA_DEFINE_SIMPLE_BINARY_WRAPPER(ReturnType, Name, SortAssert,      \
@@ -794,6 +808,19 @@ SMTExprRef SMTSolverImpl::mkEqual(const SMTExprRef &LHS,
   }
   SMTExprRef theExp = mkEqualImpl(LHS, RHS);
   assert(theExp->isBoolSort());
+  // Native-FP equality with exactly one shadowed side: if this equality
+  // gets asserted top-level, the other side provably carries the same
+  // bits (see IEEEBVShadow; commit happens in addConstraint).
+  if (LHS->isFPSort() && !usesBVFPEncoding(LHS)) {
+    auto L = IEEEBVShadow.find(&*LHS);
+    auto R = IEEEBVShadow.find(&*RHS);
+    const bool HasL = L != IEEEBVShadow.end();
+    const bool HasR = R != IEEEBVShadow.end();
+    if (HasL != HasR)
+      PendingShadowLinks.emplace(
+          &*theExp, PendingShadowLink{HasL ? &*RHS : &*LHS,
+                                      HasL ? L->second : R->second});
+  }
   return theExp;
 }
 CAMADA_DEFINE_SIMPLE_BINARY_WRAPPER(SMTExprRef, mkImplies,
@@ -2029,6 +2056,12 @@ SMTExprRef SMTSolverImpl::mkFPFromBin(const std::string &FP, unsigned EWidth,
                           : mkFPFromBinImpl(FP, EWidth);
   assert(theExp->isFPSort());
   assert(theExp->getWidth() == FP.length());
+  // The bits of a native-FP constant are known here and nowhere else;
+  // remember them so mkIEEEFPToBV round-trips exactly, NaN payloads
+  // included (see IEEEBVShadow).
+  if (!usesBVFPEncoding(Sort))
+    IEEEBVShadow.emplace(&*theExp,
+                         mkBVFromBin(FP, static_cast<unsigned>(FP.length())));
   FPConstExprCache.emplace(std::move(Key), theExp);
   return theExp;
 }
@@ -2154,11 +2187,26 @@ SMTExprRef SMTSolverImpl::mkBVToIEEEFP(const SMTExprRef &Exp,
                           : mkBVToIEEEFPImpl(Exp, To);
   assert(theExp->isFPSort());
   assert(theExp->getWidth() == Exp->getWidth());
+  // Remember the bits this native-FP term was built from, so a later
+  // mkIEEEFPToBV round-trips exactly (see IEEEBVShadow). BV-encoded FP is
+  // already exact (the base mkIEEEFPToBVImpl retags the same term), and
+  // only a plain-BV source can be handed back by mkIEEEFPToBV.
+  if (!usesBVFPEncoding(To) && Exp->Sort->getSortKind() == SMTSortKind::BV)
+    IEEEBVShadow.emplace(&*theExp, Exp);
   return theExp;
 }
 
 SMTExprRef SMTSolverImpl::mkIEEEFPToBV(const SMTExprRef &Exp) {
   requireFPSort(Exp, "Expected floating-point expression");
+  // Bit-exact where provenance is known: if this term was built from bits
+  // (or an asserted equality ties it to one that was), hand the original
+  // bits back instead of asking the backend — fp.to_ieee_bv is
+  // underspecified at NaN and a backend may otherwise answer with any NaN
+  // pattern. See IEEEBVShadow. Terms with no provable provenance fall
+  // back to the underspecified operation SILENTLY; callers that need
+  // unconditional bit-exactness must use FPEncoding::BV.
+  if (auto It = IEEEBVShadow.find(&*Exp); It != IEEEBVShadow.end())
+    return It->second;
   SMTExprRef theExp = usesBVFPEncoding(Exp)
                           ? SMTSolverImpl::mkIEEEFPToBVImpl(Exp)
                           : mkIEEEFPToBVImpl(Exp);
@@ -2270,6 +2318,7 @@ void SMTSolverImpl::reset() {
 void SMTSolverImpl::push(unsigned nscopes) {
   invalidateUnsatAssumptions();
   LazyConstraintLevels.resize(LazyConstraintLevels.size() + nscopes);
+  ShadowScopeLevels.resize(ShadowScopeLevels.size() + nscopes);
   pushImpl(nscopes);
 }
 
@@ -2285,6 +2334,14 @@ void SMTSolverImpl::pop(unsigned nscopes) {
     Reassert.insert(Reassert.end(), std::make_move_iterator(Level.begin()),
                     std::make_move_iterator(Level.end()));
     LazyConstraintLevels.pop_back();
+  }
+  // Assert-derived bit-pattern shadows die with their scope: the tying
+  // equality is retracted by the pop, and keeping the bits without it
+  // would let mkIEEEFPToBV claim facts no longer asserted.
+  for (unsigned I = 0; I < nscopes && ShadowScopeLevels.size() > 1; ++I) {
+    for (const SMTExpr *Key : ShadowScopeLevels.back())
+      IEEEBVShadow.erase(Key);
+    ShadowScopeLevels.pop_back();
   }
   popImpl(nscopes);
   for (SMTExprRef &Constraint : Reassert) {

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -284,6 +284,37 @@ protected:
   SMTResult<ArrayModel> ackArrayModel(const SMTExprRef &Array);
   void noteAckBVConstBits(const SMTExprRef &Exp, const std::string &Bits);
 
+  // --- IEEE bit-pattern shadow for mkIEEEFPToBV ---
+  // fp.to_ieee_bv is underspecified at NaN: the FP sort has one NaN value
+  // while the encoding has millions of NaN patterns, so no function out
+  // of the sort can recover which pattern produced a NaN, and a backend
+  // may answer with any of them. That is unsound for callers that need
+  // bit-exact fp<->bv round-trips (byte-level memory models). Where
+  // camada can PROVE the bits — the FP term was built by mkBVToIEEEFP or
+  // mkFPFromBin, or a top-level asserted equality ties it to such a term
+  // — mkIEEEFPToBV returns the original bits instead of asking the
+  // backend. This is a term-level rewrite, not a constraint: nothing is
+  // asserted, so it composes with push/pop and every backend uniformly.
+  //
+  // Provenance entries (terms camada itself built from bits) are
+  // scope-independent identity facts. Entries derived from asserted
+  // equalities die with their push scope: the tying constraint is
+  // retracted by pop(), and keeping the bits without it could conjure
+  // contradictions out of thin air.
+  std::unordered_map<const SMTExpr *, SMTExprRef> IEEEBVShadow;
+  // mkEqual results pairing a native-FP term with a shadowed counterpart;
+  // the shadow commits only if the equality is actually asserted
+  // top-level (a negated or embedded equality proves nothing).
+  struct PendingShadowLink {
+    const SMTExpr *Target;
+    SMTExprRef Bits;
+  };
+  std::unordered_map<const SMTExpr *, PendingShadowLink> PendingShadowLinks;
+  // Scope journal for assert-derived entries: pop() erases them — the
+  // opposite of LazyConstraintLevels' re-assert, deliberately.
+  std::vector<std::vector<const SMTExpr *>> ShadowScopeLevels{1};
+  void commitShadowLink(const SMTExprRef &Constraint);
+
   /// Lower a constant array as a fresh backend array symbol whose
   /// "every element equals InitValue" semantics are enforced lazily: the
   /// default axiom is instantiated at each index term the formula observes


### PR DESCRIPTION
## Problem (ESBMC report: fp.to_ieee_bv round-trips lose the bit pattern)

`fp.to_ieee_bv` is underspecified at NaN — the FP sort has one NaN value, the encoding has millions of patterns, so no function out of the sort can recover which pattern produced a NaN. The report's repro fails for a subtler reason than the final value being NaN: ESBMC's memcpy writes floats **byte by byte**, round-tripping each *partial-write state* through the FP sort (`bytes → to_fp → SSA symbol → to_ieee_bv → next byte`). An uninitialized float's partial states can encode NaN, at which point the next round-trip lets the solver discard the bytes already written — the countermodel's `f = -INFINITY` is one such intermediate. Z3's native primitive and the fresh-symbol backends fail identically; this is the operation's semantics, not an implementation slip.

## Fix: an IEEE bit-pattern shadow

Where camada can *prove* the bits, `mkIEEEFPToBV` returns them exactly instead of asking the backend:

- `mkBVToIEEEFP(bv, ...)` and `mkFPFromBin` (native-FP) remember the source bits against the produced term;
- a **top-level asserted equality** tying an FP term to a shadowed one propagates the bits (recorded at `mkEqual`, committed only at `addConstraint` — a negated or embedded equality proves nothing);
- assert-derived entries **die with their push scope** (the tying constraint is retracted by pop; keeping the bits would conjure facts out of thin air), while provenance entries for terms camada itself built are scope-independent identities.

It's a term-level rewrite — nothing is asserted, uniform across all backends. The semantic trade is documented on the API: the result becomes a function of the term's *provenance*, not only its FP value (C's memory semantics rather than SMT-LIB's functional one).

**Recorded reservation** (in the docstring): bit-exactness is contingent on provenance camada can prove. A future caller pattern that launders a float through anything other than these forms falls back to the underspecified operation **silently, with no diagnostic**. That is an argument for eventually moving ESBMC's byte-level memory model off the per-byte FP round-trip entirely; this PR should not be read as closing that issue.

## Validation

- New `fp_ieee_bv_bitexact_roundtrip` fixture (both encodings, every backend): universal `bits(to_fp(b)) == b` (NaN payloads included), the exact ESBMC byte-write laundering chain, and the scope-death case. Without the shadow it fails on **both** mechanisms — bitwuzla's fresh-symbol tie and Z3's native `fp.to_ieee_bv` (485/486 and 486/487 respectively).
- End-to-end: rebuilt ESBMC against the patched camada — the report's repro and its self-contradiction variant both flip to **VERIFICATION SUCCESSFUL** on bitwuzla (default) and `--z3`.
- Full suite 231/231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3