### PR TITLE
Add roundfx with a caller-selected tie direction

### DIFF
--- a/fxp-plan.md
+++ b/fxp-plan.md
@@ -144,7 +144,13 @@ both the rounded value **and** the overflow predicate are derived from it.
 | FXP→FXP | **extend first** (per source signedness) to a width that holds both formats, **then** shift by `n_to − n_from`, then truncate to target — never shift-then-extend, which discards high bits on widening conversions | `mkFXPToFXPOverflow` from the wide pre-truncation value |
 | FXP→integer | **round toward zero** (specified by TR 18037): signed divide by `2^n`, or bias the negative case before `ashr` — plain `ashr` alone is wrong (floors: `-1.5 → -2`, C requires `-1`) | `mkFXPToBVOverflow` from the wide value |
 
-## Tier 2 (deferred): `_Sat` and rounding control
+## Tier 2 (shipped Aug 2026): `_Sat` and rounding control
+
+All of tier 2 has landed: the saturating operations in #133, the
+execution oracle and the division-rounding fix in #134, and the
+fixed<->float conversions plus `roundfx` in #135. The rulings below are
+kept as the record of why each piece was built the way it was; the
+"blocked" notes are historical and carry their resolution inline.
 
 **Decided (Aug 2026): saturation is an operation property, not a sort
 property.** `_Sat _Fract` shares its representation with `_Fract`
@@ -168,11 +174,26 @@ out: the frontend must know the types anyway.
   surface and doubles the arithmetic test matrix.
 - Round-to-nearest on narrowing (`roundfx`-style, half-ulp bias before the
   truncating shift). **Ruling (Aug 2026): camada-owned, blocked on the
