### PR TITLE
Record FP-over-BV measurement findings and correct the add figure

### DIFF
--- a/docs/fp-bv-vs-native.md
+++ b/docs/fp-bv-vs-native.md
@@ -78,9 +78,14 @@ structural refutation.
 outlier; add, sub, mul, div, fma and toIntegral are all within a factor
 of ~2 of each other. This is the honest cost of bit-blasting.
 
-**`sqrt` at ~13x is the real outlier** and the only clear optimisation
-target left. It is the one operation whose ratio is stable across both
-shapes and far above its neighbours.
+**`sqrt` at ~13x is the real outlier**, stable across both shapes and
+across f32/f64. It was investigated and is **not** cheaply fixable: see
+`rejected-experiments.md`. The short version is that native emits ~150
+bytes for every operation because it hands the term to bitwuzla whole,
+where SymFPU expands it inside the word-blaster; the gap is structural to
+being a wrapper. Two attempts to close it (narrowing the loop's add,
+adding sqrt rounder hints) both failed, and removing the rounder entirely
+made a 30% smaller formula solve 48% *slower*.
 
 The conversions (`sbvtofp`, `ubvtofp`, `fptofp` narrow) at 4-6x are the
 second tier. Note their normalisation is *load-bearing* — the
@@ -109,3 +114,10 @@ passing them to `mkFPEqual` aborts.
 
 Camada has no `mkFPMin`/`mkFPMax`/`mkFPIsNegative`/`mkFPIsPositive` —
 earlier "30 operation" counts included operations that do not exist.
+
+**Do not substitute formula size for solve time.** `dump()` makes it
+tempting, and emitted size does correlate loosely across operations, but
+the sqrt investigation produced a direct counterexample within a single
+operation: bypassing the rounder cut the formula from 26112 to 18356
+bytes and made it solve 48% slower. This is the same trap as the
+node-count gate in `rejected-experiments.md`.

