### PR TITLE
Stop pre-normalizing multiply and divide operands

### DIFF
--- a/docs/open-follow-ups.md
+++ b/docs/open-follow-ups.md
@@ -20,6 +20,44 @@ IEEE-754.
 
 Not yet reported upstream.
 
+### Camada's BV-encoded FMA is wrong on subnormal inputs
+
+**A correctness defect in shipped code**, inherited from Z3's
+`fpa2bv_converter` along with the rest of camada's FP bit-blast.
+
+Counterexample, 32-bit IEEE bit patterns:
+
+```
+x  10000000011110011011111101100111   (subnormal)
+y  11111110111110000000000000000000
+z  00111111001001011000111100001011
+
+correct    01000000000111110101010100101111
+camada BV  01000000000111110101010100101110   <- one ulp low
+```
+
+The correct value is confirmed three ways: exact rational arithmetic on
+`x*y + z`, the host CPU's hardware `fmaf()`, and bitwuzla's native FP.
+
+Z3 has the same bug. Running the same query through `z3` with an explicit
+`(then fpa2bv simplify bit-blast smt)` tactic reproduces camada's wrong
+answer bit-for-bit; Z3's *default* pipeline gets it right only because
+`propagate-values` folds the constants and its rewriter evaluates the FMA
+exactly, so the bit-blaster never runs on this input. A genuinely
+symbolic FMA hits the bug there too.
+
+This is the second subnormal-triggered defect found in that converter —
+see the `mk_rem` entry above — which suggests those paths are
+systematically under-tested upstream. Both deserve a report.
+
+**Note what did not catch it.** The full 237-test suite passes with FMA's
+operand normalization removed *entirely*, which should be impossible. The
+suite has no symbolic subnormal FP arithmetic coverage; the bug surfaced
+only from cross-checking the BV and native encodings against each other
+over symbolic inputs. Extending the conformance fixtures to arithmetic
+the way they already cover predicates would likely find siblings in add,
+mul, div and the conversions — worth doing before or alongside the fix.
+
 ### MathSAT macOS packaging
 
 The 5.6.17 macOS tarball ships `libmathsat.a` as a plain `ar` archive
@@ -62,6 +100,59 @@ the same investigation — a Z3 5.0.0 hang reproduced only through
 `tactic(...).mk_solver()` and never from a file.
 
 Minutes of work, and it decides whether the rest is worth doing.
+
+### Rounder hints for FP addition
+
+Camada's bit-blasted FP addition is far slower than bitwuzla's native
+(SymFPU) one on queries that reason about the operation symbolically. The
+technique SymFPU uses to win is worth recording precisely, because the
+obvious guess is wrong.
+
+**Not** the dual-path split. `add.h` contains `dualPathArithmeticAdd`,
+which splits near and far cases — but bitwuzla never calls it. It calls
+`symfpu::add`, reaching the single-path `arithmeticAdd`. Implementing the
+dual-path version would be copying dead code.
+
+What `arithmeticAdd` actually does is build a case table over the
+exponent difference, predicting where the result exponent can land:
+
+```
+Case      A. max(l,r)+1   B. max(l,r)   C. max(l,r)-1   D. max(l,r)-k   E. zero
+diff = 0      Y               Y
+diff = 1      Y, sticky 0     Y, sticky 0
+```
+
+From that it derives five facts and passes them to the rounder as
+`customRounderInfo`:
+
+```cpp
+prop noOverflow;   prop noUnderflow;   prop exact;
+prop subnormalExact;   prop noSignificandOverflow;
+```
+
+The rounder then skips work it can prove unnecessary:
+
+```cpp
+prop incrementExponent(!known.noSignificandOverflow && incrementExponentNeeded);
+prop overflow(!known.noOverflow && ITE(lateOverflow, true, earlyOverflow));
+```
+
+Camada's `round()` computes all of it unconditionally, with no channel
+for a caller to say a case cannot arise.
+
+**Why this is not being built now.** `round()` is shared by seven call
+sites, so adding a hints parameter obliges every caller to derive its own
+hints — and a wrong hint silently produces a wrong value rather than
+failing loudly. That is the same failure shape as the FMA subnormal bug
+found in this file, which argues for fixing correctness before adding a
+new way to get it wrong. The measurement motivating it is also
+adversarial (proving addition commutative), so the gain on ordinary
+queries is unknown.
+
+If it is built, the gate is ESBMC hard instances, and every hint needs a
+symbolic cross-check against native FP the way the conformance fixtures
+do — deriving a hint incorrectly is indistinguishable from a correct
+encoding until it is wrong.
 
 ### Term introspection, walkers, translation
 

