### PR TITLE
Stop pre-normalizing the fptoFP source operand

### DIFF
--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -1648,7 +1648,11 @@ SMTExprRef SMTSolverImpl::mkFPtoFPImpl(const SMTExprRef &From,
 
   // otherwise: the actual conversion with rounding.
   SMTExprRef sgn, sig, exp, lz;
-  unpack(*this, From, sgn, sig, exp, lz, true);
+  // Unnormalized: the significand is only padded or collapsed to a sticky
+  // below, neither of which touches its leading zeros, and the exponent
+  // path already subtracts lz explicitly — so round() sees a consistent
+  // pair and renormalizes from its own count.
+  unpack(*this, From, sgn, sig, exp, lz, false);
 
   SMTExprRef res_sgn = sgn;
 


### PR DESCRIPTION
Follow-up to #144, which removed the same redundancy from multiply and
divide. `fptoFP` had it too, and is the largest single gain of the three.

| | Before | After | vs native |
|---|---|---|---|
| `fptofp` (f32 -> f64) | 109 ms | ~61 ms | 8.19x -> 4.87x |

Stable across four runs (59-64 ms), measured against bitwuzla's native FP
on symbolic single-operation queries.

## The change

`round()` computes a leading-zero count over its input and renormalizes
from it, so unpacking the source operand with `Normalize=true` builds a
leading-zero tree and a variable-amount shift that are discarded moments
later. Variable shifts bit-blast into barrel shifters, which is where the
cost sits.

## Why it is safe here

This needed checking rather than assuming, because the same change is
**wrong** for FMA — there the product's exponent is compared against the
addend's to choose an alignment, and an unnormalized exponent understates
a subnormal by its leading-zero count.

`fptoFP` does not compare exponents on the paths that matter. The
significand is only padded on the right or collapsed into a sticky bit,
neither of which changes its leading zeros, so `round()` derives the same
count `unpack` would have. The exponent path subtracts `lz` explicitly,
keeping the pair consistently scaled.

The `lz` subtractions now subtract a constant zero and fold away. They are
deliberately left in place: `exp_sub_lz` also feeds the overflow and
underflow comparisons on the narrowing branch, and the FMA bug (#145)
showed how easily an exponent path breaks when its invariants are assumed
rather than checked. Removing them buys nothing measurable.

## Verification

The regression suite is not sufficient evidence here — it passed with
FMA's normalization removed *entirely*, which is how that bug survived. So
this was cross-checked symbolically against bitwuzla's native FP over
**all** inputs, in both directions, with a subnormal-only variant of each:

```
f32->f64 (all)               agree
f32->f64 (subnormal only)    agree
f64->f32 (all)               agree
f64->f32 (subnormal only)    agree
```

Those are UNSAT proofs over every input, not sampled values.

233 tests pass on all seven backends.

## Note: the technique is now exhausted

Every operation that routes through `unpack` and `round()` has been
checked. `sbvtofp`/`ubvtofp` look similar — they call `mkLeadingZeros`
and shift — but there the normalization is **load-bearing**: the
significand and sticky are read from fixed bit positions, so without the
shift a small integer's bits fall outside the extract entirely. Confirmed
by trying it: the suite fails.

What remains is `add`, which needs the rounder-hint protocol described in
`docs/open-follow-ups.md` — an architectural change to a function with
seven call sites, wanting hard-instance gating first.

## Gate

**Not hard-instance tested**, same caveat as #144. Node-count reductions
have regressed on real benchmarks before.