--- a/docs/fp-bv-vs-native.md
+++ b/docs/fp-bv-vs-native.md
@@ -1,0 +1,111 @@
+# FP-over-BV vs native FP: measured cost
+
+Camada bit-blasts floating point through bit-vectors (`FPEncoding::BV`).
+Bitwuzla can also solve FP natively (SymFPU). This file records how the
+two compare, and — more importantly — how to measure that without
+fooling yourself.
+
+## The methodology rule
+
+**Every operation must be given the same query shape.**
+
+An earlier comparison gave each operation whatever query suited it, and
+addition alone drew commutativity (`x+y == y+x`). That produced a
+reported 1880x slowdown for `add` which was entirely an artifact:
+commutativity measures the difficulty of proving two mirror-image
+circuits equivalent, not the cost of the encoding. Holding the shape
+fixed, add is ordinary.
+
+A second trap: the shape must actually force the operation to be
+reasoned about. `res == z && res != z` is UNSAT propositionally, without
+the solver ever looking at `res` — visible as a suspiciously flat native
+column of ~0.4 ms for every operation.
+
+The two shapes below are uniform across operations and both force real
+work:
+
+- **model (SAT)** — the result is constrained to be finite and nonzero
+  (or the predicate asserted true), so the solver must invert the
+  operation to produce a witness.
+- **determinism (UNSAT)** — the operation is built twice over the same
+  operands *in the same order*, and the two results asserted to differ.
+  Same operand order both times, so no operation receives an
+  algebraic-symmetry query the others do not.
+
+## Results
+
+f32, bitwuzla, 10 repetitions per cell, ratio = BV / native. Measured on
+master with #144 (mul/div pre-normalisation), #145 (FMA sticky fix) and
+#146 (fptoFP pre-normalisation) applied. Two independent runs agreed
+within noise.
+
+| op | model | determinism |
+|---|---|---|
+| `rem` | **0.44x** | **0.49x** |
+| `ieeebv-roundtrip` | **0.28x** | **0.17x** |
+| `abs` | **0.55x** | 1.33x |
+| `neg` | **0.59x** | 1.29x |
+| `equal` | **0.54x** | 1.40x |
+| `isZero` / `isNormal` / `isDenormal` | **0.48-0.52x** | 1.50x |
+| `lt` / `le` / `gt` / `ge` | **0.64-0.89x** | 2.00-2.50x |
+| `isNaN` / `isInfinite` | 1.17-1.33x | 1.50x |
+| `fptosbv` / `fptoubv` | 1.49x | 5.75-6.00x |
+| `add` | 2.03x | 3.74x |
+| `sub` | 2.14x | 3.77x |
+| `fptofp` (widen) | 2.72x | 2.62x |
+| `div` | 2.88x | 3.71x |
+| `mul` | 3.15x | 4.82x |
+| `toIntegral` | 3.33x | 4.09x |
+| `fma` | 2.10x | 5.38x |
+| `fptofp` (narrow) | 4.09x | 6.08x |
+| `ubvtofp` | 4.60x | 4.52x |
+| `sbvtofp` | 4.88x | 5.02x |
+| `sqrt` | **12.98x** | **13.02x** |
+
+## What this says
+
+**BV wins outright on `rem` and the IEEE bit round-trip.** `rem` is
+2.0-2.3x *faster* than native — camada's square-and-multiply beats
+SymFPU's linear chain of ~276 divide steps (f32). ESBMC observed this
+independently. The round-trip is 3-6x faster because in the BV encoding
+it is the identity: the value is already a bit-vector.
+
+**Predicates and comparisons are at or better than parity** on the model
+shape, and only mildly behind on determinism where native gets a cheap
+structural refutation.
+
+**The arithmetic core sits at 2-5x.** No operation in that group is an
+outlier; add, sub, mul, div, fma and toIntegral are all within a factor
+of ~2 of each other. This is the honest cost of bit-blasting.
+
+**`sqrt` at ~13x is the real outlier** and the only clear optimisation
+target left. It is the one operation whose ratio is stable across both
+shapes and far above its neighbours.
+
+The conversions (`sbvtofp`, `ubvtofp`, `fptofp` narrow) at 4-6x are the
+second tier. Note their normalisation is *load-bearing* — the
+significand is read from fixed bit positions — so the trick that helped
+mul/div/fptofp (#144, #146) does not apply; removing it fails the
+suite.
+
+## Reproducing
+
+The harness is not checked in; it is ~90 lines against the public API.
+Build a case table of `(name, lambda, is_predicate)`, then for each
+operation and each encoding run both shapes above. The essentials:
+
+```cpp
+for (auto V : {X, Y}) {              // exclude NaN/inf so specials
+  S->addConstraint(S->mkNot(S->mkFPIsNaN(V)));       // cannot discharge
+  S->addConstraint(S->mkNot(S->mkFPIsInfinite(V)));  // the query trivially
+}
+// determinism shape:
+SMTExprRef a = build(X, Y), b = build(X, Y);
+S->addConstraint(S->mkNot(S->mkFPEqual(a, b)));   // mkEqual if BV-valued
+```
+
+`mkFPtoSBV`/`mkFPtoUBV` return bit-vectors, so they need `mkEqual`;
+passing them to `mkFPEqual` aborts.
+
+Camada has no `mkFPMin`/`mkFPMax`/`mkFPIsNegative`/`mkFPIsPositive` —
+earlier "30 operation" counts included operations that do not exist.

--- a/docs/open-follow-ups.md
+++ b/docs/open-follow-ups.md
@@ -58,20 +58,6 @@ only thing that caught #145.
 Doing the same for add, mul, div and the conversions would likely find
 siblings.
 
-### Investigate `fp.sqrt`, the last FP-over-BV outlier
-
-`sqrt` is ~13x native and the only arithmetic operation far above its
-neighbours — add, sub, mul, div, fma and toIntegral all sit within a
-factor of ~2 of each other. It is also stable across query shapes, so
-unlike the earlier `add` scare it is unlikely to be an artifact. Numbers
-and methodology in `docs/fp-bv-vs-native.md`.
-
-Nothing has been diagnosed yet: the first step is to find where the cost
-sits, not to assume the restoring-division loop is at fault.
-
-Gate on ESBMC hard instances. Microbenchmarks have now overstated FP
-encoding gains twice.
-
 ### `fp.rem` fast path for small divisors
 
 The square-and-multiply remainder encoding is 30-100x faster than the

--- a/docs/open-follow-ups.md
+++ b/docs/open-follow-ups.md
@@ -140,19 +140,45 @@ prop overflow(!known.noOverflow && ITE(lateOverflow, true, earlyOverflow));
 Camada's `round()` computes all of it unconditionally, with no channel
 for a caller to say a case cannot arise.
 
-**Why this is not being built now.** `round()` is shared by seven call
-sites, so adding a hints parameter obliges every caller to derive its own
-hints — and a wrong hint silently produces a wrong value rather than
-failing loudly. That is the same failure shape as the FMA subnormal bug
-found in this file, which argues for fixing correctness before adding a
-new way to get it wrong. The measurement motivating it is also
-adversarial (proving addition commutative), so the gain on ordinary
-queries is unknown.
+**Why this is not being built: the motivating number was an artifact.**
+The "add is 1880x slower" figure came from a benchmark that gave each
+operation a different query shape, and add alone drew commutativity
+(`x+y == y+x`). Holding the operation fixed and varying only the shape:
 
-If it is built, the gate is ESBMC hard instances, and every hint needs a
-symbolic cross-check against native FP the way the conformance fixtures
-do — deriving a hint incorrectly is indistinguishable from a correct
-encoding until it is wrong.
+| shape | add | mul |
+|---|---|---|
+| single op, `isNaN` | 3.8x | 4.6x |
+| result equated to a free symbol | 6.8x | 7.0x |
+| commutativity | **1720x** | 8.1x |
+
+On ordinary query shapes add is indistinguishable from multiply, and
+slightly better. There is no add-specific rounder deficit.
+
+The blowup is the *swap network*, not the rounder. `addCore` orders its
+operands by exponent, so `x+y` and `y+x` bit-blast into mirror-image
+circuits, and the solver must prove the swap symmetric before anything
+downstream cancels. Multiply takes its operands symmetrically and has no
+such network. Constraining both operands to one binade — which pins
+`exp_delta` to 0 and makes the alignment shift constant — drops the
+commutativity query from 9113 ms to 1251 ms, a 7.3x collapse. That is
+where the cost lives.
+
+`round()`'s share of a single add is roughly 70% (`toIntegral`, which is
+round-dominated with almost no front end, costs 12.4 ms against add's
+17.6 ms) — but since add is already at parity with multiply, shrinking
+the rounder is a general FP optimisation, not an add fix, and would have
+to be justified on its own.
+
+Against that, the cost stays what it was: `round()` is shared by seven
+call sites, so a hints parameter obliges every caller to derive its own
+hints, and a wrong hint silently produces a wrong value rather than
+failing loudly — the same failure shape as the FMA subnormal bug in this
+file.
+
+If anyone revisits this, the gate is ESBMC hard instances, every hint
+needs a symbolic cross-check against native FP the way the conformance
+fixtures do, and the benchmark must hold the query shape fixed across
+operations.
 
 ### Term introspection, walkers, translation
 

