### PR TITLE
Fix STP bvsrem returning the divisor's sign

### DIFF
--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -201,6 +201,27 @@ inline void bv_extend_by_zero_semantics(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::checkResult::SAT);
 }
 
+// bvsrem takes the sign of the DIVIDEND and bvsdiv truncates toward zero
+// (SMT-LIB), which differ from the modulo convention whenever the operand
+// signs disagree: -7 srem 2 is -1, not +1. The STP backend used to call
+// STP's modulo routine here and silently returned the divisor's sign.
+inline void bv_signed_div_rem_semantics(const camada::SMTSolverRef &solver) {
+  auto d = [&](int64_t V) { return solver->mkBVFromDec(V, 32); };
+  struct Case {
+    int64_t A, B, SDiv, SRem;
+  };
+  const Case Cases[] = {
+      {-7, 2, -3, -1}, {7, -2, -3, 1}, {-7, -2, 3, -1}, {7, 2, 3, 1}};
+  camada::SMTExprRef All = solver->mkBool(true);
+  for (const Case &C : Cases)
+    All = solver->mkAnd(
+        All, solver->mkAnd(
+                 solver->mkEqual(solver->mkBVSDiv(d(C.A), d(C.B)), d(C.SDiv)),
+                 solver->mkEqual(solver->mkBVSRem(d(C.A), d(C.B)), d(C.SRem))));
+  solver->addConstraint(All);
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
 inline void bv_lshr_semantics(const camada::SMTSolverRef &solver) {
   auto value = solver->mkBVFromBin("1000", 4);
   auto shift = solver->mkBVFromDec(1, 4);

--- a/src/stpsolver.cpp
+++ b/src/stpsolver.cpp
@@ -237,9 +237,12 @@ SMTExprRef STPSolver::mkBVMulOverflowImpl(const SMTExprRef &LHS,
 
 SMTExprRef STPSolver::mkBVSRemImpl(const SMTExprRef &LHS,
                                    const SMTExprRef &RHS) {
+  // vc_sbvRemExpr, not vc_sbvModExpr: SMT-LIB's bvsrem takes the sign of
+  // the dividend, while STP's "mod" takes the sign of the divisor. The
+  // two agree only when the operand signs match.
   return makeExprRef<STPExpr>(
       SMTExprKind::BVSRem, &Context, LHS->Sort,
-      STP::vc_sbvModExpr(Context, LHS->getWidth(),
+      STP::vc_sbvRemExpr(Context, LHS->getWidth(),
                          toSolverExpr<STPExpr>(*LHS).Expr,
                          toSolverExpr<STPExpr>(*RHS).Expr));
 }


### PR DESCRIPTION
**Soundness fix.** STP has returned the wrong sign from `bvsrem` since
the backend was added in July 2020 (`2d95f25`), so this affects every
release including v0.16.

`mkBVSRemImpl` called STP's `vc_sbvModExpr`, which is a *modulo*: its
result takes the sign of the divisor. SMT-LIB's `bvsrem` takes the sign
of the **dividend**. The two agree only when the operand signs match, so:

| expression | SMT-LIB | STP returned |
|---|---|---|
| `-7 srem 2` | `-1` | **`+1`** |
| `7 srem -2` | `+1` | **`-1`** |
| `-7 srem -2` | `-1` | `-1` ✓ |
| `7 srem 2` | `+1` | `+1` ✓ |

`bvsdiv` was always correct; STP's `vc_sbvDivExpr` already truncates
toward zero. The fix is to call `vc_sbvRemExpr`, which is the operation
camada wants.

## Why it went unnoticed for five years

No fixture exercised `mkBVSRem` on any backend — grepping the regression
suite for it before this change returns nothing. The operation had zero
coverage, so there was nothing to fail.

It surfaced while implementing a fixed-point `exp`, which is the first
code in camada to use `bvsrem` with a deliberately negative dividend (to
floor-adjust `x / ln2`). STP computed a different result from every other
backend for one input, and bisecting the encoder's intermediates traced
it here.

## Impact

Anything lowering C's `%` on mixed-sign integers through STP could have
produced unsound results. Worth an audit of the other backends'
arithmetic against SMT-LIB semantics — if `bvsrem` went five years
untested, siblings may have too.

## Test

`bv_signed_div_rem_semantics` covers `bvsdiv` and `bvsrem` across all
four sign combinations, on every backend. Confirmed to fail on the
unfixed STP backend (at assertion 23, early in the suite) and pass after.

232 tests pass on all seven backends.
