### PR TITLE
Make FP encoding constants width-safe and bound degenerate formats

### DIFF
--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -673,3 +673,44 @@ fp_cancellation_and_normalization(const camada::SMTSolverRef &solver,
   solver->addConstraint(solver->mkFPIsNormal(sub));
   REQUIRE(solver->check() == camada::checkResult::SAT);
 }
+
+// Wide formats previously hit undefined behavior in the BV encoding's
+// host-side constant construction (1ULL << N at N >= 64): binary128
+// constants (2^112-1 significand masks) and x87-extended sqrt
+// (2^(sbits+3) with sbits = 64). The constants are now built as bit
+// strings at any width; these pin the previously-broken formats
+// end-to-end. Constant operands let the backend fold the circuits, so
+// the checks stay fast despite the widths.
+inline void fp_wide_format_semantics(const camada::SMTSolverRef &solver) {
+  // Bit pattern of the power-of-two value 2^K at a given format:
+  // sign 0, exponent bias + K, significand zero.
+  auto pow2At = [&](unsigned EW, unsigned SW, uint64_t K) {
+    uint64_t exp = ((uint64_t(1) << (EW - 1)) - 1) + K;
+    std::string bits = "0";
+    for (unsigned i = 0; i < EW; ++i)
+      bits += (exp >> (EW - 1 - i)) & 1 ? '1' : '0';
+    bits += std::string(SW, '0');
+    return solver->mkFPFromBin(bits, EW, camada::FPEncoding::BV);
+  };
+
+  // binary128: 1.0 + 1.0 == 2.0.
+  {
+    auto one = pow2At(15, 112, 0);
+    auto two = pow2At(15, 112, 1);
+    auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
+    solver->addConstraint(
+        solver->mkNot(solver->mkEqual(solver->mkFPAdd(one, one, rm), two)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    solver->reset();
+  }
+
+  // x87-extended-like (15, 63): sqrt(4.0) == 2.0.
+  {
+    auto four = pow2At(15, 63, 2);
+    auto two = pow2At(15, 63, 1);
+    auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
+    solver->addConstraint(
+        solver->mkNot(solver->mkEqual(solver->mkFPSqrt(four, rm), two)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
+}

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -41,6 +41,18 @@ template <typename Fn> inline void require_abort(Fn &&Body) {
 #endif
 }
 
+// Degenerate formats whose significand cannot be renormalized within the
+// exponent arithmetic width are rejected at sort creation for the BV
+// encoding (they would silently misround; see mkFPSort). Lives here
+// rather than fp.test.h because it needs require_abort.
+inline void fp_degenerate_format_rejected(const camada::SMTSolverRef &solver) {
+  require_abort(
+      [&]() { (void)solver->mkFPSort(2, 10, camada::FPEncoding::BV); });
+  // The boundary format itself is accepted: 2*(4+1)+5 = 15 = 2^(3+1)-1.
+  auto ok = solver->mkFPSort(3, 4, camada::FPEncoding::BV);
+  REQUIRE(ok->isFPSort());
+}
+
 inline void tests(const camada::SMTSolverRef &solver) {
   constexpr auto NativeFP = camada::FPEncoding::Native;
   constexpr auto BVFP = camada::FPEncoding::BV;
@@ -128,6 +140,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDARGTEST(fp_non_standard_widths, BVFP);
   RESETANDARGTEST(fp_cancellation_and_normalization, NativeFP);
   RESETANDARGTEST(fp_cancellation_and_normalization, BVFP);
+  RESETANDTEST(fp_wide_format_semantics);
+  RESETANDTEST(fp_degenerate_format_rejected);
 
   // Fixed-point: pure common-layer BV encoding, no backend gating needed.
   RESETANDTEST(fxp_exhaustive_semantics);

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -123,27 +123,58 @@ static inline SMTExprRef extractExpSig(SMTSolver &S, const SMTExprRef &Exp) {
   return S.mkBVExtract(Exp->getWidth() - 2, 0, Exp);
 }
 
-static inline int64_t power2(unsigned int N, bool Negated) {
-  int64_t b = 1ULL << N;
-  return Negated ? -b : b;
-}
-
-static inline int64_t power2m1(unsigned int N, bool Negated) {
-  int64_t b = 1ULL << N;
-  b -= 1;
-  return Negated ? -b : b;
+// Two's-complement bit string of +-(2^Pow + Add) at the given width,
+// computed entirely in string arithmetic. Every constant this file needs
+// has that shape, and the previous int64 helpers (1ULL << N) capped the
+// representable widths — undefined at N >= 64 — which silently broke
+// wide formats (binary128 significands, x87-extended sqrt). |Add| is
+// tiny at every call site (0, -1 or -2), so the ripple loops below run
+// at most twice.
+static std::string pow2Bits(unsigned Pow, int64_t Add, bool Negated,
+                            unsigned Width) {
+  std::string Bits(Width, '0');
+  if (Pow < Width)
+    Bits[Width - 1 - Pow] = '1';
+  auto increment = [&Bits] {
+    for (auto It = Bits.rbegin(); It != Bits.rend(); ++It) {
+      if (*It == '0') {
+        *It = '1';
+        return;
+      }
+      *It = '0';
+    }
+  };
+  auto decrement = [&Bits] {
+    for (auto It = Bits.rbegin(); It != Bits.rend(); ++It) {
+      if (*It == '1') {
+        *It = '0';
+        return;
+      }
+      *It = '1';
+    }
+  };
+  for (; Add > 0; --Add)
+    increment();
+  for (; Add < 0; ++Add)
+    decrement();
+  if (Negated) {
+    for (char &C : Bits)
+      C = C == '0' ? '1' : '0';
+    increment();
+  }
+  return Bits;
 }
 
 SMTExprRef mkMinExp(SMTSolver &S, unsigned int ExpWidth) {
-  return S.mkBVFromDec(power2m1(ExpWidth - 1, true) + 1, ExpWidth);
+  return S.mkBVFromBin(pow2Bits(ExpWidth - 1, -2, true, ExpWidth), ExpWidth);
 }
 
 SMTExprRef mkMaxExp(SMTSolver &S, unsigned int ExpWidth) {
-  return S.mkBVFromDec(power2m1(ExpWidth - 1, false), ExpWidth);
+  return S.mkBVFromBin(pow2Bits(ExpWidth - 1, -1, false, ExpWidth), ExpWidth);
 }
 
 static inline SMTExprRef mkTopExp(SMTSolver &S, unsigned int ExpWidth) {
-  return S.mkBVFromDec(power2m1(ExpWidth, false), ExpWidth);
+  return S.mkBVFromBin(pow2Bits(ExpWidth, -1, false, ExpWidth), ExpWidth);
 }
 
 static inline SMTExprRef mkBotExp(SMTSolver &S, unsigned int ExpWidth) {
@@ -217,9 +248,10 @@ static inline SMTExprRef mkIsNInf(SMTSolver &S, const SMTExprRef &Exp) {
 SMTExprRef mkOne(SMTSolver &S, const SMTExprRef &Sgn, unsigned int EWidth,
                  unsigned int SWidth) {
   return S.mkBVToIEEEFP(
-      S.mkBVConcat(
-          Sgn, S.mkBVConcat(S.mkBVFromDec(power2m1(EWidth - 1, false), EWidth),
-                            S.mkBVFromDec(0, SWidth - 1))),
+      S.mkBVConcat(Sgn, S.mkBVConcat(S.mkBVFromBin(pow2Bits(EWidth - 1, -1,
+                                                            false, EWidth),
+                                                   EWidth),
+                                     S.mkBVFromDec(0, SWidth - 1))),
       S.mkFPSort(EWidth, SWidth - 1, FPEncoding::BV));
 }
 
@@ -255,13 +287,15 @@ SMTExprRef SMTSolverImpl::getFPSpecialExpr(unsigned ExpWidth, unsigned SigWidth,
 
 static inline SMTExprRef mkBias(SMTSolver &S, const SMTExprRef &e) {
   unsigned int ExpWidth = e->getWidth();
-  SMTExprRef bias = S.mkBVFromDec(power2m1(ExpWidth - 1, false), ExpWidth);
+  SMTExprRef bias =
+      S.mkBVFromBin(pow2Bits(ExpWidth - 1, -1, false, ExpWidth), ExpWidth);
   return S.mkBVAdd(e, bias);
 }
 
 static inline SMTExprRef mkUnbias(SMTSolver &S, const SMTExprRef &Src) {
   unsigned EWidth = Src->getWidth();
-  SMTExprRef bias = S.mkBVFromDec(power2m1(EWidth - 1, false), EWidth);
+  SMTExprRef bias =
+      S.mkBVFromBin(pow2Bits(EWidth - 1, -1, false, EWidth), EWidth);
   return S.mkBVSub(Src, bias);
 }
 
@@ -519,7 +553,7 @@ SMTExprRef SMTSolverImpl::mkFPIsNormalImpl(const SMTExprRef &Exp) {
   SMTExprRef isZero = mkFPIsZero(Exp);
 
   unsigned eWidth = exp->getWidth();
-  SMTExprRef p = mkBVFromDec(power2m1(eWidth, false), eWidth);
+  SMTExprRef p = mkBVFromBin(pow2Bits(eWidth, -1, false, eWidth), eWidth);
 
   SMTExprRef isSpecial = mkEqual(exp, p);
 
@@ -1178,8 +1212,8 @@ SMTExprRef SMTSolverImpl::mkFPSqrtImpl(const SMTExprRef &Exp,
   assert(sig_prime->getWidth() == sbits + 1);
 
   // This is algorithm 10.2 in the Handbook of Floating-Point Arithmetic
-  auto p2 = power2(sbits + 3, false);
-  SMTExprRef Q = mkBVFromDec(p2, sbits + 5);
+  SMTExprRef Q =
+      mkBVFromBin(pow2Bits(sbits + 3, 0, false, sbits + 5), sbits + 5);
   SMTExprRef R = mkBVSub(mkBVConcat(sig_prime, mkBVZero4(*this)), Q);
   SMTExprRef S = Q;
 
@@ -1653,13 +1687,15 @@ SMTExprRef SMTSolverImpl::mkFPtoFPImpl(const SMTExprRef &From,
     SMTExprRef exp_sub_lz = mkBVSub(mkBVSignExt(2, exp), mkBVSignExt(2, lz));
 
     // check whether exponent is within roundable (to_ebits+2) range.
-    unsigned int z = power2(to_ebits + 1, true);
     SMTExprRef max_exp = mkBVConcat(
-        mkBVFromDec(power2m1(to_ebits, false), to_ebits + 1), mkBVZero1(*this));
-    SMTExprRef min_exp = mkBVFromDec(z + 2, to_ebits + 2);
+        mkBVFromBin(pow2Bits(to_ebits, -1, false, to_ebits + 1), to_ebits + 1),
+        mkBVZero1(*this));
+    // -(2^(to_ebits+1)) + 2 == -(2^(to_ebits+1) - 2)
+    SMTExprRef min_exp = mkBVFromBin(
+        pow2Bits(to_ebits + 1, -2, true, to_ebits + 2), to_ebits + 2);
 
-    unsigned int ovft = power2m1(to_ebits + 1, false);
-    SMTExprRef first_ovf_exp = mkBVFromDec(ovft, from_ebits + 2);
+    SMTExprRef first_ovf_exp = mkBVFromBin(
+        pow2Bits(to_ebits + 1, -1, false, from_ebits + 2), from_ebits + 2);
     SMTExprRef first_udf_exp = mkBVConcat(
         mkBVNeg(mkBVFromDec(1, ebits_diff + 3)), mkBVFromDec(1, to_ebits + 1));
 
@@ -2063,7 +2099,8 @@ SMTExprRef SMTSolverImpl::mkFPtoIntegralImpl(const SMTExprRef &From,
   SMTExprRef none = mkFPOne(*this, ebits, sbits, true);
   SMTExprRef xone = mkIte(sgn_eq_1, none, pone);
 
-  SMTExprRef pow_2_sbitsm1 = mkBVFromDec(power2(sbits - 1, false), sbits);
+  SMTExprRef pow_2_sbitsm1 =
+      mkBVFromBin(pow2Bits(sbits - 1, 0, false, sbits), sbits);
   SMTExprRef m1 = mkBVNeg(mkBVFromDec(1, ebits));
   SMTExprRef t1 = mkEqual(a_sig, pow_2_sbitsm1);
   SMTExprRef t2 = mkEqual(a_exp, m1);
@@ -2249,6 +2286,15 @@ SMTExprRef SMTSolverImpl::round(const SMTExprRef &R, const SMTExprRef &Sgn,
   // in sgn. Furthermore, note that sig is an unsigned bit-vector, while exp is
   // signed.
 
+  // The leading-zero count of the (SWidth + 4)-bit significand is used in
+  // (EWidth + 2)-bit signed arithmetic below, so it must fit as a positive
+  // value. mkFPSort rejects such formats for the BV encoding; this backstop
+  // catches BVFP sorts minted through backend-internal routes (e.g.
+  // MathSAT's bvfpView) that bypass the public sort constructor.
+  fatalErrorIf(EWidth < 31 && SWidth + 4 > (1u << (EWidth + 1)) - 1,
+               "Floating-point format unsupported by the BV rounder: the "
+               "significand is too wide for the exponent width");
+
   assert(R->getWidth() == 3);
   assert(Sgn->getWidth() == 1);
   assert(Sig->getWidth() >= 5);
@@ -2381,7 +2427,8 @@ SMTExprRef SMTSolverImpl::round(const SMTExprRef &R, const SMTExprRef &Sgn,
   SMTExprRef exp_redand = mkBVRedAnd(biased_exp);
   SMTExprRef preOVF2 = mkEqual(exp_redand, one_1);
   SMTExprRef OVF2 = mkAnd(SIGovf, preOVF2);
-  SMTExprRef pem2m1 = mkBVFromDec(power2m1(EWidth - 2, false), EWidth);
+  SMTExprRef pem2m1 =
+      mkBVFromBin(pow2Bits(EWidth - 2, -1, false, EWidth), EWidth);
   biased_exp = mkIte(OVF2, pem2m1, biased_exp);
   SMTExprRef OVF = mkOr(OVF1, OVF2);
 
@@ -2402,9 +2449,11 @@ SMTExprRef SMTSolverImpl::round(const SMTExprRef &R, const SMTExprRef &Sgn,
 
   SMTExprRef sgn_is_zero = mkEqual(Sgn, nil_1);
 
-  SMTExprRef max_sig = mkBVFromDec(power2m1(SWidth - 1, false), SWidth - 1);
+  SMTExprRef max_sig =
+      mkBVFromBin(pow2Bits(SWidth - 1, -1, false, SWidth - 1), SWidth - 1);
   SMTExprRef max_exp = mkBVConcat(
-      mkBVFromDec(power2m1(EWidth - 1, false), EWidth - 1), mkBVZero1(*this));
+      mkBVFromBin(pow2Bits(EWidth - 1, -1, false, EWidth - 1), EWidth - 1),
+      mkBVZero1(*this));
   SMTExprRef inf_sig = mkBVFromDec(0, SWidth - 1);
   const SMTExprRef &inf_exp = top_exp;
 

--- a/src/camadaimpl.cpp
+++ b/src/camadaimpl.cpp
@@ -386,6 +386,18 @@ SMTSortRef SMTSolverImpl::mkFPSort(const unsigned ExpWidth,
   constexpr unsigned MaxWidth = std::numeric_limits<unsigned>::max();
   fatalErrorIf(SigWidth > MaxWidth - 1 || ExpWidth > MaxWidth - 1 - SigWidth,
                "Floating-point sort width overflow");
+  // The BV encoding's normalization counts leading zeros of intermediates
+  // up to 2*sbits + 5 bits wide (sbits = SigWidth + 1 with the hidden
+  // bit; the widest is FMA's renormalize) in (ExpWidth + 2)-bit signed
+  // arithmetic, so the count must fit as a positive value there. A format
+  // with a wide significand and a tiny exponent would silently misround —
+  // reject it at sort creation. Every IEEE format passes with orders of
+  // magnitude to spare (binary32: 53 <= 511).
+  fatalErrorIf(Encoding == FPEncoding::BV && ExpWidth < 31 &&
+                   2 * (SigWidth + 1) + 5 > (1u << (ExpWidth + 1)) - 1,
+               "Floating-point format unsupported by the BV encoding: the "
+               "significand is too wide for the exponent width (requires "
+               "2*(SigWidth+1) + 5 <= 2^(ExpWidth+1) - 1)");
   auto &Cache = FPSortCaches[fpEncodingIndex(Encoding)];
   FPSortCacheKey Key{ExpWidth, SigWidth};
   auto It = Cache.find(Key);


### PR DESCRIPTION
## What

Two format-robustness fixes in the FP-over-BV encoding, from the capability/quality review:

1. **Width-safe constants.** The `power2`/`power2m1` helpers computed constants via `1ULL << N` — undefined behavior at `N >= 64` — so wide formats were silently broken through the BV encoding: binary128's significand masks (`2^112 - 1`) and x87-extended sqrt's `2^(sbits+3)` with `sbits = 64`. Every constant in the file has the shape `±(2^Pow + Add)` with `|Add| <= 2`, so they are now built as two's-complement bit strings at any width (`pow2Bits`), and the int64 helpers are gone. Thirteen call sites converted, including the FP-to-FP conversion block that previously stuffed a negative value into `unsigned int` and survived by accidental modular truncation.
2. **Degenerate-format rejection.** The rounder and FMA renormalize count leading zeros of up to `(2*sbits + 5)`-bit intermediates in `(ExpWidth + 2)`-bit signed arithmetic (the inherited `CMW: is this always large enough?` question, now answered). A format with a wide significand and tiny exponent silently misrounds, so `mkFPSort` rejects it for the BV encoding (`2*(SigWidth+1) + 5 <= 2^(ExpWidth+1) - 1`), with a backstop in `round()` for BVFP sorts minted through backend-internal routes (MathSAT's `bvfpView`). Every IEEE format passes with wide margins (binary32: 53 vs 511).

## Validation

- `pow2Bits` verified against an `__int128` reference over every call-site shape at widths 1–126: 874/874 exact.
- All 231 regression tests pass on every backend, now including new fixtures: binary128 `1+1==2` and x87-like `(15,63)` `sqrt(4)==2` end-to-end (both UB before this patch), the degenerate rejection (`mkFPSort(2,10,BV)` aborts), and the exact boundary format `(3,4)` accepted.
- Review verified each of the 13 conversions against the removed formulas (including the modular-truncation site), the bound's sufficiency for every leading-zero-count site in the file, and the shift guards; no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhZgn5Po8RyT7zDGj2mEk3