### PR TITLE
Memoize and constant-fold Ackermann array select lowering

### DIFF
--- a/regression/bench/main.cpp
+++ b/regression/bench/main.cpp
@@ -274,6 +274,34 @@ void benchmarkArraySelectFanout(camada::SMTSolver &solver,
   (void)sink;
 }
 
+// Select constant indexes from a constant-index store chain. Every level
+// is decidable at build time, so a host-side fold in the Ackermann chain
+// walk answers hits and skips misses without emitting a single term;
+// without it each select emits a 24-deep ite cascade of constant
+// comparisons for the backend rewriter to chew through.
+void benchmarkArraySelectConstChain(camada::SMTSolver &solver,
+                                    std::size_t iterations) {
+  auto idx_sort = solver.mkBVSort(32);
+  auto elem_sort = solver.mkBVSort(32);
+  auto arr = solver.mkSymbol("cc_a", solver.mkArraySort(idx_sort, elem_sort));
+
+  for (int i = 0; i < 24; ++i)
+    arr = solver.mkArrayStore(
+        arr, solver.mkBVFromDec(i, idx_sort),
+        solver.mkBVFromDec(static_cast<int64_t>(i * 3), elem_sort));
+
+  volatile std::size_t sink = 0;
+  // 24 of every 32 iterations hit a store; the rest fall through to the
+  // symbol root and mint (memoized) reads.
+  for (std::size_t i = 0; i < iterations; ++i)
+    sink += solver
+                .mkArraySelect(arr, solver.mkBVFromDec(
+                                        static_cast<int64_t>(i % 32), idx_sort))
+                ->getWidth();
+
+  (void)sink;
+}
+
 // Unlike the construction-only cases, this one calls check(): the array
 // encoding trade (native theory vs Ackermann ground constraints) only
 // shows up in solve time. Each cycle builds a small store chain, a few