--- a/docs/open-follow-ups.md
+++ b/docs/open-follow-ups.md
@@ -180,6 +180,10 @@ needs a symbolic cross-check against native FP the way the conformance
 fixtures do, and the benchmark must hold the query shape fixed across
 operations.
 
+Full fixed-shape numbers for every FP operation are in
+`docs/fp-bv-vs-native.md`. On that measurement the remaining outlier is
+`sqrt` (~13x), not `add`.
+
 ### Term introspection, walkers, translation
 
 Parked until cross-solver term transfer becomes an actual goal. Camada

--- a/docs/open-follow-ups.md
+++ b/docs/open-follow-ups.md
@@ -20,43 +20,20 @@ IEEE-754.
 
 Not yet reported upstream.
 
-### Camada's BV-encoded FMA is wrong on subnormal inputs
+### Report the Z3 `fpa2bv` FMA sticky-bit bug
 
-**A correctness defect in shipped code**, inherited from Z3's
-`fpa2bv_converter` along with the rest of camada's FP bit-blast.
+Camada's copy is fixed (#145); Z3's is not, and we owe the report.
 
-Counterexample, 32-bit IEEE bit patterns:
+FMA narrows its sum through one of two paths. The wider one discards an
+extra bit but reused the narrower path's sticky, so that bit vanished,
+the rounder saw a false exact tie and rounded to even — one ulp low on
+subnormal operands. Reproduce with an explicit
+`(then fpa2bv simplify bit-blast smt)` tactic; Z3's default pipeline
+hides it because `propagate-values` folds constants before the
+bit-blaster runs.
 
