### PR TITLE
Fix FMA dropping a sticky bit on subnormal operands

### DIFF
--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -4,6 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <limits>
+#include <tuple>
 #include <utility>
 
 inline void fp_native_bv_predicate_parity(const camada::SMTSolverRef &solver) {
@@ -596,6 +597,43 @@ inline void check_rem_pair_f64(const camada::SMTSolverRef &solver,
     solver->addConstraint(
         solver->mkEqual(rem, solver->mkFP64(Expected, Encoding)));
   REQUIRE(solver->check() == camada::checkResult::SAT);
+}
+
+// FMA against the host CPU's fused multiply-add, which is exact per
+// IEEE-754: one rounding of x*y+z, never two. The subnormal cases are the
+// point — camada's bit-blast inherited a one-ulp error from Z3's
+// fpa2bv_converter that only shows when an operand is subnormal, and the
+// symbolic fixtures above do not reach it.
+inline void fp_fma_host_oracle(const camada::SMTSolverRef &solver,
+                               camada::FPEncoding Encoding) {
+  const float Sub = std::numeric_limits<float>::denorm_min();
+  const std::tuple<float, float, float> Triples[] = {
+      // Ordinary values, as a control.
+      {2.0f, 3.0f, 1.0f},
+      {0.5f, 0.5f, 0.25f},
+      {-2.5f, 4.0f, 0.5f},
+      // Subnormal operands: a subnormal times a large value lands back in
+      // the normal range, so the product's leading zeros must be accounted
+      // for before it is aligned against the addend.
+      {Sub, 1e38f, 0.6467139f},
+      {Sub * 3.0f, -1.6482427e38f, 0.6467139f},
+      {-1.1180757e-38f, -1.6482427e38f, 0.64671391f},
+      {Sub, Sub, 1.0f},
+      {Sub * 7.0f, 2.0f, -Sub},
+  };
+
+  for (auto [X, Y, Z] : Triples) {
+    solver->reset();
+    auto x = solver->mkFP32(X, Encoding);
+    auto y = solver->mkFP32(Y, Encoding);
+    auto z = solver->mkFP32(Z, Encoding);
+    auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, Encoding);
+    auto got = solver->mkFPFMA(x, y, z, rm);
+    auto want = solver->mkFP32(std::fma(X, Y, Z), Encoding);
+    INFO("fma(" << X << ", " << Y << ", " << Z << ")");
+    solver->addConstraint(solver->mkNot(solver->mkFPEqual(got, want)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
 }
 
 inline void fp_remainder_host_oracle(const camada::SMTSolverRef &solver,

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -154,6 +154,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDARGTEST(fp_div_overflow_to_inf, BVFP);
   RESETANDARGTEST(fp_remainder_semantics, NativeFP);
   RESETANDARGTEST(fp_remainder_semantics, BVFP);
+  RESETANDARGTEST(fp_fma_host_oracle, NativeFP);
+  RESETANDARGTEST(fp_fma_host_oracle, BVFP);
   RESETANDARGTEST(fp_remainder_host_oracle, NativeFP);
   RESETANDARGTEST(fp_remainder_host_oracle, BVFP);
   RESETANDTEST(arena_stress_test);

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -1499,7 +1499,12 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
 
   SMTExprRef sig_abs_h2 =
       mkBVExtract(2 * sbits + too_short + 4, sbits + too_short, sig_abs);
-  SMTExprRef sticky_h2_red = mkBVZeroExt(sbits + 4, mkBVRedOr(sticky_h1));
+  // h2 drops one bit more than h1, so it needs its own sticky over that
+  // wider range. Reusing sticky_h1 loses bit (sbits + too_short - 1): the
+  // rounder then sees an exact tie where the value is actually above the
+  // halfway point and rounds to even instead of up.
+  SMTExprRef sticky_h2 = mkBVExtract(sbits + too_short - 1, 0, sig_abs);
+  SMTExprRef sticky_h2_red = mkBVZeroExt(sbits + 4, mkBVRedOr(sticky_h2));
   SMTExprRef sig_abs_h2_f = mkBVZeroExt(1, mkBVOr(sig_abs_h2, sticky_h2_red));
   SMTExprRef res_sig_2 = mkBVExtract(sbits + 3, 0, sig_abs_h2_f);
   assert(sig_abs_h2->getWidth() == sbits + 5);


### PR DESCRIPTION
**Correctness fix.** Camada's bit-blasted FMA returned a value one ulp
low for some subnormal operands, on every release to date.

```
x  10000000011110011011111101100111   (subnormal)
y  11111110111110000000000000000000
z  00111111001001011000111100001011

correct    01000000000111110101010100101111
camada BV  01000000000111110101010100101110
```

The correct value is confirmed three independent ways: exact rational
arithmetic on `x*y + z`, the host CPU's hardware `fmaf()`, and bitwuzla's
native FP.

## The defect

FMA narrows its wide sum to the rounder's width through one of two
extracts, `h1` or `h2`, chosen by whether the sum overflowed:

```
h1 keeps bits [52:23], sticky over [22:0]
h2 keeps bits [52:24], sticky over [22:0]   <- one bit short
```

`h2` discards one bit more than `h1` but reused `h1`'s sticky, so a set
bit at the boundary position vanished from the rounding decision. In the
failing case that bit was the only evidence the value sat above the
halfway point — the rounder saw guard=1, sticky=0, read it as an exact
tie, and applied ties-to-even downward.

Subnormal operands reach this because they can leave the exponent
difference at zero, so the entire remainder comes from the addition
rather than the alignment shift. Ordinary operands with differing
exponents do not produce that shape.

The fix gives `h2` its own sticky over the range it actually discards.

## Inherited from Z3

Camada's FP bit-blast was ported from Z3's `fpa2bv_converter`, and this
came with it. The same query through `z3` with an explicit
`(then fpa2bv simplify bit-blast smt)` tactic returns camada's wrong
answer bit-for-bit. Z3's *default* pipeline gets it right only because
`propagate-values` folds the constants so the rewriter evaluates the FMA
exactly and the bit-blaster never runs on this input — a genuinely
symbolic FMA hits the bug there too.

This is the second subnormal-triggered defect found in that converter;
`docs/open-follow-ups.md` already records an unreported `mk_rem` headroom
bug. Both are worth reporting upstream.

## Test

`fp_fma_host_oracle` checks `mkFPFMA` against the host CPU's fused
multiply-add, which is exact per IEEE-754, over three ordinary and five
subnormal triples, under both encodings. It is committed **first, failing**
so the reproduction is in-tree rather than in a scratch file.

Worth noting what did not catch this: the suite passes with FMA's operand
normalization removed *entirely*. It had no symbolic subnormal FP
arithmetic coverage at all, and the bug surfaced only from cross-checking
the two encodings against each other over symbolic inputs. Extending the
conformance fixtures to arithmetic the way they already cover predicates
would likely find siblings — filed as follow-up work.

233 tests pass on all seven backends.