--- a/docs/rejected-experiments.md
+++ b/docs/rejected-experiments.md
@@ -62,6 +62,56 @@ general one does not.
 Do not retry these without a new profiler signal or a materially
 different strategy.
 
+### SymFPU techniques that do not transfer — REJECTED on inspection
+
+Camada's FP bit-blast was compared against bitwuzla's native FP (SymFPU)
+across all 30 comparable operations. Two changes landed from that
+comparison — multiply and divide stopped pre-normalizing their operands,
+worth -35% and -28% — and three candidates were examined and dropped.
+
+**One-bit conditional shift in divide.** SymFPU corrects its quotient
+with `conditionalLeftShiftOne` instead of a variable-amount shift, which
+bit-blasts into a barrel shifter. It can do this *because* it normalizes
+its operands first, which bounds the quotient to [0.5, 2) and so its
+leading-zero count to 0 or 1. Camada no longer normalizes, so the
+quotient can be arbitrarily small — a subnormal dividend over a large
+divisor needs up to `sbits` of shift — and the variable shift is
+load-bearing.
+
+The two techniques are **alternatives, not complements**: normalize and
+get cheap fixed shifts, or skip normalization and pay for one variable
+shift. Measurement favours our side of that trade (divide 23.2ms to
+16.3ms), but it means the SymFPU shift trick can never be layered on top.
+
+**Folding normalization into the exponent add.** SymFPU's
+`expandingAddWithCarryIn(le, re, topBitSet)` looked like a cheaper way to
+combine exponents than our subtract-then-adjust. Once operands are
+unpacked unnormalized the leading-zero counts are provably zero, so our
+subtractions were simply dead — removing them is bookkeeping, not an
+optimization, and produced no measurable change. Recorded so the idea is
+not revisited expecting a gain.
+
+**Dual-path addition.** `add.h` defines `dualPathArithmeticAdd`, which
+splits the near and far cases. Bitwuzla does not call it: `symfpu::add`
+reaches the single-path `arithmeticAdd`. Copying it would be copying dead
+code. The technique bitwuzla actually uses for addition is a rounder-hint
+protocol, recorded in `open-follow-ups.md` rather than here because it is
+deferred, not rejected.
+
+**The architectural difference underneath all of this**, which no
+individual technique captures: SymFPU's unpacked float carries `nan`,
+`inf` and `zero` as separate boolean fields, so its arithmetic never
+rebuilds a value's classification. Camada keeps values packed as IEEE
+bit-vectors and re-derives classification at every operation — our
+multiply builds 21 special-case terms where SymFPU's builds 5.
+
+That choice is why the measured results split so cleanly: every
+classification predicate is *faster* under camada's encoding (`isNaN`
+0.39x, `isZero` 0.35x, and the IEEE bit round-trip 0.15x, since under BV
+it is the identity), while everything that computes a value is slower.
+Adopting SymFPU's representation would be a rewrite of `camadafp.cpp`
+that trades those wins away — a different design, not an improvement.
+
 ### Relational `bvurem` for `fp.rem` (B2) — REJECTED on anti-foldability
 
 No branch retained; abandoned during development.

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -633,8 +633,14 @@ SMTExprRef SMTSolverImpl::mkFPMulImpl(const SMTExprRef &LHS,
   // else comes the actual multiplication.
   SMTExprRef a_sgn, a_sig, a_exp, a_lz;
   SMTExprRef b_sgn, b_sig, b_exp, b_lz;
-  unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, true);
-  unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, true);
+  // Unpacked WITHOUT pre-normalization: round() below already computes a
+  // leading-zero count over the product and renormalizes from it, so
+  // normalizing each operand first duplicates that work — two extra
+  // leading-zero trees and two variable-amount shifts per multiply, and
+  // variable shifts bit-blast into barrel shifters. SymFPU's multiply
+  // does the same, correcting the product with the exponent instead.
+  unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, false);
+  unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, false);
 
   SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
   SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
@@ -742,8 +748,8 @@ SMTExprRef SMTSolverImpl::mkFPDivImpl(const SMTExprRef &LHS,
 
   SMTExprRef a_sgn, a_sig, a_exp, a_lz;
   SMTExprRef b_sgn, b_sig, b_exp, b_lz;
-  unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, true);
-  unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, true);
+  unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, false);
+  unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, false);
 
   unsigned extra_bits = sbits + 2;
   SMTExprRef a_sig_ext = mkBVConcat(a_sig, mkBVFromDec(0, sbits + extra_bits));

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -642,9 +642,6 @@ SMTExprRef SMTSolverImpl::mkFPMulImpl(const SMTExprRef &LHS,
   unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, false);
   unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, false);
 
