### PR TITLE
Bump version to 0.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 set(CAMADA_VER_MAJOR 0)
-set(CAMADA_VER_MINOR 15)
+set(CAMADA_VER_MINOR 16)
 
 project(
   camada

--- a/regression/main.cpp
+++ b/regression/main.cpp
@@ -13,5 +13,5 @@ int main(int argc, char *argv[]) {
 // a quoting mistake there once shipped the literal macro names as the
 // version string, and nothing noticed.
 TEST_CASE("Camada version string", "[Camada]") {
-  REQUIRE(camada::getCamadaVersion() == "0.15");
+  REQUIRE(camada::getCamadaVersion() == "0.16");
 }


### PR DESCRIPTION
Version bump for the v0.16 release, which is the fixed-point release:
ESBMC's Phase 3 gap report is fully closed, so their migration can
consume a tag instead of a branch head.

Since v0.15:

- **Saturating fixed-point operations** (#133) — the TR 18037 `_Sat`
  family, plus a target-signedness parameter on the integer range checks
  and runtime-amount shifts.
- **A fixed-point execution oracle, and a division-rounding fix** (#134)
  — Clang floors signed division where camada truncated toward zero.
  That is a correctness fix to what v0.15 shipped.
- **Fixed <-> floating point conversions** (#135), rounding once through
  an exact wide intermediate, plus a latent `fp.to_sbv` fix for
  one-bit signed targets.
- **`roundfx` with a caller-selected tie direction** (#136) — the TR
  leaves the halfway direction to the implementation, so the caller
  states which one it models.
- **`absfx`, `countlsfx` and a correctly-rounded `sqrtfx`** (#137), plus
  a fix for STP aborting on a zero-width bit-vector extension.
