### PR TITLE
Bump version to 0.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 set(CAMADA_VER_MAJOR 0)
-set(CAMADA_VER_MINOR 16)
+set(CAMADA_VER_MINOR 17)
 
 project(
   camada

--- a/regression/main.cpp
+++ b/regression/main.cpp
@@ -13,5 +13,5 @@ int main(int argc, char *argv[]) {
 // a quoting mistake there once shipped the literal macro names as the
 // version string, and nothing noticed.
 TEST_CASE("Camada version string", "[Camada]") {
-  REQUIRE(camada::getCamadaVersion() == "0.16");
+  REQUIRE(camada::getCamadaVersion() == "0.17");
 }


### PR DESCRIPTION
Version bump for v0.17.

Worth releasing promptly rather than waiting for more features: v0.16
ships a soundness bug that has been present since 2020, and a release is
how consumers get the fix.

Since v0.16:

- **`bvsrem` returned the divisor's sign on STP** (#139) — SMT-LIB takes
  the sign of the dividend, so `-7 srem 2` gave `+1` instead of `-1`.
  Wrong since the STP backend was added in July 2020, on every release
  to date, and never caught because no fixture exercised `mkBVSRem` on
  any backend. Anything lowering C's `%` on mixed-sign integers through
  STP could have been unsound.
- **A correctly-rounded fixed-point `exp`** (#140) — `mkFXPExp`, TR
  18037's `expfx`, for the six C `_Accum` formats. Exact rather than a
  reproduction of any library's approximation, so it can serve as the
  ground truth for checking the error bounds LLVM libc claims for
  `exphk` and `expk`.
