### PR TITLE
Emulate fp->bv as an uninterpreted function on bitwuzla/cvc5/smtlib

### DIFF
--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -381,6 +381,52 @@ inline void fp_ieee_bv_bitexact_roundtrip(const camada::SMTSolverRef &solver,
   }
 }
 
+// Regression for the second ESBMC fp.to_ieee_bv report
+// (github_3719_4-nondet): mkIEEEFPToBV must be functionally consistent —
+// value-equal FP terms report equal bits, matching z3's native
+// primitive. The fresh-symbol emulation minted unrelated constants per
+// call, so an equality asserted BEFORE either side had provenance left
+// the two symbols free to diverge at NaN.
+inline void fp_ieee_bv_consistency(const camada::SMTSolverRef &solver,
+                                   camada::FPEncoding Encoding) {
+  auto fp32 = [&]() { return solver->mkFP32Sort(Encoding); };
+
+  // 1. Equality-before-provenance: two plain FP symbols asserted equal
+  // before any fp->bv conversion exists must report equal bits, NaN
+  // included.
+  {
+    auto y = solver->mkSymbol("cy", fp32());
+    auto z = solver->mkSymbol("cz", fp32());
+    solver->addConstraint(solver->mkEqual(y, z));
+    auto by = solver->mkIEEEFPToBV(y);
+    auto bz = solver->mkIEEEFPToBV(z);
+    solver->addConstraint(solver->mkNot(solver->mkEqual(by, bz)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
+  solver->reset();
+
+  // 2. Repeated reads of one term cannot diverge.
+  {
+    auto f = solver->mkSymbol("cf", fp32());
+    auto b1 = solver->mkIEEEFPToBV(f);
+    auto b2 = solver->mkIEEEFPToBV(f);
+    solver->addConstraint(solver->mkNot(solver->mkEqual(b1, b2)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
+  solver->reset();
+
+  // 3. Exactness where the encoding is injective: a non-NaN value's bits
+  // are fully determined.
+  {
+    auto f = solver->mkSymbol("cg", fp32());
+    solver->addConstraint(solver->mkEqual(f, solver->mkFP32(1.5f, Encoding)));
+    auto bits = solver->mkIEEEFPToBV(f);
+    solver->addConstraint(solver->mkNot(
+        solver->mkEqual(bits, solver->mkBVFromDec(0x3FC00000, 32))));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
+}
+
 // Regression: mkIEEEFPToBV must return a PLAIN BV sort, not BVFP. The
 // native backends used to tag the bit pattern with the BVFP sort, which
 // leaked into caller sort comparisons — ESBMC's float→int bitcast

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -113,6 +113,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDARGTEST(fp_ieee_bv_sort_identity, BVFP);
   RESETANDARGTEST(fp_ieee_bv_bitexact_roundtrip, NativeFP);
   RESETANDARGTEST(fp_ieee_bv_bitexact_roundtrip, BVFP);
+  RESETANDARGTEST(fp_ieee_bv_consistency, NativeFP);
+  RESETANDARGTEST(fp_ieee_bv_consistency, BVFP);
   RESETANDARGTEST(fp_to_signed_bv_multiple_widths, BVFP);
   RESETANDARGTEST(fp_denormal_round_to_integral, NativeFP);
   RESETANDARGTEST(fp_denormal_round_to_integral, BVFP);

--- a/src/bitwuzlasolver.cpp
+++ b/src/bitwuzlasolver.cpp
@@ -1006,14 +1006,9 @@ SMTExprRef BitwuzlaSolver::mkBVToIEEEFPImpl(const SMTExprRef &Exp,
 }
 
 SMTExprRef BitwuzlaSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
-  const std::string name = "__CAMADA_ieeebv" + std::to_string(ToBVCounter++);
-  // Plain BV, not BVFP: the contract is "give me the bit pattern", and a
-  // BVFP-sorted result leaks into caller sort comparisons (a float→int
-  // bitcast would carry a BVFP sort where the caller's type says BV).
-  const SMTExprRef &newSymbol =
-      mkSymbolUnchecked(name, mkBVSort(Exp->getWidth()));
-  addConstraint(mkEqual(Exp, mkBVToIEEEFP(newSymbol, Exp->Sort)));
-  return newSymbol;
+  // No native fp->bv primitive: emulate it as an uninterpreted function
+  // so equal FP values report equal bits (see mkIEEEFPToBVViaUF).
+  return mkIEEEFPToBVViaUF(Exp);
 }
 
 bool BitwuzlaSolver::supportsImpl(SolverFeature Feature) const {

--- a/src/bitwuzlasolver.h
+++ b/src/bitwuzlasolver.h
@@ -74,7 +74,6 @@ protected:
   BitwuzlaContextRef context() const { return Context; }
   BitwuzlaOptions *options() const { return Options; }
   BitwuzlaTermManager *termManager() const { return TermManager; }
-  uint64_t ToBVCounter = 0;
 
   void initializeContext();
   void destroyContext();

--- a/src/camada.h
+++ b/src/camada.h
@@ -1036,14 +1036,14 @@ public:
   /// diagnostic. Callers that need unconditional bit-exactness must use
   /// FPEncoding::BV, where FP values ARE their bit patterns.
   ///
-  /// Scope caveat: bitwuzla, cvc5, and the SMT-LIB pipeline backend implement
-  /// the fallback by materializing a fresh BV symbol and binding it to the FP
-  /// value through an asserted equality. That equality is tied to the current
-  /// (push) level, so the returned bitvector is only meaningful at the
-  /// nesting level where this method was called — using it after a (pop)
-  /// that crosses the call site leaves the result effectively unconstrained.
-  /// (Provenance-derived results are immune: nothing is asserted for them.
-  /// Assert-derived provenance itself dies with its scope on pop.)
+  /// The fallback is nevertheless FUNCTIONALLY CONSISTENT on every
+  /// backend: value-equal FP terms report equal bits. Z3 and MathSAT get
+  /// this from their native fp->bv primitives; backends without one
+  /// (bitwuzla, cvc5, the SMT-LIB pipeline) emulate the primitive as a
+  /// per-sort uninterpreted function tied per-term by `to_fp(fn(x)) == x`,
+  /// so functional congruence provides the same guarantee. The tie is a
+  /// definitional fact re-asserted across (pop), so the result stays
+  /// meaningful at any nesting level.
   virtual SMTExprRef mkIEEEFPToBV(const SMTExprRef &Exp) = 0;
 
   /// Check if the constraints are satisfiable

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -282,6 +282,8 @@ void SMTSolverImpl::clearExprCaches() {
   IEEEBVShadow.clear();
   PendingShadowLinks.clear();
   ShadowScopeLevels.assign(1, {});
+  IEEEBVFnCache.clear();
+  IEEEBVAppCache.clear();
   invalidateUnsatAssumptions();
 }
 
@@ -2194,6 +2196,30 @@ SMTExprRef SMTSolverImpl::mkBVToIEEEFP(const SMTExprRef &Exp,
   if (!usesBVFPEncoding(To) && Exp->Sort->getSortKind() == SMTSortKind::BV)
     IEEEBVShadow.emplace(&*theExp, Exp);
   return theExp;
+}
+
+SMTExprRef SMTSolverImpl::mkIEEEFPToBVViaUF(const SMTExprRef &Exp) {
+  // Emulate the fp->bv primitive as a per-sort uninterpreted FUNCTION,
+  // not a per-call constant: functional congruence then forces
+  // value-equal terms to report equal bits, the same guarantee z3's
+  // native fp.to_ieee_bv provides. The per-term tie `to_fp(fn(x)) == x`
+  // pins the exact bits wherever the encoding is injective (everything
+  // but NaN); at NaN the payload is unspecified but consistent. The tie
+  // is a definitional, scope-independent fact — journal it so pop()
+  // re-asserts it, keeping the application memo valid across scopes.
+  if (auto It = IEEEBVAppCache.find(&*Exp); It != IEEEBVAppCache.end())
+    return It->second;
+  auto [FnIt, Inserted] = IEEEBVFnCache.try_emplace(&*Exp->Sort);
+  if (Inserted)
+    FnIt->second = mkSymbolUnchecked(
+        "__CAMADA_ieeebv_fn" + std::to_string(IEEEBVFnCache.size() - 1),
+        mkFunctionSort({Exp->Sort}, mkBVSort(Exp->getWidth())));
+  SMTExprRef Bits = mkApply(FnIt->second, {Exp});
+  IEEEBVAppCache.emplace(&*Exp, Bits);
+  SMTExprRef Tie = mkEqual(mkBVToIEEEFP(Bits, Exp->Sort), Exp);
+  addConstraint(Tie);
+  LazyConstraintLevels.back().push_back(std::move(Tie));
+  return Bits;
 }
 
 SMTExprRef SMTSolverImpl::mkIEEEFPToBV(const SMTExprRef &Exp) {

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -315,6 +315,21 @@ protected:
   std::vector<std::vector<const SMTExpr *>> ShadowScopeLevels{1};
   void commitShadowLink(const SMTExprRef &Constraint);
 
+  // --- IEEE bits function for backends without a native fp->bv ---
+  // The old emulation minted a fresh constant per call, so two FP terms
+  // asserted equal could report different bit patterns (the equality may
+  // arrive before either side has shadow provenance, and to_fp is
+  // many-to-one at NaN, so the inverse ties constrain nothing). Emulate
+  // the FUNCTION instead: one uninterpreted function per FP sort, applied
+  // to the term, tied per-term by `to_fp(fn(x)) == x`. Functional
+  // congruence then makes value-equal terms agree by construction — the
+  // same guarantee z3's native primitive has. The tie is a definitional,
+  // scope-independent fact, journaled in LazyConstraintLevels so pop()
+  // re-asserts it; applications are memoized per term.
+  std::unordered_map<const SMTSort *, SMTExprRef> IEEEBVFnCache;
+  std::unordered_map<const SMTExpr *, SMTExprRef> IEEEBVAppCache;
+  SMTExprRef mkIEEEFPToBVViaUF(const SMTExprRef &Exp);
+
   /// Lower a constant array as a fresh backend array symbol whose
   /// "every element equals InitValue" semantics are enforced lazily: the
   /// default axiom is instantiated at each index term the formula observes

--- a/src/cvc5solver.cpp
+++ b/src/cvc5solver.cpp
@@ -1189,22 +1189,9 @@ SMTExprRef CVC5Solver::mkBVToIEEEFPImpl(const SMTExprRef &Exp,
 }
 
 SMTExprRef CVC5Solver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
-  // CVC5 does not provide a direct way to convert from fp
-  // to bv, so we create a new symbol
-  const std::string name = "__CAMADA_ieeebv" + std::to_string(ToBVCounter++);
-
-  // Plain BV, not BVFP: the contract is "give me the bit pattern", and a
-  // BVFP-sorted result leaks into caller sort comparisons (a float→int
-  // bitcast would carry a BVFP sort where the caller's type says BV).
-  const SMTExprRef &newSymbol =
-      mkSymbolUnchecked(name, mkBVSort(Exp->getWidth()));
-
-  // and constraint it to be the conversion of the fp, since
-  // (fp_matches_bv f bv) <-> (= f ((_ to_fp E S) bv))
-  addConstraint(mkEqual(Exp, mkBVToIEEEFP(newSymbol, Exp->Sort)));
-
-  // NewSymbol is the resulting bitvector
-  return newSymbol;
+  // No native fp->bv primitive: emulate it as an uninterpreted function
+  // so equal FP values report equal bits (see mkIEEEFPToBVViaUF).
+  return mkIEEEFPToBVViaUF(Exp);
 }
 
 SMTExprRef CVC5Solver::mkArrayConstImpl(const SMTSortRef &IndexSort,

--- a/src/cvc5solver.h
+++ b/src/cvc5solver.h
@@ -396,7 +396,6 @@ protected:
 private:
   cvc5::TermManager Terms;
   cvc5::Solver Context;
-  unsigned int ToBVCounter = 0;
 
 }; // end class CVC5Solver
 

--- a/src/smtlibsolver.cpp
+++ b/src/smtlibsolver.cpp
@@ -1590,15 +1590,10 @@ SMTExprRef SMTLIBSolver::mkBVToIEEEFPImpl(const SMTExprRef &Exp,
 }
 
 SMTExprRef SMTLIBSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
-  // Same trick as the cvc5 backend: SMT-LIB has no direct fp→bv that
-  // preserves the IEEE bit pattern, so introduce a fresh BV symbol and tie it
-  // back via the inverse direction.
-  const std::string Name = "__CAMADA_ieeebv" + std::to_string(NextIEEEBVId++);
-  SMTSortRef BVSort = mkBVSort(Exp->Sort->getFPExponentWidth() +
-                               Exp->Sort->getFPSignificandWidth() + 1);
-  SMTExprRef NewSymbol = mkSymbolUnchecked(Name, BVSort);
-  addConstraint(mkEqual(Exp, mkBVToIEEEFP(NewSymbol, Exp->Sort)));
-  return NewSymbol;
+  // SMT-LIB has no portable fp->bv that preserves the IEEE bit pattern:
+  // emulate it as an uninterpreted function so equal FP values report
+  // equal bits (see mkIEEEFPToBVViaUF).
+  return mkIEEEFPToBVViaUF(Exp);
 }
 
 // --- Int / Real literals + arithmetic ---

--- a/src/smtlibsolver.h
+++ b/src/smtlibsolver.h
@@ -584,14 +584,6 @@ private:
   // the same logic.
   std::string LogicOverride;
 
-  // Counter for fresh symbols introduced by mkIEEEFPToBVImpl. SMT-LIB has no
-  // portable fp→bv same-encoding op, so we materialize a fresh BV symbol
-  // and constrain it via the inverse fp.from-IEEE-bv direction. The
-  // constraint is scoped to the current push level — same trade-off the
-  // bitwuzla and cvc5 native backends make. See the docstring on
-  // SMTSolver::mkIEEEFPToBV for the user-facing implication.
-  uint64_t NextIEEEBVId = 0;
-
   // Counter for fresh tuple-sort names. mkTupleSortImpl declares a fresh
   // datatype per distinct tuple shape (Camada caches sort identity, so the
   // declaration runs at most once per shape).


### PR DESCRIPTION
## Problem (ESBMC report: equal FP terms get different bit-vectors)

`regression/python/github_3719_4-nondet`: `(assert (= y list_elem))` arrives **before** either term has any fp->bv conversion, then each later `mkIEEEFPToBV` mints its own `__CAMADA_ieeebv` constant. Nothing relates the two constants — the inverse ties `term == to_fp(sym)` constrain nothing at NaN, where `to_fp` is many-to-one — so a model can give one float value two different payloads. Z3 passes the same program because `fp.to_ieee_bv` is a *function*: congruence forces equal values to equal bits regardless of which unspecified pattern the solver picks.

## Fix

Give the fresh-symbol backends the same property by emulating the **function**, not the value: one uninterpreted function per FP sort (`__CAMADA_ieeebv_fn : FP -> BV`), `mkIEEEFPToBVImpl` returns `fn(Exp)`, tied once per term by `to_fp(fn(Exp)) == Exp`. Consistency across value-equal terms then comes from the solver's congruence closure — order-independent, no camada-side equivalence tracking (this replaces both the union-find and canonical-NaN designs considered).

- Ties are definitional, scope-independent facts, journaled in `LazyConstraintLevels` so `pop()` re-asserts them — which **retires the old docstring scope caveat** (a result no longer goes unconstrained after a pop crossing its call site).
- Applications are memoized per term; the per-call counters (`ToBVCounter`, `NextIEEEBVId`) are deleted.
- The #125 provenance shadow is unchanged and orthogonal: shadow = NaN-payload **exactness** where bits are provable, UF = **consistency** everywhere else. Neither subsumes the other (the first report's memcpy chain still needs the shadow).

## Testing

New `fp_ieee_bv_consistency` fixture (both encodings, every backend): the report's equality-before-provenance pattern, repeated-read agreement, and non-NaN exactness through the tie. Verified failing against the fresh-symbol implementation before the change (493/494 on bitwuzla, the equality case) and passing after. Full suite 231/231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3