### PR TITLE
Revert Z3 to 4.13.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ config_solver(CVC5 1.0.8)
 config_solver(MathSAT 5.6.3)
 config_solver(STP 2.4.0)
 config_solver(Yices 2.6.1)
-config_solver(Z3 4.16.0)
+config_solver(Z3 4.13.3)
 
 # The SMT-LIB pipeline backend drives an external SMT-LIB-speaking process via
 # fork/exec/setrlimit/select, so it is POSIX-only. Default ON elsewhere; force

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Downloaded sources and locally installed solver artifacts are stored under
 
 When CMake downloads dependencies itself:
 - `Bitwuzla` uses the prebuilt static release archive from `0.9.1`.
-- `Z3` uses the prebuilt release archive from `z3-5.0.0`.
+- `Z3` uses the prebuilt release archive from `z3-4.13.3`.
 - `CVC5` uses the prebuilt static release archive from `cvc5-1.3.4`.
 - `Yices` uses a source build.
 - `GMP` uses a source build when it is needed by downloaded dependencies and no
@@ -139,7 +139,7 @@ location during the build.
 | [MathSAT](https://mathsat.fbk.eu/)         |  5.6.3          | ✔️<sup>1</sup> |
 | [STP](https://stp.github.io/)              |  2.4.0          |   |
 | [Yices](https://yices.csl.sri.com/)        |  2.6.1          |   |
-| [Z3](https://github.com/Z3Prover/z3)       |  5.0.0          | ✔️ |
+| [Z3](https://github.com/Z3Prover/z3)       |  4.13.3         | ✔️ |
 | SMT-LIB (any external solver) | n/a | depends on child |
 
 <sup>1</sup> `fp.fma` and `fp.rem` are bit-blasted when using MathSAT because

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -69,7 +69,7 @@ TEST_CASE("Override Z3 Solver", "[Z3]") {
 
   class myZ3Solver : public camada::Z3Solver {
   public:
-    explicit myZ3Solver(z3::context C) : camada::Z3Solver(std::move(C)) {
+    explicit myZ3Solver(z3::config &Cfg) : camada::Z3Solver(Cfg) {
       setSolver(makeSolver(context()));
     }
 
@@ -81,8 +81,10 @@ TEST_CASE("Override Z3 Solver", "[Z3]") {
     }
   };
 
-  // Create Z3 Solver
-  camada::SMTSolverRef z3 = std::make_unique<myZ3Solver>(z3::context{});
+  // Create Z3 Solver from a caller-owned configuration; the context is
+  // built inside the solver (z3::context cannot be moved in Z3 4.13.x).
+  z3::config Cfg;
+  camada::SMTSolverRef z3 = std::make_unique<myZ3Solver>(Cfg);
 
   tests(z3);
 }

--- a/scripts/cmake/CamadaDependencies.cmake
+++ b/scripts/cmake/CamadaDependencies.cmake
@@ -26,22 +26,22 @@ set(CAMADA_DEPS_INSTALL_DIR
     CACHE PATH "Directory used to install downloaded solver dependencies")
 
 set(CAMADA_Z3_LINUX_X86_64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-x64-glibc-2.39.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-glibc-2.35.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for Linux x86_64")
 set(CAMADA_Z3_LINUX_AARCH64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-arm64-glibc-2.38.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-arm64-glibc-2.34.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for Linux aarch64")
 set(CAMADA_Z3_MACOS_X86_64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-x64-osx-13.3.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-osx-13.7.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for macOS x86_64")
 set(CAMADA_Z3_MACOS_ARM64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-arm64-osx-13.3.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-arm64-osx-13.7.zip"
     CACHE STRING "URL used to download the prebuilt Z3 archive for macOS arm64")
 set(CAMADA_Z3_WINDOWS_X86_64_URL
-    "https://github.com/Z3Prover/z3/releases/download/z3-5.0.0/z3-5.0.0-x64-win.zip"
+    "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-win.zip"
     CACHE STRING
           "URL used to download the prebuilt Z3 archive for Windows x86_64")
 set(CAMADA_CVC5_LINUX_X86_64_URL

--- a/src/z3solver.cpp
+++ b/src/z3solver.cpp
@@ -112,8 +112,8 @@ Z3Solver::Z3Solver(ArrayEncoding Arrays) : Solver(Context) {
   initializeCommonSingletons();
 }
 
-Z3Solver::Z3Solver(z3::context C, ArrayEncoding Arrays)
-    : Context(std::move(C)), Solver(Context) {
+Z3Solver::Z3Solver(z3::config &Config, ArrayEncoding Arrays)
+    : Context(Config), Solver(Context) {
   ArrayMode = Arrays;
   z3::set_param("rewriter.hi_fp_unspecified", true);
   initializeCommonSingletons();

--- a/src/z3solver.h
+++ b/src/z3solver.h
@@ -68,14 +68,15 @@ public:
 class Z3Solver : public SMTSolverImpl {
 public:
   explicit Z3Solver(ArrayEncoding Arrays = ArrayEncoding::Native);
-  explicit Z3Solver(z3::context C,
+  // z3::context is neither copyable nor movable in Z3 4.13.x, so a
+  // caller-configured context cannot cross this API; the configuration
+  // does instead, and the context is built in place from it. For the
+  // same reason there is no (context, solver) constructor: any solver a
+  // caller could pass would reference a context object outside this
+  // class. Subclass and call setSolver() against context() to install a
+  // custom solver (see the Override Z3 regression).
+  explicit Z3Solver(z3::config &Config,
                     ArrayEncoding Arrays = ArrayEncoding::Native);
-  // There is deliberately no (context, solver) constructor: z3::solver
-  // holds a pointer to the context *object* it was built against, and
-  // z3::context is move-only, so any solver a caller could pass would
-  // reference the moved-from (nulled) context and crash on the first
-  // refcount operation. Subclass and call setSolver() against context()
-  // to install a custom solver (see the Override Z3 regression).
   ~Z3Solver() override;
 
 protected:


### PR DESCRIPTION
## What

Z3 releases after 4.13.3 regress solve times on ESBMC workloads, so this pins the bundled archives and the minimum version back:

- All five prebuilt-archive URLs point at the `z3-4.13.3` release assets (names taken from the actual GitHub release — the osx/glibc suffixes differ per release).
- `config_solver(Z3 4.16.0)` lowered to `4.13.3`; README bundled/minimum versions updated.

## The constructor rewrite

`z3::context` has no move constructor in 4.13.x (it was added later; present in 5.0.0), so the context-by-value `Z3Solver(z3::context, ...)` constructor cannot compile there. It is now:

```cpp
explicit Z3Solver(z3::config &Config, ArrayEncoding Arrays = ArrayEncoding::Native);
```

The caller-supplied configuration crosses the API and the context is built in place — same embedder capability, and version-agnostic since `context(config&)` exists in every Z3 release. The Override regression test now passes a caller-owned `z3::config` and exercises the new signature end to end (custom tactic solver via `setSolver()`).

## Validation

- All 44 `[Z3]` test cases (2458 assertions) pass against real Z3 4.13.3, including the tactic-chain Override test.
- The full 231-test suite passes against a tree with Z3 5.0.0 installed, so the new constructor is source-compatible with newer Z3 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3