### PR TITLE
Remove chained adder and dead abs from the FMA bit-blast

### DIFF
--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -1311,7 +1311,6 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
 
   // else comes the fused multiplication.
   SMTExprRef one_1 = mkBVOne1(*this);
-  SMTExprRef zero_1 = mkBVZero1(*this);
 
   SMTExprRef a_sgn, a_sig, a_exp, a_lz;
   SMTExprRef b_sgn, b_sig, b_exp, b_lz;
@@ -1394,13 +1393,16 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   assert(e_sig->getWidth() == 2 * sbits + 5);
   assert(shifted_f_sig->getWidth() == 2 * sbits + 5);
 
+  /* Jam the alignment sticky into the aligned operand before the one
+   * add/sub. e_sig is always even (mul_sig and c_sig_ext both carry
+   * trailing zeros), so the sum/difference LSB equals shifted_f_sig's LSB
+   * and this is exactly equivalent to the conditional post-add/sub on an
+   * even result -- without chaining a second full-width adder onto the
+   * first. Same shape as addCore. */
   SMTExprRef sticky_wide = mkBVZeroExt(2 * sbits + 4, alignment_sticky);
+  shifted_f_sig = mkBVOr(shifted_f_sig, sticky_wide);
   SMTExprRef e_plus_f = mkBVAdd(e_sig, shifted_f_sig);
-  e_plus_f = mkIte(mkEqual(mkBVExtract(0, 0, e_plus_f), zero_1),
-                   mkBVAdd(e_plus_f, sticky_wide), e_plus_f);
   SMTExprRef e_minus_f = mkBVSub(e_sig, shifted_f_sig);
-  e_minus_f = mkIte(mkEqual(mkBVExtract(0, 0, e_minus_f), zero_1),
-                    mkBVSub(e_minus_f, sticky_wide), e_minus_f);
 
   SMTExprRef sum = mkIte(eq_sgn, e_plus_f, e_minus_f);
   assert(sum->getWidth() == 2 * sbits + 5);
@@ -1419,10 +1421,6 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   SMTExprRef res_sgn_c2 = mkBVAnd(mkBVAnd(e_sgn, not_f_sgn), not_sign_bv);
   SMTExprRef res_sgn_c3 = mkBVAnd(e_sgn, f_sgn);
   SMTExprRef res_sgn = mkBVOr(mkBVOr(res_sgn_c1, res_sgn_c2), res_sgn_c3);
-
-  SMTExprRef is_sig_neg =
-      mkEqual(one_1, mkBVExtract(2 * sbits + 4, 2 * sbits + 4, sig_abs));
-  sig_abs = mkIte(is_sig_neg, mkBVNeg(sig_abs), sig_abs);
 
   // Result could have overflown into 4.xxx.
   assert(sig_abs->getWidth() == 2 * sbits + 5);


### PR DESCRIPTION
## What

Two exact transforms in `mkFPFMAImpl`, items A1/A2 of the encoding-structure audit:

- **A1**: the alignment sticky was incorporated by testing the LSB of the significand adder's output and conditionally running a *second* full-width add/sub — two chained ~(2·sbits+5)-bit carry chains plus a reconvergent mux on both the plus and minus paths. `e_sig` is always even (`mul_sig` carries three trailing zeros, `c_sig_ext` carries sbits+2), so ORing the sticky into the aligned operand before one single add/sub is exactly equivalent in all four (LSB, sticky) cases. This is the shape `addCore` already uses.
- **A2**: the second absolute-value step was dead — operands are zero-extended by 2, so `|sum| < 2^(2·sbits+4)` and the first negation can never wrap; the second sign-test-and-negate was an identity on the FMA critical path.

Both patterns appear inherited from Z3's fpa2bv.

## Evidence

- **Hard instance (ESBMC, `fma_horner` polynomial family, self-controlling probe)**: ~6% solve-time improvement.
- **Correctness**: all 231 regression tests pass; 418 directed + random fp32 triples (targeting the alignment-sticky and effective-subtraction paths) match host `fmaf` bit-exactly on both old and new encodings; `fp_solve_fma` commutativity still proves UNSAT.
- **Shape probe**: fp64 fma SMT-LIB dumps differ by exactly −1 bvadd, −1 bvsub, −1 bvneg, −3 ite, +1 bvor — the patch's fingerprint and nothing else.
- **Toy tripwire, reported honestly**: `fp_solve_fma` at fp8 runs 1.16× slower patched — the same backwards-pointing regime the LZC episode documented for millisecond-scale proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3