-```
-x  10000000011110011011111101100111   (subnormal)
-y  11111110111110000000000000000000
-z  00111111001001011000111100001011
-
-correct    01000000000111110101010100101111
-camada BV  01000000000111110101010100101110   <- one ulp low
-```
-
-The correct value is confirmed three ways: exact rational arithmetic on
-`x*y + z`, the host CPU's hardware `fmaf()`, and bitwuzla's native FP.
-
-Z3 has the same bug. Running the same query through `z3` with an explicit
-`(then fpa2bv simplify bit-blast smt)` tactic reproduces camada's wrong
-answer bit-for-bit; Z3's *default* pipeline gets it right only because
-`propagate-values` folds the constants and its rewriter evaluates the FMA
-exactly, so the bit-blaster never runs on this input. A genuinely
-symbolic FMA hits the bug there too.
-
-This is the second subnormal-triggered defect found in that converter —
-see the `mk_rem` entry above — which suggests those paths are
-systematically under-tested upstream. Both deserve a report.
-
-**Note what did not catch it.** The full 237-test suite passes with FMA's
-operand normalization removed *entirely*, which should be impossible. The
-suite has no symbolic subnormal FP arithmetic coverage; the bug surfaced
-only from cross-checking the BV and native encodings against each other
-over symbolic inputs. Extending the conformance fixtures to arithmetic
-the way they already cover predicates would likely find siblings in add,
-mul, div and the conversions — worth doing before or alongside the fix.
+This is the second subnormal-triggered defect in that converter (see
+`mk_rem` above), so report both together.
 
 ### MathSAT macOS packaging
 
@@ -69,6 +46,31 @@ meanwhile — see `CAMADA_MATHSAT_MACOS_VERSION` in
 Not yet reported to FBK.
 
 ## Exploratory, no commitment
+
+### Extend the conformance fixtures to arithmetic
+
+The 237-test suite passes with FMA's operand normalization removed
+*entirely*, which should be impossible. The fixtures cover predicates
+symbolically but not arithmetic, so nothing cross-checks the BV and
+native encodings against each other on subnormal inputs — which is the
+only thing that caught #145.
+
+Doing the same for add, mul, div and the conversions would likely find
+siblings.
+
+### Investigate `fp.sqrt`, the last FP-over-BV outlier
+
+`sqrt` is ~13x native and the only arithmetic operation far above its
+neighbours — add, sub, mul, div, fma and toIntegral all sit within a
+factor of ~2 of each other. It is also stable across query shapes, so
+unlike the earlier `add` scare it is unlikely to be an artifact. Numbers
+and methodology in `docs/fp-bv-vs-native.md`.
+
+Nothing has been diagnosed yet: the first step is to find where the cost
+sits, not to assume the restoring-division loop is at fault.
+
+Gate on ESBMC hard instances. Microbenchmarks have now overstated FP
+encoding gains twice.
 
 ### `fp.rem` fast path for small divisors
 
@@ -100,89 +102,6 @@ the same investigation — a Z3 5.0.0 hang reproduced only through
 `tactic(...).mk_solver()` and never from a file.
 
 Minutes of work, and it decides whether the rest is worth doing.
