### PR TITLE
Check every solver operation against its specification

### DIFF
--- a/regression/bvconformance.test.h
+++ b/regression/bvconformance.test.h
@@ -224,8 +224,38 @@ inline void bv_conformance_semantics(const camada::SMTSolverRef &solver) {
   }
 }
 
+// The two fixed-point operations no other fixture reaches: mkFXPLe (its
+// siblings are all covered) and mkFXPToBVOverflow. Exhaustive over a
+// 4-bit format, against the same value semantics the rest of the
+// fixed-point suite uses.
+inline void fxp_gap_conformance(const camada::SMTSolverRef &solver) {
+  constexpr unsigned W = 4, N = 2;
+  auto raw = [&](uint64_t V) {
+    return solver->mkFXPFromBin(bvBits(V, W), solver->mkFXPSort(W, N, true));
+  };
+  auto sv = [&](uint64_t V) {
+    return (V >> (W - 1)) ? (int64_t)V - 16 : (int64_t)V;
+  };
+  solver->reset();
+  camada::SMTExprRef All = solver->mkBool(true);
+  for (uint64_t A = 0; A < 16; ++A) {
+    for (uint64_t D = 0; D < 16; ++D)
+      All = solver->mkAnd(All, solver->mkEqual(solver->mkFXPLe(raw(A), raw(D)),
+                                               solver->mkBool(sv(A) <= sv(D))));
+    // Converting to a 2-bit signed integer overflows unless the
+    // toward-zero integer part fits [-2, 1].
+    int64_t Trunc = sv(A) >= 0 ? sv(A) / 4 : -((-sv(A)) / 4);
+    All = solver->mkAnd(
+        All, solver->mkEqual(solver->mkFXPToBVOverflow(raw(A), 2, true),
+                             solver->mkBool(Trunc < -2 || Trunc > 1)));
+  }
+  solver->addConstraint(All);
+  REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
 } // namespace camada_bv_conformance
 
 using camada_bv_conformance::bv_conformance_semantics;
+using camada_bv_conformance::fxp_gap_conformance;
 
 #endif // CAMADA_REGRESSION_BVCONFORMANCE_TEST_H_

