### PR TITLE
Make the exported STP and CVC5 link interfaces consumer-resolvable

### DIFF
--- a/.github/workflows/benchmark-master.yml
+++ b/.github/workflows/benchmark-master.yml
@@ -34,6 +34,10 @@ jobs:
             build/deps
             build/_deps
           key: ${{ runner.os }}-bench-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
+          # Same prefix fallback (and downgrade caveat) as the build
+          # workflows' deps cache.
+          restore-keys: |
+            ${{ runner.os }}-bench-deps-
 
       - name: Configure Camada
         run: >

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -44,6 +44,10 @@ jobs:
             build/deps
             build/_deps
           key: ${{ runner.os }}-bench-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
+          # Same prefix fallback (and downgrade caveat) as the build
+          # workflows' deps cache.
+          restore-keys: |
+            ${{ runner.os }}-bench-deps-
 
       - name: Download latest master baseline
         id: download-master-baseline

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -26,6 +26,13 @@ jobs:
           build/deps
           build/_deps
         key: ${{ runner.os }}-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
+        # Prefix fallback: a key change (solver version bump) restores the
+        # newest previous deps tree and only rebuilds what changed. Caveat:
+        # on a *downgrade*, the restored tree still holds the newer solver,
+        # which satisfies the minimum-version find and skips the download —
+        # delete the stale caches (gh cache delete) when downgrading.
+        restore-keys: |
+          ${{ runner.os }}-deps-
 
     - name: Configure Camada
       run: cmake -S . -B build -GNinja -DCAMADA_ENABLE_REGRESSION=ON -DBUILD_SHARED_LIBS=OFF -DCAMADA_DOWNLOAD_DEPENDENCIES=ALL -DCAMADA_SOLVER_BITWUZLA_ENABLE=ON -DCAMADA_SOLVER_CVC5_ENABLE=ON -DCAMADA_SOLVER_MATHSAT_ENABLE=ON -DCAMADA_SOLVER_STP_ENABLE=ON -DCAMADA_SOLVER_YICES_ENABLE=ON -DCAMADA_SOLVER_Z3_ENABLE=ON -DENABLE_WARNINGS=ON -DENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/release -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,6 +32,13 @@ jobs:
           build/deps
           build/_deps
         key: ${{ runner.os }}-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
+        # Prefix fallback: a key change (solver version bump) restores the
+        # newest previous deps tree and only rebuilds what changed. Caveat:
+        # on a *downgrade*, the restored tree still holds the newer solver,
+        # which satisfies the minimum-version find and skips the download —
+        # delete the stale caches (gh cache delete) when downgrading.
+        restore-keys: |
+          ${{ runner.os }}-deps-
 
     - name: Configure Camada
       run: cmake -S . -B build -GNinja -DCAMADA_ENABLE_REGRESSION=ON -DBUILD_SHARED_LIBS=OFF -DCAMADA_DOWNLOAD_DEPENDENCIES=ALL -DCAMADA_SOLVER_BITWUZLA_ENABLE=ON -DCAMADA_SOLVER_CVC5_ENABLE=ON -DCAMADA_SOLVER_MATHSAT_ENABLE=ON -DCAMADA_SOLVER_STP_ENABLE=ON -DCAMADA_SOLVER_YICES_ENABLE=ON -DCAMADA_SOLVER_Z3_ENABLE=ON -DENABLE_WARNINGS=ON -DENABLE_WERROR=ON -DCMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/release -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,6 +31,13 @@ jobs:
           build/deps
           build/_deps
         key: ${{ runner.os }}-deps-${{ hashFiles('scripts/cmake/CamadaDependencies.cmake') }}
+        # Prefix fallback: a key change (solver version bump) restores the
+        # newest previous deps tree and only rebuilds what changed. Caveat:
+        # on a *downgrade*, the restored tree still holds the newer solver,
+        # which satisfies the minimum-version find and skips the download —
+        # delete the stale caches (gh cache delete) when downgrading.
+        restore-keys: |
+          ${{ runner.os }}-deps-
 
     - name: Configure Camada
       shell: pwsh