-
-### Rounder hints for FP addition
-
-Camada's bit-blasted FP addition is far slower than bitwuzla's native
-(SymFPU) one on queries that reason about the operation symbolically. The
-technique SymFPU uses to win is worth recording precisely, because the
-obvious guess is wrong.
-
-**Not** the dual-path split. `add.h` contains `dualPathArithmeticAdd`,
-which splits near and far cases — but bitwuzla never calls it. It calls
-`symfpu::add`, reaching the single-path `arithmeticAdd`. Implementing the
-dual-path version would be copying dead code.
-
-What `arithmeticAdd` actually does is build a case table over the
-exponent difference, predicting where the result exponent can land:
-
-```
-Case      A. max(l,r)+1   B. max(l,r)   C. max(l,r)-1   D. max(l,r)-k   E. zero
-diff = 0      Y               Y
-diff = 1      Y, sticky 0     Y, sticky 0
-```
-
-From that it derives five facts and passes them to the rounder as
-`customRounderInfo`:
-
-```cpp
-prop noOverflow;   prop noUnderflow;   prop exact;
-prop subnormalExact;   prop noSignificandOverflow;
-```
-
-The rounder then skips work it can prove unnecessary:
-
-```cpp
-prop incrementExponent(!known.noSignificandOverflow && incrementExponentNeeded);
-prop overflow(!known.noOverflow && ITE(lateOverflow, true, earlyOverflow));
-```
-
-Camada's `round()` computes all of it unconditionally, with no channel
-for a caller to say a case cannot arise.
-
-**Why this is not being built: the motivating number was an artifact.**
-The "add is 1880x slower" figure came from a benchmark that gave each
-operation a different query shape, and add alone drew commutativity
-(`x+y == y+x`). Holding the operation fixed and varying only the shape:
-
-| shape | add | mul |
-|---|---|---|
-| single op, `isNaN` | 3.8x | 4.6x |
-| result equated to a free symbol | 6.8x | 7.0x |
-| commutativity | **1720x** | 8.1x |
-
-On ordinary query shapes add is indistinguishable from multiply, and
-slightly better. There is no add-specific rounder deficit.
-
-The blowup is the *swap network*, not the rounder. `addCore` orders its
-operands by exponent, so `x+y` and `y+x` bit-blast into mirror-image
-circuits, and the solver must prove the swap symmetric before anything
-downstream cancels. Multiply takes its operands symmetrically and has no
-such network. Constraining both operands to one binade — which pins
-`exp_delta` to 0 and makes the alignment shift constant — drops the
-commutativity query from 9113 ms to 1251 ms, a 7.3x collapse. That is
-where the cost lives.
-
-`round()`'s share of a single add is roughly 70% (`toIntegral`, which is
-round-dominated with almost no front end, costs 12.4 ms against add's
-17.6 ms) — but since add is already at parity with multiply, shrinking
-the rounder is a general FP optimisation, not an add fix, and would have
-to be justified on its own.
-
-Against that, the cost stays what it was: `round()` is shared by seven
-call sites, so a hints parameter obliges every caller to derive its own
-hints, and a wrong hint silently produces a wrong value rather than
-failing loudly — the same failure shape as the FMA subnormal bug in this
-file.
-
-If anyone revisits this, the gate is ESBMC hard instances, every hint
-needs a symbolic cross-check against native FP the way the conformance
-fixtures do, and the benchmark must hold the query shape fixed across
-operations.
-
-Full fixed-shape numbers for every FP operation are in
-`docs/fp-bv-vs-native.md`. On that measurement the remaining outlier is
-`sqrt` (~13x), not `add`.
 
 ### Term introspection, walkers, translation
 

--- a/docs/rejected-experiments.md
+++ b/docs/rejected-experiments.md
@@ -95,8 +95,8 @@ not revisited expecting a gain.
 splits the near and far cases. Bitwuzla does not call it: `symfpu::add`
 reaches the single-path `arithmeticAdd`. Copying it would be copying dead
 code. The technique bitwuzla actually uses for addition is a rounder-hint