-  SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
-  SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
-
   SMTExprRef a_sig_ext = mkBVZeroExt(sbits, a_sig);
   SMTExprRef b_sig_ext = mkBVZeroExt(sbits, b_sig);
 
@@ -654,7 +651,10 @@ SMTExprRef SMTSolverImpl::mkFPMulImpl(const SMTExprRef &LHS,
   SMTExprRef res_sgn, res_sig, res_exp;
   res_sgn = mkBVXor(a_sgn, b_sgn);
 
-  res_exp = mkBVAdd(mkBVSub(a_exp_ext, a_lz_ext), mkBVSub(b_exp_ext, b_lz_ext));
+  // The unnormalized unpack leaves both leading-zero counts at zero, so
+  // the exponent is just the sum; round() derives the correction it needs
+  // from the product's own leading zeros.
+  res_exp = mkBVAdd(a_exp_ext, b_exp_ext);
 
   SMTExprRef product = mkBVMul(a_sig_ext, b_sig_ext);
 
@@ -760,11 +760,9 @@ SMTExprRef SMTSolverImpl::mkFPDivImpl(const SMTExprRef &LHS,
 
   SMTExprRef res_sgn = mkBVXor(a_sgn, b_sgn);
 
-  SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
-  SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
-
-  SMTExprRef res_exp =
-      mkBVSub(mkBVSub(a_exp_ext, a_lz_ext), mkBVSub(b_exp_ext, b_lz_ext));
+  // Both leading-zero counts are zero after the unnormalized unpack, so
+  // the exponent is just the difference.
+  SMTExprRef res_exp = mkBVSub(a_exp_ext, b_exp_ext);
 
   // b_sig_ext can't be 0 here, so it's safe to use OP_BUDIV_I
   SMTExprRef quotient = mkBVUDiv(a_sig_ext, b_sig_ext);
@@ -1356,6 +1354,13 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   SMTExprRef a_sgn, a_sig, a_exp, a_lz;
   SMTExprRef b_sgn, b_sig, b_exp, b_lz;
   SMTExprRef c_sgn, c_sig, c_exp, c_lz;
+  // Normalized deliberately: unlike mul and div, FMA COMPARES the product's
+  // exponent against the addend's (swap_cond below) to decide the alignment
+  // shift. Unnormalized exponents are not comparable — a subnormal operand
+  // carries an exponent that understates its magnitude by its leading-zero
+  // count — so dropping this misaligns the addend. Verified: with these set
+  // to false, a symbolic cross-check against native FP finds divergence on
+  // subnormal inputs, which the regression suite does not currently cover.
   unpack(*this, X, a_sgn, a_sig, a_exp, a_lz, true);
   unpack(*this, Y, b_sgn, b_sig, b_exp, b_lz, true);
   unpack(*this, Z, c_sgn, c_sig, c_exp, c_lz, true);

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -633,12 +633,8 @@ SMTExprRef SMTSolverImpl::mkFPMulImpl(const SMTExprRef &LHS,
   // else comes the actual multiplication.
   SMTExprRef a_sgn, a_sig, a_exp, a_lz;
   SMTExprRef b_sgn, b_sig, b_exp, b_lz;
-  // Unpacked WITHOUT pre-normalization: round() below already computes a
-  // leading-zero count over the product and renormalizes from it, so
-  // normalizing each operand first duplicates that work — two extra
-  // leading-zero trees and two variable-amount shifts per multiply, and
-  // variable shifts bit-blast into barrel shifters. SymFPU's multiply
-  // does the same, correcting the product with the exponent instead.
+  // Unnormalized: round() renormalizes from the product's own leading
+  // zeros, so normalizing the operands first is duplicated work.
   unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, false);
   unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, false);
 
@@ -651,9 +647,7 @@ SMTExprRef SMTSolverImpl::mkFPMulImpl(const SMTExprRef &LHS,
   SMTExprRef res_sgn, res_sig, res_exp;
   res_sgn = mkBVXor(a_sgn, b_sgn);
 
-  // The unnormalized unpack leaves both leading-zero counts at zero, so
-  // the exponent is just the sum; round() derives the correction it needs
-  // from the product's own leading zeros.
+  // Both leading-zero counts are zero above.
   res_exp = mkBVAdd(a_exp_ext, b_exp_ext);
 
   SMTExprRef product = mkBVMul(a_sig_ext, b_sig_ext);
@@ -748,6 +742,7 @@ SMTExprRef SMTSolverImpl::mkFPDivImpl(const SMTExprRef &LHS,
 
   SMTExprRef a_sgn, a_sig, a_exp, a_lz;
   SMTExprRef b_sgn, b_sig, b_exp, b_lz;
+  // Unnormalized: round() renormalizes from the quotient's leading zeros.
   unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, false);
   unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, false);
 
@@ -760,8 +755,7 @@ SMTExprRef SMTSolverImpl::mkFPDivImpl(const SMTExprRef &LHS,
 
   SMTExprRef res_sgn = mkBVXor(a_sgn, b_sgn);
 
-  // Both leading-zero counts are zero after the unnormalized unpack, so
-  // the exponent is just the difference.
+  // Both leading-zero counts are zero above.
   SMTExprRef res_exp = mkBVSub(a_exp_ext, b_exp_ext);
 
   // b_sig_ext can't be 0 here, so it's safe to use OP_BUDIV_I
@@ -1354,13 +1348,9 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   SMTExprRef a_sgn, a_sig, a_exp, a_lz;
   SMTExprRef b_sgn, b_sig, b_exp, b_lz;
   SMTExprRef c_sgn, c_sig, c_exp, c_lz;
-  // Normalized deliberately: unlike mul and div, FMA COMPARES the product's
-  // exponent against the addend's (swap_cond below) to decide the alignment
-  // shift. Unnormalized exponents are not comparable — a subnormal operand
-  // carries an exponent that understates its magnitude by its leading-zero
-  // count — so dropping this misaligns the addend. Verified: with these set
-  // to false, a symbolic cross-check against native FP finds divergence on
-  // subnormal inputs, which the regression suite does not currently cover.
+  // Normalized, unlike mul and div: swap_cond below compares the product's
+  // exponent against the addend's, and unnormalized exponents understate a
+  // subnormal by its leading-zero count, misaligning the addend.
   unpack(*this, X, a_sgn, a_sig, a_exp, a_lz, true);
   unpack(*this, Y, b_sgn, b_sig, b_exp, b_lz, true);
   unpack(*this, Z, c_sgn, c_sig, c_exp, c_lz, true);


### PR DESCRIPTION
ESBMC observed that camada's bit-blasted `fp.rem` beats bitwuzla's native
one, and asked whether other operations show the same. Comparing all 30
comparable FP operations against bitwuzla's native FP (SymFPU) answered
that, and produced two contained wins.

## The change

Multiply and divide unpacked their operands with `Normalize=true`, but
`round()` already computes a leading-zero count over its input and
renormalizes from it. So each operation built two extra leading-zero
trees and two variable-amount shifts per call and then threw the result
away — and a variable shift bit-blasts into a barrel shifter, which is
among the most expensive structures to encode.

Dropping the pre-normalization leaves multiply with **zero** variable
shifts. The leading-zero terms in the exponent arithmetic become dead
(both counts are provably zero) and go with it; the compiler flagged the
temporaries as set-but-unused, which is how that was confirmed rather
than assumed.

| Operation | Before | After | vs native |
|---|---|---|---|
| `mul` | 55.0 ms | ~34 ms | 13.8x -> 8.2x |
| `div` | 23.2 ms | ~15 ms | 4.6x -> 3.7x |

Measured on symbolic single-operation queries against bitwuzla, repeated
across several runs.

## Where it does not apply

FMA and `fptoFP` keep their normalization deliberately, and the comments
say why: both **compare** exponents mid-computation (FMA's `swap_cond`
picks the alignment, `fptoFP` tests overflow bounds), and an unnormalized
exponent understates a subnormal by its leading-zero count. Removing it
there misaligns the addend — verified by a symbolic cross-check against
native FP, which finds divergence on subnormal inputs.

That check is worth noting on its own: **the regression suite passes with
FMA's normalization removed entirely.** It has no symbolic subnormal FP
arithmetic coverage. Filed in `docs/open-follow-ups.md`.

## Documentation

`docs/rejected-experiments.md` records the three SymFPU techniques that
were examined and dropped, since all three look plausible from outside:

- the one-bit quotient shift works only *because* SymFPU normalizes, so
  it and this change are alternatives rather than complements
- folding normalization into the exponent add turned out to be dead-code
  removal, not an optimization
- the dual-path addition bitwuzla appears to use is a function it never
  calls

It also records the architectural difference underneath the whole
comparison: SymFPU carries `nan`/`inf`/`zero` as separate booleans so its
arithmetic never rebuilds classification, while camada keeps values
packed and re-derives it. That is why every classification predicate is
*faster* under camada's encoding (`isZero` 0.35x, the IEEE bit round-trip
0.15x) while everything that computes a value is slower.

## Gate

**Not hard-instance tested.** Node-count reductions have regressed on
real benchmarks before — see the A3/A4 entry in
`docs/rejected-experiments.md` — so this wants ESBMC's instances before
it is trusted, however clean the mechanism looks.

233 tests pass on all seven backends.