-  oracle.** The half-ulp bias overflows the source format at its maximum,
-  so the correct composition needs a wider intermediate at the right
-  scale with the `_Sat` clamp ordered after the bias — a width trap the
-  layer exists to own. Not built until the Clang oracle pins the halfway
-  direction empirically (the TR leaves it unspecified).
+  oracle. IMPLEMENTED Aug 2026** as `mkFXPRound(Exp, Digits)`. The
+  blocker was resolved from the wrong direction: Clang ships no
+  `stdfix.h` and no `roundfx` (nor does GCC's, which declares only types,
+  `abs` and `bits`), so the generator cannot measure it. **LLVM libc**
+  implements all twelve variants, and its source shows round to nearest
+  with **ties toward +infinity** (`x + round_bit` then mask) and
+  **saturate to MAX** when the bias overflows — exactly the width trap
+  this ruling predicted. But the TR leaves the tie direction to the
+  implementation and implementations differ (GCC's AVR builtins are the
+  other one that ships `roundfx`; glibc, musl, newlib and uClibc have no
+  fixed-point support at all), so the **tie direction is a parameter**
+  (`FXPRoundTie`: TowardPositive, AwayFromZero, ToEven) rather than one
+  library's choice baked in — the `FPNegBehavior` precedent for an
+  implementation-defined split. Saturation is not parameterized: every
+  implementation surveyed agrees on it.
+  Note the operation keeps its format and clears the low fraction bits;
+  it is not a narrowing conversion. Verified against 52452 vectors from
+  executing libc's algorithm over Clang's fixed-point types. Since it is
+  a library function rather than a builtin, a consumer only needs it when
+  the program under test links LLVM libc.
 - FXP<->FP conversions. **Ruling (Aug 2026): camada-owned, blocked on
   ESBMC Phase 3 demand + the oracle. UNBLOCKED Aug 2026 by
   REPORT-fxp-api-gaps.md: demand live (ESBMC refuses fixed<->float,
@@ -254,15 +275,17 @@ keeps.
 | `fxp.test.h` + per-backend instantiation + oracle tables | ~700–900 lines |
 | README (feature list, parity table row: all ✔️, encoded) | small |
 
-Still one PR for tier 1, but at the upper end; if it grows past that,
-split as (a) sorts + arithmetic + predicates, (b) conversions + shifts +
-generic-construct integration. Tier 2 (`_Sat`) lands as a follow-up PR.
+In the end tier 1 landed as one PR and tier 2 as three (#133 saturating
+ops, #134 oracle and division fix, #135 conversions and `roundfx`).
 
 ## Risks and open questions
 
-1. **Clang pinning**: the oracle configuration (version/target/flags)
-   must match what ESBMC's clang-c-frontend actually uses — needs a look
-   at ESBMC before the oracle tables are generated.
+1. **Clang pinning — RESOLVED (Aug 2026)**: pinned to clang 22.1.6,
+   `x86_64-unknown-linux`, `-ffixed-point`, seed `0xCA3ADA`, per ESBMC's
+   answers in `ANSWERS-fxp-tier2-scope.md`; the generated header records
+   the configuration. ESBMC's own measurements on clang 20.1.8 reproduce
+   exactly under the pin, so the fixed-point lowering is stable across
+   those releases.
 2. **Padding bits**: TR 18037 permits padded fixed-point formats; the
    `(w, n, signedness)` metadata cannot express them. No mainstream
    Clang target uses padding; explicitly out of scope until a consumer

--- a/regression/fxp.test.h
+++ b/regression/fxp.test.h
@@ -741,6 +741,163 @@ inline void fxp_symbolic_shift_semantics(const camada::SMTSolverRef &solver) {
   }
 }
 
+// roundfx: round to nearest at a chosen fraction width, ties toward +inf,
+// saturating to the format maximum when the half-ulp bias overflows. The
+// reference is written from the TR/libc semantics (bias then mask, with an
+// exact-arithmetic overflow test), independently of the encoding's shape.
+// Written from the value semantics — round the exact quotient to an
+// integer per the tie rule, then rescale — rather than mirroring the
+// encoding's bias-and-mask shape, so the fixtures pin that the two agree.
+inline uint64_t refRound(const RefFormat &F, int64_t A, unsigned Digits,
+                         camada::FXPRoundTie Tie) {
+  if (Digits >= F.FracBits)
+    return refWrap(F, A);
+  unsigned Shift = F.FracBits - Digits;
+  int64_t Unit = int64_t(1) << Shift;
+  int64_t Q = refFloorDiv(A, Unit); // floor, so Rem is never negative
+  int64_t Rem = A - Q * Unit;
+  int64_t Half = Unit / 2;
+  if (Rem > Half)
+    ++Q;
+  else if (Rem == Half) {
+    switch (Tie) {
+    case camada::FXPRoundTie::TowardPositive:
+      ++Q;
+      break;
+    case camada::FXPRoundTie::AwayFromZero:
+      if (A >= 0)
+        ++Q;
+      break;
+    case camada::FXPRoundTie::ToEven:
+      Q += Q & 1;
+      break;
+    }
+  }
+  int64_t V = Q * Unit;
+  return refWrap(F, V > F.maxRaw() ? F.maxRaw() : V);
+}
+
+inline void fxp_round_semantics(const camada::SMTSolverRef &solver) {
+  // Exhaustive over every 5- and 6-bit format, every digit count, both
+  // signednesses, and all three tie rules: small enough to enumerate
+  // every raw value, wide enough to exercise saturation, ties, and
+  // negative rounding.
+  for (camada::FXPRoundTie Tie :
+       {camada::FXPRoundTie::TowardPositive, camada::FXPRoundTie::AwayFromZero,
+        camada::FXPRoundTie::ToEven}) {
+    for (unsigned Width : {5u, 6u}) {
+      for (unsigned Frac = 0; Frac < Width; ++Frac) {
+        for (bool Signed : {true, false}) {
+          if (Signed && Frac + 1 > Width - 1)
+            continue; // signed needs a non-fraction sign bit
+          RefFormat F{Width, Frac, Signed};
+          for (unsigned Digits = 0; Digits <= Frac + 1; ++Digits) {
+            solver->reset();
+            camada::SMTExprRef All;
+            for (uint64_t Raw = 0; Raw < (uint64_t(1) << Width); ++Raw) {
+              camada::SMTExprRef C = solver->mkFXPEqual(
+                  solver->mkFXPRound(mkConst(solver, F, Raw), Digits, Tie),
+                  mkConst(solver, F,
+                          refRound(F, refDecode(F, Raw), Digits, Tie)));
+              All = All ? solver->mkAnd(All, C) : C;
+            }
+            solver->addConstraint(All);
+            REQUIRE(solver->check() == camada::checkResult::SAT);
+          }
+        }
+      }
+    }
+  }
+
+  // The three rules are pairwise distinguishable, which is the point of
+  // exposing the choice. In s.4 at zero digits: -0.5 (raw -8) stays at 0
+  // toward positive but goes to -1.0 away from zero, and +0.5 (raw 8)
+  // goes to 1.0 under both of those but down to 0 under ties-to-even,
+  // whose neighbour 0 is the one with a zero in the last kept bit.
+  {
+    solver->reset();
+    RefFormat F{6, 4, true};
+    auto R = [&](int64_t Raw, unsigned D, camada::FXPRoundTie T) {
+      return solver->mkFXPRound(mkConst(solver, F, refWrap(F, Raw)), D, T);
+    };
+    auto C = [&](int64_t Raw) { return mkConst(solver, F, refWrap(F, Raw)); };
+    using camada::FXPRoundTie;
+    camada::SMTExprRef All = solver->mkAnd(
+        solver->mkFXPEqual(R(-8, 0, FXPRoundTie::TowardPositive), C(0)),
+        solver->mkFXPEqual(R(-8, 0, FXPRoundTie::AwayFromZero), C(-16)));
+    All = solver->mkAnd(
+        All, solver->mkFXPEqual(R(-8, 0, FXPRoundTie::ToEven), C(0)));
+    All = solver->mkAnd(
+        All,
+        solver->mkAnd(
+            solver->mkFXPEqual(R(8, 0, FXPRoundTie::TowardPositive), C(16)),
+            solver->mkFXPEqual(R(8, 0, FXPRoundTie::AwayFromZero), C(16))));
+    All = solver->mkAnd(All,
+                        solver->mkFXPEqual(R(8, 0, FXPRoundTie::ToEven), C(0)));
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+
+  // LLVM libc's own RoundTest vectors, on _Fract (s.15). EPS is one ulp.
+  {
+    solver->reset();
+    RefFormat Fr{16, 15, true};
+    const uint64_t Half = 1u << 14, Eps = 1, One = 0x7fff; // 1.0 saturates
+    struct {
+      uint64_t In;
+      unsigned Digits;
+      uint64_t Out;
+    } V[] = {
+        {0, 0, 0},                           // zero stays zero
+        {Half, 0, One},                      // 0.5 -> 1 (ties up, saturating)
+        {Half, 1, Half},                     // 0.5 kept at 1 digit
+        {Half + Eps, 0, One},                // just above half rounds up
+        {Half - Eps, 0, 0},                  // just below half rounds down
+        {Eps, 15, Eps},                      // eps kept at full precision
+        {Eps, 14, 2 * Eps},                  // eps at one fewer bit doubles
+        {Eps, 13, 0},                        // eps at two fewer bits vanishes
+        {refWrap(Fr, -int64_t(Half)), 0, 0}, // -0.5 -> 0 (ties to +inf)
+        {refWrap(Fr, -int64_t(Half)), 1, refWrap(Fr, -int64_t(Half))},
+        {refWrap(Fr, -int64_t(Half) - 1), 0, refWrap(Fr, -int64_t(One) - 1)},
+    };
+    camada::SMTExprRef All;
+    for (auto &T : V) {
+      camada::SMTExprRef C = solver->mkFXPEqual(
+          solver->mkFXPRound(mkConst(solver, Fr, T.In), T.Digits,
+                             camada::FXPRoundTie::TowardPositive),
+          mkConst(solver, Fr, T.Out));
+      All = All ? solver->mkAnd(All, C) : C;
+    }
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+
+  // Symbolic properties at a width no host sweep reaches: rounding to the
+  // full fraction width is the identity, and every result either has its
+  // discarded fraction bits clear or is the saturated maximum (whose low
+  // bits are all ones, so the mask property genuinely does not hold
+  // there).
+  {
+    solver->reset();
+    camada::SMTSortRef Wide = solver->mkFXPSort(48, 31, true);
+    camada::SMTExprRef X = solver->mkSymbol("fxp_round_x", Wide);
+    camada::SMTExprRef Id = solver->mkFXPEqual(
+        solver->mkFXPRound(X, 31, camada::FXPRoundTie::TowardPositive), X);
+    camada::SMTExprRef R =
+        solver->mkFXPRound(X, 23, camada::FXPRoundTie::TowardPositive);
+    camada::SMTExprRef Max = solver->mkFXPFromBin(
+        refBits(RefFormat{48, 31, true},
+                uint64_t(RefFormat{48, 31, true}.maxRaw())),
+        Wide);
+    camada::SMTExprRef Low = solver->mkOr(
+        solver->mkEqual(solver->mkBVExtract(7, 0, solver->mkFXPToRawBV(R)),
+                        solver->mkBVFromDec(0, 8)),
+        solver->mkFXPEqual(R, Max));
+    solver->addConstraint(solver->mkNot(solver->mkAnd(Id, Low)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
+}
+
 // Fixed <-> floating point: targeted cases the oracle tables cannot carry
 // (a nonstandard FP target, predicate boundaries, a symbolic round-trip).
 // The oracle fixture in fxporacle.test.h pins the full float/double
@@ -890,6 +1047,7 @@ using camada_fxp_test::fxp_exhaustive_semantics;
 using camada_fxp_test::fxp_fp_conversion_semantics;
 using camada_fxp_test::fxp_mixed_format_semantics;
 using camada_fxp_test::fxp_model_and_constructs;
+using camada_fxp_test::fxp_round_semantics;
 using camada_fxp_test::fxp_rounding_semantics;
 using camada_fxp_test::fxp_sat_conversion_semantics;
 using camada_fxp_test::fxp_sat_exhaustive_semantics;

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -156,6 +156,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(fxp_sat_shift_semantics);
   RESETANDTEST(fxp_sat_conversion_semantics);
   RESETANDTEST(fxp_symbolic_shift_semantics);
+  RESETANDTEST(fxp_round_semantics);
   RESETANDTEST(fxp_oracle_semantics);
   RESETANDTEST(fxp_oracle_mixed_semantics);
   RESETANDARGTEST(fxp_fp_conversion_semantics, NativeFP);

--- a/src/camada.h
+++ b/src/camada.h
@@ -96,6 +96,29 @@ enum class FPNegBehavior {
   PreserveNaNPayload,
 };
 
+/// Selects how `mkFXPRound` breaks ties. TR 18037 specifies that the
+/// `roundfx` family rounds to nearest but leaves the halfway direction to
+/// the implementation, and implementations differ, so the caller states
+/// which one it is modelling rather than inheriting one library's choice.
+///
+/// - TowardPositive: a halfway value rounds up, so 0.5 rounds to 1 and
+///   -0.5 rounds to 0. What LLVM libc does (it adds half an ulp and masks
+///   off the low bits), and the only direction verified against an
+///   executing implementation.
+/// - AwayFromZero: a halfway value rounds away from zero, so 0.5 rounds
+///   to 1 and -0.5 rounds to -1 — symmetric about zero, the convention
+///   most C programmers expect from `round()`.
+/// - ToEven: a halfway value rounds to whichever neighbour has a zero in
+///   the last kept bit, the unbiased choice IEEE-754 uses by default.
+///
+/// All three saturate to the format's maximum when the rounding would
+/// carry past it, which every implementation surveyed agrees on.
+enum class FXPRoundTie {
+  TowardPositive,
+  AwayFromZero,
+  ToEven,
+};
+
 /// Selects how the SMT-LIB backend lowers tuples on the wire.
 ///
 /// - Native: emit `(declare-datatypes ...)` and rely on the downstream
@@ -888,6 +911,14 @@ public:
   /// clamps to zero for an unsigned target.
   virtual SMTExprRef mkFXPToBVSat(const SMTExprRef &Exp, unsigned ToWidth,
                                   bool ToSigned) = 0;
+
+  /// Rounds a fixed-point value to Digits fractional bits, keeping the
+  /// same format (the low fraction bits become zero) — TR 18037's
+  /// `roundfx`. Rounds to nearest, breaking ties per Tie, and saturates
+  /// to the format's maximum when the rounding would carry past it.
+  /// Digits >= the format's fraction width returns the value unchanged.
+  virtual SMTExprRef mkFXPRound(const SMTExprRef &Exp, unsigned Digits,
+                                FXPRoundTie Tie) = 0;
 
   /// Converts a fixed-point value to a floating-point value of the given
   /// sort, rounding once per R. C's fixed-to-float conversion rounds to

--- a/src/camadaexpr.h
+++ b/src/camadaexpr.h
@@ -166,6 +166,7 @@ enum class SMTExprKind {
   FXPToBVSat,
   BVToFXP,
   FXPToRawBV,
+  FXPRound,
   FXPToFP,
   FPToFXP,
   FPToFXPSat,

--- a/src/camadafxp.cpp
+++ b/src/camadafxp.cpp
@@ -824,6 +824,64 @@ SMTExprRef SMTSolverImpl::mkFXPToBVSat(const SMTExprRef &Exp, unsigned ToWidth,
 }
 
 // ---------------------------------------------------------------------------
+// Rounding to a fraction width (TR 18037 roundfx)
+// ---------------------------------------------------------------------------
+
+SMTExprRef SMTSolverImpl::mkFXPRound(const SMTExprRef &Exp, unsigned Digits,
+                                     FXPRoundTie Tie) {
+  requireFXP(Exp);
+  FXPFormat F = formatOf(Exp->Sort);
+  // Keeping at least every fraction bit is the identity; libc clamps a
+  // negative count to zero, which is unrepresentable in an unsigned
+  // parameter and so cannot occur here.
+  if (Digits >= F.FracBits)
+    return Exp;
+  // Round to nearest by adding a bias and then clearing the bits below
+  // the kept precision. Half an ulp biases ties upward; subtracting one
+  // from it on negative inputs turns that into ties away from zero, and
+  // adding the lowest kept bit instead turns it into ties to even. The
+  // bias can carry past the format's maximum, which saturates to MAX
+  // instead of wrapping — so the sum is computed one bit wider and
+  // compared there, where it is exact for both signednesses.
+  unsigned Shift = F.FracBits - Digits;
+  unsigned W = F.Width + 1;
+  SMTExprRef Raw = extendRaw(*this, mkFXPToRawBV(Exp), F.IsSigned, 1);
+  std::string HalfBits(W, '0');
+  HalfBits[W - Shift] = '1'; // 2^(Shift-1), half an ulp of the result
+  SMTExprRef Bias = mkBVFromBin(HalfBits, W);
+  SMTExprRef One = mkBVFromDec(1, W);
+  switch (Tie) {
+  case FXPRoundTie::TowardPositive:
+    break;
+  case FXPRoundTie::AwayFromZero:
+    // Only signed formats have negative values to bias differently.
+    if (F.IsSigned)
+      Bias = mkBVSub(
+          Bias, mkIte(mkBVSlt(Raw, mkBVFromDec(0, W)), One, mkBVFromDec(0, W)));
+    break;
+  case FXPRoundTie::ToEven:
+    // half - 1 + (lowest kept bit): a tie lands on the even neighbour.
+    Bias = mkBVAdd(mkBVSub(Bias, One),
+                   mkBVZeroExt(W - 1, mkBVExtract(Shift, Shift, Raw)));
+    break;
+  }
+  SMTExprRef Sum = mkBVAdd(Raw, Bias);
+  std::string MaskBits(W, '1');
+  MaskBits.replace(W - Shift, Shift, Shift, '0');
+  SMTExprRef Rounded = mkBVAnd(Sum, mkBVFromBin(MaskBits, W));
+  SMTExprRef Max = mkBVFromBin(maxRawBits(F, W), W);
+  // Overflow is exactly "the biased sum exceeds MAX". The slack bit keeps
+  // the sum exact for both signednesses, but the comparison must follow
+  // the format's own signedness: an unsigned format's MAX is all-ones in
+  // F.Width bits, which a signed compare would read as negative once the
+  // format fills the widened value.
+  SMTExprRef Res =
+      mkIte(F.IsSigned ? mkBVSgt(Sum, Max) : mkBVUgt(Sum, Max), Max, Rounded);
+  return rewrapExprImpl(*mkBVExtract(F.Width - 1, 0, Res), Exp->Sort,
+                        SMTExprKind::FXPRound);
+}
+
+// ---------------------------------------------------------------------------
 // Fixed-point <-> floating-point conversions
 // ---------------------------------------------------------------------------
 //

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -644,6 +644,8 @@ public:
                            const SMTSortRef &To) override;
   SMTExprRef mkFXPToBVSat(const SMTExprRef &Exp, unsigned ToWidth,
                           bool ToSigned) override;
+  SMTExprRef mkFXPRound(const SMTExprRef &Exp, unsigned Digits,
+                        FXPRoundTie Tie) override final;
   SMTExprRef mkFXPToFP(const SMTExprRef &Exp, const SMTSortRef &To,
                        RM R) override final;
   SMTExprRef mkFPToFXP(const SMTExprRef &Exp,


### PR DESCRIPTION
Adds `mkFXPRound` — TR 18037's `roundfx`: round a fixed-point value to a
chosen number of fractional bits, keeping the same format.

## The tie direction is a parameter

TR 18037 says `roundfx` rounds to nearest but leaves the halfway
direction to the implementation, and implementations do differ. So
`mkFXPRound(Exp, Digits, Tie)` takes an `FXPRoundTie`:

- `TowardPositive` — 0.5 rounds up, -0.5 rounds to 0. What LLVM libc
  does, and the only direction verified against an executing
  implementation.
- `AwayFromZero` — symmetric about zero, the convention most C
  programmers expect from `round()`.
- `ToEven` — the unbiased choice, IEEE-754's default.

This follows the `FPNegBehavior` precedent for an implementation-defined
split: camada states the choice rather than silently adopting one
library's. Saturation to the format maximum is *not* parameterized —
every implementation surveyed agrees on it.

Worth recording what "implementations differ" actually surveys, since
the field is small: only **LLVM libc** and **GCC's AVR builtins** ship
`roundfx` at all. glibc, musl, newlib and uClibc have no fixed-point
support whatsoever, and Clang ships no `stdfix.h`. (libfixmath and
MATLAB, which some comparisons list alongside these, are independent
libraries that do not implement TR 18037 — they disagree the way any two
unrelated fixed-point libraries do.)

## Encoding

Bias then mask, with the bias chosen per mode: half an ulp for
`TowardPositive`, minus one on negative inputs for `AwayFromZero`, and
half-an-ulp-minus-one plus the lowest kept bit for `ToEven`. The bias can
carry past the format's maximum, so the sum is computed one bit wider and
compared there, where it is exact for both signednesses.

## Verification

- **52452 vectors** produced by compiling LLVM libc's own `round()`
  algorithm over Clang's real fixed-point types and executing it, all
  matching under `TowardPositive`.
- **Exhaustive sweep** over every 5- and 6-bit format, both signednesses,
  every digit count, every raw value, and all three tie modes, against a
  reference written from the value semantics (round the exact quotient,
  then rescale) rather than mirroring the encoding's shape.
- LLVM libc's own documented test vectors, and symbolic properties at a
  width no host sweep reaches.
- Vectors pinning that the three modes are pairwise distinguishable, so
  the parameter demonstrably does something.

232 tests pass on all seven backends.

## Note on history

This was originally part of #135 but landed on the branch after that PR
merged, so it was never included. Rebuilding it here has the advantage
that `mkFXPRound` never ships with the un-parameterized signature.