-protocol, recorded in `open-follow-ups.md` rather than here because it is
-deferred, not rejected.
+protocol, recorded below — it was later rejected outright once the
+measurement motivating it turned out to be an artifact.
 
 **The architectural difference underneath all of this**, which no
 individual technique captures: SymFPU's unpacked float carries `nan`,
@@ -430,6 +430,65 @@ operations.
 Full fixed-shape numbers for every FP operation are in
 `docs/fp-bv-vs-native.md`. On that measurement the remaining outlier is
 `sqrt` (~13x), not `add`.
+
+### Narrowing the sqrt loop / sqrt rounder hints — REJECTED on measurement
+
+Investigated because `sqrt` is the last FP-over-BV outlier (~13-14x
+native, stable across query shapes and across f32/f64).
+
+**SymFPU's sqrt is not the reason it wins.** `core/sqrt.h` calls
+`fixedPointSqrt`, whose loop does a full `expandingMultiply(candidate,
+candidate)` every iteration — strictly more work per step than camada's
+restoring loop (one add, one subtract). Its own comment concedes "the
+default algorithm given here isn't a great one". Bitwuzla does not
+override it (`symfpu::sqrt` is called directly from `word_blaster.cpp`).
+
+**What actually differs is where the expansion happens.** Dumping one
+`fp.sqrt` query:
+
+| encoding | emitted |
+|---|---|
+| BV | 26112 bytes |
+| native | 114 bytes |
+
+Native emits ~150 bytes for *every* FP operation — it hands `fp.sqrt` to
+bitwuzla as a single term and SymFPU expands it inside the word-blaster,
+subject to bitwuzla's own rewriting before the SAT solver sees it. That
+is a structural property of being an external wrapper, not an encoding
+defect we can close.
+
+**Two things were tried and both failed:**
+
+1. *Narrowing the per-iteration add.* `S` in the loop is provably
+   constant (dumping it shows no symbols) with a single set bit, and `Q`
+   accumulates top-down, so `Q`'s low bits are structurally zero.
+   Splicing the add down to the live prefix made the formula **larger**
+   (26112 -> 29235 bytes): the extract/concat scaffolding costs more than
+   the zero bits, which bitwuzla was already folding.
+
+2. *Rounder hints.* SymFPU passes `customRounderInfo(noOverflow=true,
+   noUnderflow=true, exact=false, subnormalExact=true, ...)` — for sqrt
+   these are unconditional constants, not caller-derived facts, so unlike
+   the addition case they carry no wrong-hint risk. The invariant holds
+   for camada too: `sqrt(normal)` is never subnormal is UNSAT over all
+   inputs, verified symbolically.
+
+   But the headroom is not there. `round()` is only ~13ms of sqrt's
+   ~61ms (measured against `toIntegral`, which is round-dominated with
+   almost no front end). Replacing the rounder with a raw repack — wrong
+   numerically, but an upper bound on the saving — shrank the formula 30%
+   (26112 -> 18356 bytes) and made it **slower**, 61ms -> 90ms.
+
+That last result is the useful one: for this operation a 30% smaller
+formula solved 48% slower. Formula size is not a proxy for solve time
+here, so "emit fewer nodes" is not a strategy for sqrt.
+
+**If anyone retries:** the remaining ~48ms is the restoring loop itself,
+and beating it needs a better algorithm, not a tighter encoding of this
+one. SymFPU's own comment points at the alternative — assert
+`r < 2o+1 && x = o*o + r` over nondeterministic `o`, `r`, letting the
+solver search rather than bit-blasting a fixed loop. That is a genuinely
+different shape and would have to be gated on ESBMC hard instances.
 
 ## The gates these produced
 

--- a/docs/rejected-experiments.md
+++ b/docs/rejected-experiments.md
@@ -428,8 +428,8 @@ fixtures do, and the benchmark must hold the query shape fixed across
 operations.
 
 Full fixed-shape numbers for every FP operation are in
-`docs/fp-bv-vs-native.md`. On that measurement the remaining outlier is
-`sqrt` (~13x), not `add`.
+`docs/fp-bv-vs-native.md`. On that measurement the outlier is `sqrt`
+(~13x), not `add` — and that was investigated too; see the next entry.
 
 ### Narrowing the sqrt loop / sqrt rounder hints — REJECTED on measurement
 