@@ -666,6 +694,8 @@ int main(int argc, char **argv) {
     runCase(backend, "array_store_chain", iterations, benchmarkArrayStoreChain);
     runCase(backend, "array_select_fanout", iterations,
             benchmarkArraySelectFanout);
+    runCase(backend, "array_select_const_chain", iterations,
+            benchmarkArraySelectConstChain);
     // Write-only smtlib never solves; array_solve would just measure text
     // emission there.
     if (backend != "smtlib")

--- a/regression/bench/main.cpp
+++ b/regression/bench/main.cpp
@@ -248,6 +248,32 @@ void benchmarkArrayStoreChain(camada::SMTSolver &solver,
   (void)sink;
 }
 
+// Re-select a fixed store chain with recurring index terms. Under the
+// Ackermann encoding every select lowers the whole chain to an ite
+// cascade, so repeated selects measure the re-lowering cost that a
+// select memo would remove; under native encodings this is just cheap
+// term construction either way.
+void benchmarkArraySelectFanout(camada::SMTSolver &solver,
+                                std::size_t iterations) {
+  auto idx_sort = solver.mkBVSort(32);
+  auto elem_sort = solver.mkBVSort(32);
+  auto arr = solver.mkSymbol("fan_a", solver.mkArraySort(idx_sort, elem_sort));
+
+  std::vector<camada::SMTExprRef> idxs;
+  for (int i = 0; i < 24; ++i) {
+    auto k = solver.mkSymbol("fan_i" + std::to_string(i), idx_sort);
+    idxs.push_back(k);
+    arr = solver.mkArrayStore(
+        arr, k, solver.mkBVFromDec(static_cast<int64_t>(i), elem_sort));
+  }
+
+  volatile std::size_t sink = 0;
+  for (std::size_t i = 0; i < iterations; ++i)
+    sink += solver.mkArraySelect(arr, idxs[i % idxs.size()])->getWidth();
+
+  (void)sink;
+}
+
 // Unlike the construction-only cases, this one calls check(): the array
 // encoding trade (native theory vs Ackermann ground constraints) only
 // shows up in solve time. Each cycle builds a small store chain, a few
@@ -638,6 +664,8 @@ int main(int argc, char **argv) {
     runCase(backend, "expr_construction_only", iterations,
             benchmarkExprConstructionOnly);
     runCase(backend, "array_store_chain", iterations, benchmarkArrayStoreChain);
+    runCase(backend, "array_select_fanout", iterations,
+            benchmarkArraySelectFanout);
     // Write-only smtlib never solves; array_solve would just measure text
     // emission there.
     if (backend != "smtlib")

--- a/src/camadaarray.cpp
+++ b/src/camadaarray.cpp
@@ -237,13 +237,42 @@ SMTExprRef SMTSolverImpl::mkAckArrayConst(const SMTSortRef &IndexSort,
 SMTExprRef SMTSolverImpl::mkAckArraySelect(const SMTExprRef &Array,
                                            const SMTExprRef &Index) {
   const CamadaAckArrayExpr *AE = requireAckArrayExpr(Array);
+  auto BitsIt = AckBVConstBits.find(&*Index);
+  const bool IndexIsConst = BitsIt != AckBVConstBits.end();
+
   switch (AE->getKind()) {
   case SMTExprKind::ArrayStore:
-    return mkIte(mkEqual(Index, AE->Index), AE->Element,
-                 mkAckArraySelect(AE->Base, Index));
-  case SMTExprKind::Ite:
-    return mkIte(AE->Cond, mkAckArraySelect(AE->TrueArr, Index),
-                 mkAckArraySelect(AE->FalseArr, Index));
+  case SMTExprKind::Ite: {
+    // Chain nodes are shared by construction, so memoize the lowered
+    // select per (node, index): repeated selects reuse one term instead
+    // of rebuilding the ite cascade. Constant indexes key by value,
+    // mirroring the read canonicalization at symbol roots below.
+    {
+      AckSelectMemoState &Memo = AckSelectMemo[&*Array];
+      if (IndexIsConst) {
+        if (auto It = Memo.ByConstBits.find(BitsIt->second);
+            It != Memo.ByConstBits.end())
+          return It->second;
+      } else if (auto It = Memo.ByIndex.find(&*Index);
+                 It != Memo.ByIndex.end()) {
+        return It->second;
+      }
+    }
+    SMTExprRef Result =
+        AE->getKind() == SMTExprKind::ArrayStore
+            ? mkIte(mkEqual(Index, AE->Index), AE->Element,
+                    mkAckArraySelect(AE->Base, Index))
+            : mkIte(AE->Cond, mkAckArraySelect(AE->TrueArr, Index),
+                    mkAckArraySelect(AE->FalseArr, Index));
+    // Fresh lookup: the recursion above inserts into AckSelectMemo, which
+    // can rehash and invalidate any reference held across it.
+    AckSelectMemoState &Memo = AckSelectMemo[&*Array];
+    if (IndexIsConst)
+      Memo.ByConstBits.emplace(BitsIt->second, Result);
+    else
+      Memo.ByIndex.emplace(&*Index, Result);
+    return Result;
+  }
   case SMTExprKind::ArrayConst:
     return AE->Init;
   case SMTExprKind::Symbol:
@@ -258,8 +287,6 @@ SMTExprRef SMTSolverImpl::mkAckArraySelect(const SMTExprRef &Array,
   // structurally equal terms built separately get distinct reads, which
   // is sound (their congruence guard is trivially true) if redundant.
   AckArrayRootState &Root = AckArrayRoots[&*Array];
-  auto BitsIt = AckBVConstBits.find(&*Index);
-  const bool IndexIsConst = BitsIt != AckBVConstBits.end();
   if (IndexIsConst) {
     if (auto It = Root.ReadsByConstBits.find(BitsIt->second);
         It != Root.ReadsByConstBits.end())

--- a/src/camadaarray.cpp
+++ b/src/camadaarray.cpp
@@ -258,12 +258,26 @@ SMTExprRef SMTSolverImpl::mkAckArraySelect(const SMTExprRef &Array,
         return It->second;
       }
     }
-    SMTExprRef Result =
-        AE->getKind() == SMTExprKind::ArrayStore
-            ? mkIte(mkEqual(Index, AE->Index), AE->Element,
-                    mkAckArraySelect(AE->Base, Index))
-            : mkIte(AE->Cond, mkAckArraySelect(AE->TrueArr, Index),
-                    mkAckArraySelect(AE->FalseArr, Index));
+    SMTExprRef Result;
+    if (AE->getKind() == SMTExprKind::ArrayStore) {
+      // Host-side fold before emitting anything: a select whose index is
+      // syntactically the stored index (same object, or equal BV-constant
+      // bits) hits the store; two distinct BV constants provably miss and
+      // skip the level. Only genuinely undecidable levels emit an ite.
+      auto StoreBitsIt = AckBVConstBits.find(&*AE->Index);
+      const bool StoreIsConst = StoreBitsIt != AckBVConstBits.end();
+      if (&*Index == &*AE->Index || (IndexIsConst && StoreIsConst &&
+                                     BitsIt->second == StoreBitsIt->second))
+        Result = AE->Element;
+      else if (IndexIsConst && StoreIsConst)
+        Result = mkAckArraySelect(AE->Base, Index);
+      else
+        Result = mkIte(mkEqual(Index, AE->Index), AE->Element,
+                       mkAckArraySelect(AE->Base, Index));
+    } else {
+      Result = mkIte(AE->Cond, mkAckArraySelect(AE->TrueArr, Index),
+                     mkAckArraySelect(AE->FalseArr, Index));
+    }
     // Fresh lookup: the recursion above inserts into AckSelectMemo, which
     // can rehash and invalidate any reference held across it.
     AckSelectMemoState &Memo = AckSelectMemo[&*Array];

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -278,6 +278,7 @@ void SMTSolverImpl::clearExprCaches() {
   ArrayEqualLinksByIndexSort.clear();
   ArrayEqualCongruenceDone.clear();
   AckArrayRoots.clear();
+  AckSelectMemo.clear();
   AckBVConstBits.clear();
   IEEEBVShadow.clear();
   PendingShadowLinks.clear();

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -253,6 +253,18 @@ protected:
     std::unordered_map<std::string, std::size_t> ReadsByConstBits;
   };
   std::unordered_map<const SMTExpr *, AckArrayRootState> AckArrayRoots;
+  // Lowered selects memoized per (chain node, index). Store/ite chains
+  // share their bases by construction, so repeated selects — from user
+  // code or the array-equality congruence machinery — reuse one lowered
+  // term instead of rebuilding an ite cascade per call. Same key split
+  // as AckArrayRootState: BV-constant indexes by value, everything else
+  // by object identity. Terms outlive push/pop, so entries never need
+  // scope invalidation.
+  struct AckSelectMemoState {
+    std::unordered_map<const SMTExpr *, SMTExprRef> ByIndex;
+    std::unordered_map<std::string, SMTExprRef> ByConstBits;
+  };
+  std::unordered_map<const SMTExpr *, AckSelectMemoState> AckSelectMemo;
   // Bits of BV constants built through mkBVFromBin/mkBVFromDec, tracked
   // only in Ackermann mode (general expressions are not hash-consed, so
   // the value is otherwise unrecoverable at build time).


### PR DESCRIPTION
## What

Two construction-side improvements to the Ackermann array encoding, both ideas mined from ESBMC's retired `array_conv` flattener:

1. **Select memo**: store/ite chains share their bases by construction, but every select re-lowered the whole chain to a fresh ite cascade — from user code and from the array-equality congruence machinery alike. Lowered selects are now memoized per (chain node, index), with the same const-by-value / other-by-identity key split the symbol-root reads already use. Terms outlive push/pop, so the cache needs no scope invalidation and clears with the sibling Ackermann state.
2. **Host-side constant fold**: a select whose index is syntactically the stored index (same object, or equal BV-constant bits) folds to the element with zero terms emitted; two distinct constants provably miss and skip the level. Only genuinely undecidable levels still emit an ite, so constant-index traffic over a constant chain — the common case for C programs — no longer ships cascades of constant comparisons for the backend rewriter to fold. Folded results share the memo.

Each improvement lands with its measuring instrument as a separate commit (`array_select_fanout`, `array_select_const_chain`), so both sides of every A/B are reproducible from the branch history.

## Numbers

hyperfine --warmup 3 --runs 50, bitwuzla, `--ack`, vs master:

| case | master | branch | |
|---|---|---|---|
| `array_select_fanout` (symbolic indexes, repeated selects over a 24-store chain) | 25.7 µs/select | 3.3 µs/select | 3.14× whole-run |
| `array_select_const_chain` (constant indexes over a constant chain) | ~34 µs/select | 2.43 µs/select | 3.51× whole-run |
| `array_solve` (distinct selects + check) | 6.83 s | 6.81 s | unchanged, as expected |

Native encodings are untouched by construction — both changes live entirely inside `mkAckArraySelect`, which native modes never call.

## Validation

All 231 regression tests pass. Reviewed for: soundness across push/pop (the memo caches terms only; congruence axioms are journaled independently in `LazyConstraintLevels`), iterator invalidation across the recursive lowering (`AckBVConstBits` is never written during lowering; the memo re-looks-up after recursion since child inserts can rehash), key semantics (fixed-width constant bits cannot collide across widths), and the congruence machinery (it never observed store indexes, so the elided terms change nothing it tracks). The three fold cases are exact: `X=X` tautology, value equality, and impossibility of equality for distinct fixed-width constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3