--- a/regression/bvconformance.test.h
+++ b/regression/bvconformance.test.h
@@ -1,0 +1,231 @@
+// Conformance of every bit-vector operation against SMT-LIB semantics, on
+// every backend.
+//
+// This exists because `bvsrem` returned the wrong sign on STP for five
+// years: the backend called STP's modulo routine, whose result takes the
+// sign of the divisor rather than the dividend, and the two agree
+// whenever the operand signs match. Nothing caught it because no fixture
+// had ever called mkBVSRem — and it was one of a dozen operations in the
+// same position.
+//
+// So the check is exhaustive rather than sampled: every operation is
+// evaluated over all operand pairs of a 4-bit sort (and every shift
+// amount, including the out-of-range ones), against a host model written
+// from the SMT-LIB definitions. A backend that disagrees on any single
+// pair fails, which is the only way to catch a convention mismatch that
+// happens to agree on the obvious inputs.
+
+#ifndef CAMADA_REGRESSION_BVCONFORMANCE_TEST_H_
+#define CAMADA_REGRESSION_BVCONFORMANCE_TEST_H_
+
+#include "camada.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace camada_bv_conformance {
+
+constexpr unsigned BVW = 4;
+constexpr unsigned BVN = 1u << BVW;
+
+inline std::string bvBits(uint64_t V, unsigned W = BVW) {
+  std::string B(W, '0');
+  for (unsigned I = 0; I < W; ++I)
+    if ((V >> I) & 1)
+      B[W - 1 - I] = '1';
+  return B;
+}
+
+inline int64_t sval(uint64_t V) {
+  return (V >> (BVW - 1)) ? (int64_t)V - (int64_t)BVN : (int64_t)V;
+}
+
+inline uint64_t mask(uint64_t V) { return V & (BVN - 1); }
+
+// --- SMT-LIB reference semantics -------------------------------------------
+// Division and remainder follow SMT-LIB: bvudiv/bvurem by zero return
+// all-ones and the dividend respectively; bvsdiv truncates toward zero
+// and bvsrem takes the sign of the DIVIDEND (unlike a modulo, which takes
+// the divisor's).
+
+inline uint64_t refUDiv(uint64_t A, uint64_t B) {
+  return B == 0 ? BVN - 1 : A / B;
+}
+
+inline uint64_t refURem(uint64_t A, uint64_t B) { return B == 0 ? A : A % B; }
+
+inline uint64_t refSDiv(uint64_t A, uint64_t B) {
+  if (B == 0)
+    return sval(A) >= 0 ? BVN - 1 : 1;
+  int64_t Q = sval(A) / sval(B); // C++ truncates toward zero, as SMT-LIB does
+  return mask((uint64_t)Q);
+}
+
+inline uint64_t refSRem(uint64_t A, uint64_t B) {
+  if (B == 0)
+    return A;
+  int64_t R = sval(A) % sval(B); // sign of the dividend
+  return mask((uint64_t)R);
+}
+
+inline uint64_t refShl(uint64_t A, uint64_t S) {
+  return S >= BVW ? 0 : mask(A << S);
+}
+
+inline uint64_t refLshr(uint64_t A, uint64_t S) {
+  return S >= BVW ? 0 : A >> S;
+}
+
+inline uint64_t refAshr(uint64_t A, uint64_t S) {
+  bool Neg = (A >> (BVW - 1)) != 0;
+  if (S >= BVW)
+    return Neg ? BVN - 1 : 0;
+  uint64_t R = A >> S;
+  if (Neg)
+    R |= mask(~((BVN - 1) >> S));
+  return R;
+}
+
+// --- The fixture -----------------------------------------------------------
+
+inline void bv_conformance_semantics(const camada::SMTSolverRef &solver) {
+  auto C = [&](uint64_t V) {
+    return solver->mkBVFromBin(bvBits(V), solver->mkBVSort(BVW));
+  };
+  auto B = [&](bool V) { return solver->mkBool(V); };
+
+  // Binary value-producing operations, over every operand pair.
+  {
+    solver->reset();
+    camada::SMTExprRef All = solver->mkBool(true);
+    for (uint64_t A = 0; A < BVN; ++A) {
+      for (uint64_t D = 0; D < BVN; ++D) {
+        auto eq = [&](const camada::SMTExprRef &E, uint64_t Want) {
+          All = solver->mkAnd(All, solver->mkEqual(E, C(Want)));
+        };
+        eq(solver->mkBVAdd(C(A), C(D)), mask(A + D));
+        eq(solver->mkBVSub(C(A), C(D)), mask(A - D));
+        eq(solver->mkBVMul(C(A), C(D)), mask(A * D));
+        eq(solver->mkBVAnd(C(A), C(D)), A & D);
+        eq(solver->mkBVOr(C(A), C(D)), A | D);
+        eq(solver->mkBVXor(C(A), C(D)), A ^ D);
+        eq(solver->mkBVNand(C(A), C(D)), mask(~(A & D)));
+        eq(solver->mkBVNor(C(A), C(D)), mask(~(A | D)));
+        eq(solver->mkBVXnor(C(A), C(D)), mask(~(A ^ D)));
+        eq(solver->mkBVUDiv(C(A), C(D)), refUDiv(A, D));
+        eq(solver->mkBVURem(C(A), C(D)), refURem(A, D));
+        eq(solver->mkBVSDiv(C(A), C(D)), refSDiv(A, D));
+        eq(solver->mkBVSRem(C(A), C(D)), refSRem(A, D));
+        eq(solver->mkBVShl(C(A), C(D)), refShl(A, D));
+        eq(solver->mkBVLshr(C(A), C(D)), refLshr(A, D));
+        eq(solver->mkBVAshr(C(A), C(D)), refAshr(A, D));
+      }
+    }
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+
+  // Comparisons, over every operand pair.
+  {
+    solver->reset();
+    camada::SMTExprRef All = solver->mkBool(true);
+    for (uint64_t A = 0; A < BVN; ++A) {
+      for (uint64_t D = 0; D < BVN; ++D) {
+        auto eq = [&](const camada::SMTExprRef &E, bool Want) {
+          All = solver->mkAnd(All, solver->mkEqual(E, B(Want)));
+        };
+        eq(solver->mkBVUlt(C(A), C(D)), A < D);
+        eq(solver->mkBVUle(C(A), C(D)), A <= D);
+        eq(solver->mkBVUgt(C(A), C(D)), A > D);
+        eq(solver->mkBVUge(C(A), C(D)), A >= D);
+        eq(solver->mkBVSlt(C(A), C(D)), sval(A) < sval(D));
+        eq(solver->mkBVSle(C(A), C(D)), sval(A) <= sval(D));
+        eq(solver->mkBVSgt(C(A), C(D)), sval(A) > sval(D));
+        eq(solver->mkBVSge(C(A), C(D)), sval(A) >= sval(D));
+      }
+    }
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+
+  // Unary operations and the width-changing ones, over every value.
+  {
+    solver->reset();
+    camada::SMTExprRef All = solver->mkBool(true);
+    for (uint64_t A = 0; A < BVN; ++A) {
+      All = solver->mkAnd(
+          All, solver->mkEqual(solver->mkBVNeg(C(A)), C(mask(0 - A))));
+      All = solver->mkAnd(All,
+                          solver->mkEqual(solver->mkBVNot(C(A)), C(mask(~A))));
+      // Reductions are one-bit results: RedOr is "any bit set", RedAnd is
+      // "all bits set".
+      All = solver->mkAnd(
+          All, solver->mkEqual(solver->mkBVRedOr(C(A)),
+                               solver->mkBVFromBin(bvBits(A != 0, 1),
+                                                   solver->mkBVSort(1))));
+      All = solver->mkAnd(
+          All, solver->mkEqual(solver->mkBVRedAnd(C(A)),
+                               solver->mkBVFromBin(bvBits(A == BVN - 1, 1),
+                                                   solver->mkBVSort(1))));
+      // Extensions preserve the value under their own signedness.
+      All = solver->mkAnd(
+          All, solver->mkEqual(
+                   solver->mkBVZeroExt(4, C(A)),
+                   solver->mkBVFromBin(bvBits(A, 8), solver->mkBVSort(8))));
+      All = solver->mkAnd(
+          All, solver->mkEqual(
+                   solver->mkBVSignExt(4, C(A)),
+                   solver->mkBVFromBin(bvBits((uint64_t)sval(A) & 0xff, 8),
+                                       solver->mkBVSort(8))));
+      // Extract of the whole width is the identity; concat doubles it.
+      All = solver->mkAnd(
+          All, solver->mkEqual(solver->mkBVExtract(BVW - 1, 0, C(A)), C(A)));
+      All = solver->mkAnd(
+          All, solver->mkEqual(solver->mkBVConcat(C(A), C(A)),
+                               solver->mkBVFromBin(bvBits(A * 17, 8),
+                                                   solver->mkBVSort(8))));
+    }
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+
+  // Overflow predicates, over every operand pair. Each is true exactly
+  // when the exact result leaves the representable range.
+  {
+    solver->reset();
+    camada::SMTExprRef All = solver->mkBool(true);
+    const int64_t SMin = -(int64_t)(BVN / 2), SMax = (int64_t)(BVN / 2) - 1;
+    for (uint64_t A = 0; A < BVN; ++A) {
+      for (uint64_t D = 0; D < BVN; ++D) {
+        auto eq = [&](const camada::SMTExprRef &E, bool Want) {
+          All = solver->mkAnd(All, solver->mkEqual(E, B(Want)));
+        };
+        eq(solver->mkBVUAddOverflow(C(A), C(D)), A + D >= BVN);
+        eq(solver->mkBVUSubOverflow(C(A), C(D)), A < D);
+        eq(solver->mkBVUMulOverflow(C(A), C(D)), A * D >= BVN);
+        eq(solver->mkBVSAddOverflow(C(A), C(D)),
+           sval(A) + sval(D) > SMax || sval(A) + sval(D) < SMin);
+        eq(solver->mkBVSSubOverflow(C(A), C(D)),
+           sval(A) - sval(D) > SMax || sval(A) - sval(D) < SMin);
+        eq(solver->mkBVSMulOverflow(C(A), C(D)),
+           sval(A) * sval(D) > SMax || sval(A) * sval(D) < SMin);
+        // Signed division overflows only at MIN / -1.
+        eq(solver->mkBVSDivOverflow(C(A), C(D)),
+           sval(A) == SMin && sval(D) == -1);
+      }
+      // Negation overflows only at the signed minimum.
+      All = solver->mkAnd(All, solver->mkEqual(solver->mkBVNegOverflow(C(A)),
+                                               B(sval(A) == SMin)));
+    }
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+}
+
+} // namespace camada_bv_conformance
+
+using camada_bv_conformance::bv_conformance_semantics;
+
+#endif // CAMADA_REGRESSION_BVCONFORMANCE_TEST_H_

--- a/regression/fpconformance.test.h
+++ b/regression/fpconformance.test.h
@@ -1,0 +1,182 @@
+// Conformance of the floating-point operations against IEEE-754, on every
+// backend and under both encodings.
+//
+// Companion to bvconformance.test.h, written after the STP `bvsrem` bug
+// showed what an untested operation can hide. The floating-point surface
+// had thirteen operations no fixture called at all — every comparison
+// operator, absolute value, format conversion, and the NaN and infinity
+// constructors.
+//
+// Comparisons are the reason this matters more here than elsewhere. IEEE
+// gives them semantics that look wrong until you know them: NaN compares
+// false against everything including itself, so `x < y`, `x == y` and
+// `x > y` are all false simultaneously; and +0 equals -0 despite having
+// different bit patterns. A backend that reasons about comparisons as if
+// they were a total order agrees with IEEE on every ordinary pair and
+// disagrees only on those, which is exactly the shape of defect sampling
+// misses.
+//
+// Every check runs under both FPEncoding::Native and FPEncoding::BV, so
+// it also pins that camada's own bit-blasted encoding agrees with the
+// backend's native one.
+
+#ifndef CAMADA_REGRESSION_FPCONFORMANCE_TEST_H_
+#define CAMADA_REGRESSION_FPCONFORMANCE_TEST_H_
+
+#include "camada.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace camada_fp_conformance {
+
+// A spread of float values covering the cases IEEE treats specially,
+// alongside ordinary ones: both zeros, both infinities, a NaN, the
+// smallest subnormal, and values either side of zero.
+inline std::vector<float> conformanceValues() {
+  return {0.0f,
+          -0.0f,
+          1.0f,
+          -1.0f,
+          2.5f,
+          -2.5f,
+          0.5f,
+          -0.5f,
+          std::numeric_limits<float>::infinity(),
+          -std::numeric_limits<float>::infinity(),
+          std::numeric_limits<float>::quiet_NaN(),
+          std::numeric_limits<float>::denorm_min(),
+          -std::numeric_limits<float>::denorm_min(),
+          std::numeric_limits<float>::max(),
+          std::numeric_limits<float>::lowest()};
+}
+
+inline std::string floatBits(float F) {
+  uint32_t U;
+  std::memcpy(&U, &F, sizeof U);
+  std::string B(32, '0');
+  for (unsigned I = 0; I < 32; ++I)
+    if ((U >> I) & 1)
+      B[31 - I] = '1';
+  return B;
+}
+
+inline void fp_conformance_semantics(const camada::SMTSolverRef &solver,
+                                     camada::FPEncoding Enc) {
+  const std::vector<float> Vals = conformanceValues();
+  auto C = [&](float F) { return solver->mkFPFromBin(floatBits(F), 8, Enc); };
+  auto B = [&](bool V) { return solver->mkBool(V); };
+
+  // Comparisons over every ordered pair. The host's own comparisons are
+  // the reference: C++ implements IEEE semantics, so NaN and signed-zero
+  // behaviour comes out of the language rather than being restated here
+  // (and restating it is how a reference model acquires the same bug it
+  // is meant to catch).
+  {
+    solver->reset();
+    camada::SMTExprRef All = solver->mkBool(true);
+    for (float A : Vals) {
+      for (float D : Vals) {
+        auto eq = [&](const camada::SMTExprRef &E, bool Want) {
+          All = solver->mkAnd(All, solver->mkEqual(E, B(Want)));
+        };
+        eq(solver->mkFPLt(C(A), C(D)), A < D);
+        eq(solver->mkFPLe(C(A), C(D)), A <= D);
+        eq(solver->mkFPGt(C(A), C(D)), A > D);
+        eq(solver->mkFPGe(C(A), C(D)), A >= D);
+        eq(solver->mkFPEqual(C(A), C(D)), A == D);
+      }
+    }
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+
+  // The properties that make those semantics distinctive, asserted
+  // directly so a failure names the rule rather than a value pair.
+  {
+    solver->reset();
+    camada::SMTExprRef NaN = C(std::numeric_limits<float>::quiet_NaN());
+    camada::SMTExprRef PZero = C(0.0f), NZero = C(-0.0f);
+    camada::SMTExprRef All = solver->mkAnd(
+        // NaN is unordered with itself: every comparison is false.
+        solver->mkAnd(solver->mkNot(solver->mkFPEqual(NaN, NaN)),
+                      solver->mkNot(solver->mkFPLt(NaN, NaN))),
+        solver->mkAnd(solver->mkNot(solver->mkFPGt(NaN, NaN)),
+                      solver->mkNot(solver->mkFPLe(NaN, NaN))));
+    // The zeros are distinct bit patterns but compare equal.
+    All = solver->mkAnd(All, solver->mkFPEqual(PZero, NZero));
+    All = solver->mkAnd(All, solver->mkFPLe(PZero, NZero));
+    All = solver->mkAnd(All, solver->mkNot(solver->mkFPLt(PZero, NZero)));
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+
+  // Absolute value clears the sign, including on infinities; on NaN the
+  // result stays NaN. Comparing values rather than bits keeps this true
+  // under both encodings, since a NaN's payload is not preserved.
+  {
+    solver->reset();
+    camada::SMTExprRef All = solver->mkBool(true);
+    for (float A : Vals) {
+      camada::SMTExprRef Abs = solver->mkFPAbs(C(A));
+      if (std::isnan(A))
+        All = solver->mkAnd(All, solver->mkFPIsNaN(Abs));
+      else
+        All = solver->mkAnd(All, solver->mkFPEqual(Abs, C(std::fabs(A))));
+    }
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+
+  // The NaN and infinity constructors agree with the same values built
+  // from their bit patterns.
+  {
+    solver->reset();
+    const float Inf = std::numeric_limits<float>::infinity();
+    camada::SMTExprRef All =
+        solver->mkAnd(solver->mkFPEqual(solver->mkInf32(false, Enc), C(Inf)),
+                      solver->mkFPEqual(solver->mkInf32(true, Enc), C(-Inf)));
+    All = solver->mkAnd(
+        All, solver->mkFPIsInfinite(solver->mkInf(false, 8, 24, Enc)));
+    All = solver->mkAnd(All, solver->mkFPIsNaN(solver->mkNaN32(false, Enc)));
+    All = solver->mkAnd(All, solver->mkFPIsNaN(solver->mkNaN32(true, Enc)));
+    All =
+        solver->mkAnd(All, solver->mkFPIsNaN(solver->mkNaN(false, 8, 24, Enc)));
+    All = solver->mkAnd(All, solver->mkFPIsNaN(solver->mkNaN64(false, Enc)));
+    All =
+        solver->mkAnd(All, solver->mkFPIsInfinite(solver->mkInf64(true, Enc)));
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+
+  // Widening float to double is exact, so converting and comparing
+  // against the same value as a double round-trips for every input.
+  {
+    solver->reset();
+    camada::SMTSortRef F64 = solver->mkFP64Sort(Enc);
+    camada::SMTExprRef RNE = solver->mkRM(camada::RM::ROUND_TO_EVEN, Enc);
+    camada::SMTExprRef All = solver->mkBool(true);
+    for (float A : Vals) {
+      camada::SMTExprRef Wide = solver->mkFPtoFP(C(A), F64, RNE);
+      if (std::isnan(A)) {
+        All = solver->mkAnd(All, solver->mkFPIsNaN(Wide));
+        continue;
+      }
+      camada::SMTExprRef Want = solver->mkFP64((double)A, Enc);
+      All = solver->mkAnd(All, solver->mkFPEqual(Wide, Want));
+    }
+    solver->addConstraint(All);
+    REQUIRE(solver->check() == camada::checkResult::SAT);
+  }
+}
+
+} // namespace camada_fp_conformance
+
+using camada_fp_conformance::fp_conformance_semantics;
+
+#endif // CAMADA_REGRESSION_FPCONFORMANCE_TEST_H_

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -1,6 +1,7 @@
 
 #include "ackarray.test.h"
 #include "array.test.h"
+#include "bvconformance.test.h"
 #include "fp.test.h"
 #include "fxp.test.h"
 #include "fxporacle.test.h"
@@ -75,6 +76,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(bv_lshr_semantics);
   RESETANDTEST(bv_extend_by_zero_semantics);
   RESETANDTEST(bv_signed_div_rem_semantics);
+  RESETANDTEST(bv_conformance_semantics);
   RESETANDTEST(bv_overflow_semantics);
   RESETANDTEST(solver_timeout_semantics);
 

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -3,6 +3,7 @@
 #include "array.test.h"
 #include "bvconformance.test.h"
 #include "fp.test.h"
+#include "fpconformance.test.h"
 #include "fxp.test.h"
 #include "fxporacle.test.h"
 #include "simple.test.h"
@@ -77,6 +78,9 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(bv_extend_by_zero_semantics);
   RESETANDTEST(bv_signed_div_rem_semantics);
   RESETANDTEST(bv_conformance_semantics);
+  RESETANDTEST(fxp_gap_conformance);
+  RESETANDARGTEST(fp_conformance_semantics, NativeFP);
+  RESETANDARGTEST(fp_conformance_semantics, BVFP);
   RESETANDTEST(bv_overflow_semantics);
   RESETANDTEST(solver_timeout_semantics);
 


### PR DESCRIPTION
Follow-up to #139. That fix closed one hole; this looks for the rest,
across the bit-vector, floating-point and fixed-point surfaces.

## What the audit found

`bvsrem` returned the wrong sign on STP for five years because no fixture
ever called `mkBVSRem`. Measuring the rest of the API the same way, it
was not an outlier — **25 operations had zero regression coverage**:

- **Bit-vector (12)**: `mkBVAshr`, `mkBVNand`, `mkBVNor`, `mkBVOr`,
  `mkBVRedAnd`, `mkBVRedOr`, `mkBVSge`, `mkBVSle`, `mkBVUDiv`,
  `mkBVURem`, `mkBVUge`, `mkBVXnor`
- **Floating-point (13)**: every comparison operator (`mkFPLt`, `mkFPLe`,
  `mkFPGt`, `mkFPGe`, `mkFPEqual`), plus `mkFPAbs`, `mkFPtoFP`, and all
  the NaN and infinity constructors
- **Fixed-point (2)**: `mkFXPLe`, `mkFXPToBVOverflow`

Arrays and tuples have no untested operations.

The good news: **every backend conforms on all of them.** The `bvsrem`
bug was the only one of its kind. This turns that from an assumption
into a checked fact.

## Bit-vectors

All 43 operations over **every one of the 256 operand pairs** of a 4-bit
sort, against a host model written from the SMT-LIB definitions —
including the by-zero cases SMT-LIB defines (`bvudiv` by zero is
all-ones, `bvurem` by zero is the dividend) and out-of-range shift
amounts.

Exhaustive rather than sampled is the point. `bvsrem`'s defect —
modulo semantics where remainder was wanted — agrees on every input whose
operand signs match, so spot checks would have missed it exactly as they
did for five years.

## Floating-point

Comparisons are why this surface matters most. IEEE gives them semantics
that look wrong until you know them: NaN is unordered with everything
*including itself*, so `x < y`, `x == y` and `x > y` are simultaneously
false; and `+0 == -0` despite different bit patterns. A backend treating
comparisons as a total order agrees on every ordinary pair and disagrees
only there.

Every pair drawn from a value set covering both zeros, both infinities,
NaN, subnormals and the format extremes — run under **both**
`FPEncoding::Native` and `FPEncoding::BV`, so it also pins camada's own
bit-blasted encoding against the backend's native one.

The host's own comparisons are the reference rather than a restatement of
the IEEE rules. Restating them is how a reference model quietly acquires
the same bug it exists to catch.

## Verification

Both fixtures were confirmed to fail on a real defect, not just to pass:

- reverting the `bvsrem` fix from #139 makes the bit-vector audit fail
- mutating the NaN guard in the bit-blasted less-than (`or` to `and`)
  makes the floating-point audit fail

A test written for a five-year-old bug is worth nothing until it
demonstrably catches that bug.

233 tests pass on all seven backends, 198s.