--- a/docs/rejected-experiments.md
+++ b/docs/rejected-experiments.md
@@ -348,6 +348,89 @@ work waited for evidence rather than starting on recalled semantics.
 
 ---
 
+### Rounder hints for FP addition — REJECTED, premise was a measurement artifact
+
+Proposed after camada's bit-blasted FP addition appeared far slower than
+bitwuzla's native (SymFPU) one. It is not — see the measurement below.
+The SymFPU technique is recorded anyway, because the obvious guess about
+what it does is wrong and someone will look again.
+
+**Not** the dual-path split. `add.h` contains `dualPathArithmeticAdd`,
+which splits near and far cases — but bitwuzla never calls it. It calls
+`symfpu::add`, reaching the single-path `arithmeticAdd`. Implementing the
+dual-path version would be copying dead code.
+
+What `arithmeticAdd` actually does is build a case table over the
+exponent difference, predicting where the result exponent can land:
+
+```
+Case      A. max(l,r)+1   B. max(l,r)   C. max(l,r)-1   D. max(l,r)-k   E. zero
+diff = 0      Y               Y
+diff = 1      Y, sticky 0     Y, sticky 0
+```
+
+From that it derives five facts and passes them to the rounder as
+`customRounderInfo`:
+
+```cpp
+prop noOverflow;   prop noUnderflow;   prop exact;
+prop subnormalExact;   prop noSignificandOverflow;
+```
+
+The rounder then skips work it can prove unnecessary:
+
+```cpp
+prop incrementExponent(!known.noSignificandOverflow && incrementExponentNeeded);
+prop overflow(!known.noOverflow && ITE(lateOverflow, true, earlyOverflow));
+```
+
+Camada's `round()` computes all of it unconditionally, with no channel
+for a caller to say a case cannot arise.
+
+**Why this is not being built: the motivating number was an artifact.**
+The "add is 1880x slower" figure came from a benchmark that gave each
+operation a different query shape, and add alone drew commutativity
+(`x+y == y+x`). Holding the operation fixed and varying only the shape:
+
+| shape | add | mul |
+|---|---|---|
+| single op, `isNaN` | 3.8x | 4.6x |
+| result equated to a free symbol | 6.8x | 7.0x |
+| commutativity | **1720x** | 8.1x |
+
+On ordinary query shapes add is indistinguishable from multiply, and
+slightly better. There is no add-specific rounder deficit.
+
+The blowup is the *swap network*, not the rounder. `addCore` orders its
+operands by exponent, so `x+y` and `y+x` bit-blast into mirror-image
+circuits, and the solver must prove the swap symmetric before anything
+downstream cancels. Multiply takes its operands symmetrically and has no
+such network. Constraining both operands to one binade — which pins
+`exp_delta` to 0 and makes the alignment shift constant — drops the
+commutativity query from 9113 ms to 1251 ms, a 7.3x collapse. That is
+where the cost lives.
+
+`round()`'s share of a single add is roughly 70% (`toIntegral`, which is
+round-dominated with almost no front end, costs 12.4 ms against add's
+17.6 ms) — but since add is already at parity with multiply, shrinking
+the rounder is a general FP optimisation, not an add fix, and would have
+to be justified on its own.
+
+Against that, the cost stays what it was: `round()` is shared by seven
+call sites, so a hints parameter obliges every caller to derive its own
+hints, and a wrong hint silently produces a wrong value rather than
+failing loudly — the same failure shape as the FMA subnormal bug in this
+file.
+
+If anyone revisits this, the gate is ESBMC hard instances, every hint
+needs a symbolic cross-check against native FP the way the conformance
+fixtures do, and the benchmark must hold the query shape fixed across
+operations.
+
+Full fixed-shape numbers for every FP operation are in
+`docs/fp-bv-vs-native.md`. On that measurement the remaining outlier is
+`sqrt` (~13x), not `add`.
+
 ## The gates these produced
 
 **Hard-instance gate.** Encoding performance changes merge only on ESBMC