--- a/scripts/cmake/FindCVC5.cmake
+++ b/scripts/cmake/FindCVC5.cmake
@@ -43,7 +43,10 @@ if(CVC5_FOUND)
       ${CAMADA_DEPS_INSTALL_DIR}/lib ${CAMADA_DEPS_INSTALL_DIR}/lib64
       ${CAMADA_SOLVER_CVC5_DIR}/lib ${CAMADA_SOLVER_CVC5_DIR}/lib64
       ${CAMADA_CVC5_DIR}/lib ${CAMADA_CVC5_DIR}/lib64)
-  foreach(_camada_cvc5_extra_lib_name IN ITEMS cadical picpoly picpolyxx)
+  # gmp is here because cvc5::cvc5's interface pulls it in by bare name; once
+  # the link switches to resolved paths below, it must be resolved too (it may
+  # only exist as a system library, hence no HINTS restraint).
+  foreach(_camada_cvc5_extra_lib_name IN ITEMS cadical picpoly picpolyxx gmp)
     find_library(
       _camada_cvc5_extra_lib
       NAMES ${_camada_cvc5_extra_lib_name}
@@ -54,11 +57,40 @@ if(CVC5_FOUND)
     unset(_camada_cvc5_extra_lib CACHE)
   endforeach()
 
+  # cvc5's export names its build configuration "PRODUCTION", so the location
+  # has to be looked up through IMPORTED_CONFIGURATIONS rather than assuming the
+  # RELEASE convention.
   get_target_property(_camada_cvc5_location cvc5::cvc5 IMPORTED_LOCATION)
   if(NOT _camada_cvc5_location)
-    get_target_property(_camada_cvc5_location cvc5::cvc5
-                        IMPORTED_LOCATION_RELEASE)
+    get_target_property(_camada_cvc5_configs cvc5::cvc5 IMPORTED_CONFIGURATIONS)
+    if(_camada_cvc5_configs)
+      foreach(_camada_cvc5_config IN LISTS _camada_cvc5_configs)
+        get_target_property(_camada_cvc5_location cvc5::cvc5
+                            IMPORTED_LOCATION_${_camada_cvc5_config})
+        if(_camada_cvc5_location)
+          break()
+        endif()
+      endforeach()
+    endif()
   endif()
+
+  # Same self-contained-export treatment as STP: exporting the imported target
+  # *name* forces consumers through find_package(cvc5), whose static export
+  # references its bundled archives (cadical, picpoly) by bare name with no link
+  # directory attached. Absolute paths sidestep both. The include dirs travel
+  # separately since dropping the target from the link line also drops its usage
+  # requirements.
+  get_target_property(_camada_cvc5_includes cvc5::cvc5
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  if(_camada_cvc5_includes)
+    set(CVC5_INCLUDE_DIRS "${_camada_cvc5_includes}")
+  endif()
+  if(_camada_cvc5_location)
+    set(CVC5_LINK_LIBRARIES "${_camada_cvc5_location}")
+  else()
+    set(CVC5_LINK_LIBRARIES cvc5::cvc5)
+  endif()
+
   if(_camada_cvc5_location)
     message(
       STATUS

--- a/scripts/cmake/FindSTP.cmake
+++ b/scripts/cmake/FindSTP.cmake
@@ -32,6 +32,31 @@ function(_camada_validate_stp)
   unset(STP_INCLUDE_DIRS PARENT_SCOPE)
 endfunction()
 
+# STP 2.4.0's exported interface references the libabc-pic *target*, which
+# STPTargets.cmake never defines (STP builds the archive but does not export the
+# target); every consumer that loads the file fails at generate time evaluating
+# $<TARGET_FILE:libabc-pic>. Repair our staged copy in place, pointing the
+# reference at the staged archive. Only the file under the camada deps tree is
+# touched.
+function(_camada_repair_stp_targets_file)
+  set(_camada_stp_targets_file
+      "${CAMADA_DEPS_INSTALL_DIR}/lib/cmake/STP/STPTargets.cmake")
+  set(_camada_stp_abc_lib "${CAMADA_DEPS_INSTALL_DIR}/lib/libabc-pic.a")
+  if(NOT EXISTS "${_camada_stp_targets_file}" OR NOT EXISTS
+                                                 "${_camada_stp_abc_lib}")
+    return()
+  endif()
+  file(READ "${_camada_stp_targets_file}" _camada_stp_targets_content)
+  string(FIND "${_camada_stp_targets_content}" "\\$<TARGET_FILE:libabc-pic>"
+              _camada_stp_abc_ref)
+  if(_camada_stp_abc_ref EQUAL -1)
+    return()
+  endif()
+  string(REPLACE "\\$<TARGET_FILE:libabc-pic>" "${_camada_stp_abc_lib}"
+                 _camada_stp_targets_content "${_camada_stp_targets_content}")
+  file(WRITE "${_camada_stp_targets_file}" "${_camada_stp_targets_content}")
+endfunction()
+
 function(_camada_normalize_stp_target)
   if(NOT TARGET stp)
     return()
@@ -40,6 +65,17 @@ function(_camada_normalize_stp_target)
   if(STP_INCLUDE_DIRS)
     set_property(TARGET stp PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                                      "${STP_INCLUDE_DIRS}")
+  endif()
+
+  # Resolve the imported archive so camada's link line — and therefore its
+  # installed export — carries absolute paths instead of the imported target
+  # name. install(EXPORT) can only record the *name* of an imported target,
+  # which forces consumers through find_package(STP) to reconstruct it; paths
+  # make the camada package self-contained, matching how every other backend is
+  # exported.
+  get_target_property(_camada_stp_lib stp IMPORTED_LOCATION)
+  if(NOT _camada_stp_lib)
+    get_target_property(_camada_stp_lib stp IMPORTED_LOCATION_RELEASE)
   endif()
 
   set(_camada_stp_minisat_lib "${CAMADA_DEPS_INSTALL_DIR}/lib/libminisat.a")
@@ -66,12 +102,24 @@ function(_camada_normalize_stp_target)
     endif()
     set_property(TARGET stp PROPERTY INTERFACE_LINK_LIBRARIES
                                      "${_camada_stp_dep_libs}")
+    if(_camada_stp_lib)
+      set(STP_LINK_LIBRARIES
+          "${_camada_stp_lib};${_camada_stp_dep_libs}"
+          PARENT_SCOPE)
+      return()
+    endif()
   elseif(TARGET minisat AND TARGET libcryptominisat5)
     set_property(TARGET stp PROPERTY INTERFACE_LINK_LIBRARIES
                                      "minisat;libcryptominisat5")
   elseif(TARGET minisat)
     set_property(TARGET stp PROPERTY INTERFACE_LINK_LIBRARIES "minisat")
   endif()
+
+  # System installs (or an unresolvable archive) keep the target-based link;
+  # their exported packages are expected to be reconstructable by consumers.
+  set(STP_LINK_LIBRARIES
+      stp
+      PARENT_SCOPE)
 endfunction()
 
 set(_camada_stp_find_args CONFIG QUIET HINTS ${_camada_stp_hints})
@@ -86,6 +134,7 @@ endif()
 
 find_package(cryptominisat5 CONFIG QUIET HINTS ${_camada_stp_hints})
 find_package(minisat CONFIG QUIET HINTS ${_camada_stp_hints})
+_camada_repair_stp_targets_file()
 find_package(STP ${_camada_stp_find_args})
 _camada_normalize_stp_target()
 _camada_validate_stp()
@@ -94,6 +143,7 @@ if(NOT STP_FOUND AND _camada_download_stp)
   camada_setup_stp()
   find_package(cryptominisat5 CONFIG QUIET HINTS ${_camada_stp_hints})
   find_package(minisat CONFIG QUIET HINTS ${_camada_stp_hints})
+  _camada_repair_stp_targets_file()
   find_package(
     STP
     CONFIG

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,7 +134,12 @@ if(${CAMADA_SOLVER_MATHSAT_ENABLE})
 endif()
 
 if(${CAMADA_SOLVER_STP_ENABLE})
-  list(APPEND _camada_backend_link_libs stp)
+  # STP_LINK_LIBRARIES is absolute archive paths when FindSTP resolved the
+  # imported location (deps-tree installs), or the bare `stp` target for system
+  # installs. Paths keep the installed camada export self-contained — an
+  # exported imported-target *name* would force every consumer through
+  # find_package(STP).
+  list(APPEND _camada_backend_link_libs ${STP_LINK_LIBRARIES})
   target_include_directories(${LIBRARY_TARGET_NAME}
                              PUBLIC "$<BUILD_INTERFACE:${STP_INCLUDE_DIRS}>")
   target_compile_definitions(${LIBRARY_TARGET_NAME} PRIVATE SOLVER_STP_ENABLED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,7 +117,14 @@ if(${CAMADA_SOLVER_CVC5_ENABLE})
   target_link_directories(
     ${LIBRARY_TARGET_NAME} PRIVATE ${CAMADA_DEPS_INSTALL_DIR}/lib
     ${CAMADA_DEPS_INSTALL_DIR}/lib64)
-  list(APPEND _camada_backend_link_libs cvc5::cvc5)
+  # CVC5_LINK_LIBRARIES is the resolved archive path when FindCVC5 could read
+  # the imported location, falling back to the cvc5::cvc5 target otherwise —
+  # same self-contained-export rationale as the STP block.
+  list(APPEND _camada_backend_link_libs ${CVC5_LINK_LIBRARIES})
+  if(CVC5_INCLUDE_DIRS)
+    target_include_directories(${LIBRARY_TARGET_NAME}
+                               PUBLIC "$<BUILD_INTERFACE:${CVC5_INCLUDE_DIRS}>")
+  endif()
   if(CAMADA_CVC5_EXTRA_LIBS)
     list(APPEND _camada_backend_link_libs ${CAMADA_CVC5_EXTRA_LIBS})
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,8 +121,11 @@ if(${CAMADA_SOLVER_CVC5_ENABLE})
   # the imported location, falling back to the cvc5::cvc5 target otherwise —
   # same self-contained-export rationale as the STP block.
   list(APPEND _camada_backend_link_libs ${CVC5_LINK_LIBRARIES})
+  # SYSTEM, because that is how the cvc5::cvc5 imported target propagated this
+  # directory: bitwuzla and cvc5 both define an ENUM macro, and only
+  # system-header status keeps clang's -Wmacro-redefined quiet under -Werror.
   if(CVC5_INCLUDE_DIRS)
-    target_include_directories(${LIBRARY_TARGET_NAME}
+    target_include_directories(${LIBRARY_TARGET_NAME} SYSTEM
                                PUBLIC "$<BUILD_INTERFACE:${CVC5_INCLUDE_DIRS}>")
   endif()
   if(CAMADA_CVC5_EXTRA_LIBS)


### PR DESCRIPTION
## The report

Linking camada into ESBMC fails with a "missing libabc" error:

```
CMake Error at .../STPTargets.cmake:61 (set_target_properties):
  Error evaluating generator expression:
    $<TARGET_FILE:libabc-pic>
  No target "libabc-pic"
```

Reproduced with a minimal consumer against an installed camada prefix.

## Root cause, two layers

1. **STP 2.4.0's export is broken for every CMake consumer**: it splits ABC into `libabc-pic.a` but references it in the exported interface as `$<TARGET_FILE:libabc-pic>` — a target `STPTargets.cmake` never defines. Loading the file fails at generate time. (Worth an upstream report.)
2. **camada's installed export made consumers load that file**: `install(EXPORT)` can only record the *name* of an imported target, so the exported interface carried the bare name `stp` (and `cvc5::cvc5`), forcing consumers through `find_package(STP)` to reconstruct it. Every other backend already exports as absolute paths.

## The fix

- `_camada_repair_stp_targets_file()` rewrites the staged `STPTargets.cmake` in place, pointing the reference at the staged `libabc-pic.a`. It runs before both `find_package(STP)` calls, healing existing deps trees and fresh downloads alike; only the file under the camada deps tree is touched.
- STP enters the link line — and therefore the installed export — as absolute archive paths (`STP_LINK_LIBRARIES`), with the bare-target fallback kept for system installs. Consumers no longer need `find_package(STP)` at all.
- Same treatment for CVC5, which the end-to-end test exposed as the sibling leak: `cvc5::cvc5` exported by name pulls in an interface that references `cadical`/`picpoly`/`picpolyxx`/`gmp` by bare `-l` name with no link directory. The archive is now resolved through `IMPORTED_CONFIGURATIONS` (cvc5 names its configuration `PRODUCTION`, so the usual `IMPORTED_LOCATION_RELEASE` lookup finds nothing), include dirs travel explicitly, and gmp joins the resolved extra libs since the target's interface no longer supplies it.

## Validation

- All 231 regression tests pass.
- A fresh install's `camadaTargets.cmake` contains zero imported-target names.
- A minimal consumer with **only** `find_package(camada)` — no `find_package(STP)`, no `find_package(cvc5)` — configures, links, and creates an STP solver successfully. Before the fix the same consumer failed at generate time with the exact reported error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3