### PR DESCRIPTION
Documentation only — no source changes.

Records what came out of measuring camada's FP-over-BV encoding against
bitwuzla's native FP, including two findings that overturn numbers this
repo had previously acted on.

## The correction

The "add is 1880x slower than native" figure was **an artifact of the
benchmark**, not a property of the encoding. That comparison gave each
operation whatever query suited it, and addition alone drew commutativity
(`x+y == y+x`) — which measures the difficulty of proving two
mirror-image circuits equivalent, not the cost of the encoding.

Holding the operation fixed and varying only the query shape:

| shape | add | mul |
|---|---|---|
| single op, `isNaN` | 3.8x | 4.6x |
| result equated to a free symbol | 6.8x | 7.0x |
| commutativity | **1720x** | 8.1x |

On ordinary shapes add is indistinguishable from multiply, and slightly
better. The blowup is the exponent-ordering **swap network**: `addCore`
orders its operands, so `x+y` and `y+x` bit-blast into mirror images.
Constraining both operands to one binade — pinning `exp_delta` to 0 —
drops the query from 9113 ms to 1251 ms.

The planned rounder-hints work would therefore have targeted the wrong
function, and is moved to `rejected-experiments.md`.

## The re-measurement

`docs/fp-bv-vs-native.md` is new: the full table with #144, #145 and #146
applied, every operation given the **same** query shape, two shapes, two
runs agreeing within noise.

Headline: the arithmetic core (add, sub, mul, div, fma, toIntegral) sits
in a tight **2-5x** band with no outlier. `rem` (0.44x) and the IEEE
round-trip (0.28x) beat native outright. `sqrt` at ~13x was the one
exception.

The file also documents the two shape traps, including the second one
that cost me a run: `res == z && res != z` is refutable propositionally
without the solver ever expanding the operation — visible as a flat
~0.4 ms native column for everything.

## The sqrt investigation

Chased, and there is no cheap win:

- **SymFPU's sqrt loop is worse than ours** — a full
  `expandingMultiply(candidate, candidate)` per iteration against our one
  add and one subtract. Its own comment concedes the algorithm "isn't a
  great one", and bitwuzla does not override it.
- **The gap is structural.** Native emits ~150 bytes for *every* FP
  operation because it hands the term to bitwuzla whole and SymFPU
  expands it inside the word-blaster; we emit 26 KB of already-expanded
  terms. That is a property of being an external wrapper.
- Narrowing the loop's add made the formula **larger** (26112 -> 29235
  bytes); bitwuzla was already folding the zero bits.
- Rounder hints are sound here (unlike the add case, sqrt's hints are
  unconditional constants — I verified `sqrt(normal)` is never subnormal
  is UNSAT over all inputs) but the headroom is not there: `round()` is
  only ~13 ms of sqrt's ~61 ms.

The most useful result is negative: bypassing the rounder entirely cut
the formula 30% (26112 -> 18356 bytes) and made it solve **48% slower**
(61 ms -> 90 ms). Within a single operation, a much smaller formula was
much slower. That is a direct counterexample to formula size as a proxy
for solve time — the same trap as the node-count gate — and it is now
written into both documents, since `dump()` makes the substitution
tempting.

## Housekeeping

`open-follow-ups.md` had drifted into holding results rather than work:

- the rounder-hints entry was a settled rejection -> moved
- the FMA entry described a bug already fixed by #145 -> rewritten as the
  two tasks that remain (report Z3's copy, which is still broken
  upstream; extend the conformance fixtures to arithmetic)
- the fixtures task had been buried inside that bug description, under an
  "upstream reports we owe" heading where it did not belong -> promoted
- stale cross-references repointed

## Note on the earlier perf PRs

These numbers do not show the large per-operation wins #144 and #146 were
measured with, because those were measured with per-operation query
shapes. Both changes remain correct and symbolically cross-checked
against native FP over all inputs; I would no longer quote the headline
speedups.
