### PR TITLE
Fix #144's subnormal regression, two FP guard bugs, and add FXPRM

### DIFF
--- a/docs/open-follow-ups.md
+++ b/docs/open-follow-ups.md
@@ -18,6 +18,24 @@ Reproducer: `fp.rem(3.0e38f, 7.0e-39f)` returns the wrong value. Found by
 cross-checking against the host CPU, where `std::remainder` is exact per
 IEEE-754.
 
+A second, smaller witness in binary16, found by cross-checking camada's BV
+encoding against z3's native FP symbolically:
+
+```
+x = 0111100101100010   (44096.0)
+y = 0000001111001100   (5.793571472167969e-05, subnormal)
+
+exact (host remainder) -1.9550323486328125e-05   1000000101001000
+camada BV              -1.9550323486328125e-05   exact
+z3 native              -2.6464462280273438e-05   1000000110111100  (116 ulp out)
+```
+
+**The query must be symbolic.** Passing the operands as constants makes
+every backend agree, because `propagate-values` folds them before
+`fpa2bv` runs and the buggy bit-blaster never executes. Assert the inputs
+through symbols, or use an explicit `(then fpa2bv simplify bit-blast smt)`
+tactic.
+
 Not yet reported upstream.
 
 ### Camada's BV-encoded FMA is wrong on subnormal inputs

--- a/docs/open-follow-ups.md
+++ b/docs/open-follow-ups.md
@@ -38,10 +38,11 @@ tactic.
 
 Not yet reported upstream.
 
-### Camada's BV-encoded FMA is wrong on subnormal inputs
+### Z3 `fpa2bv` FMA: sticky bit dropped, wrong rounding
 
-**A correctness defect in shipped code**, inherited from Z3's
-`fpa2bv_converter` along with the rest of camada's FP bit-blast.
+Camada's copy of this was fixed in #145; Z3's is still open, and we owe
+the report. Originally recorded here as a camada defect, inherited from
+Z3's `fpa2bv_converter` along with the rest of the FP bit-blast.
 
 Counterexample, 32-bit IEEE bit patterns:
 
@@ -51,8 +52,12 @@ y  11111110111110000000000000000000
 z  00111111001001011000111100001011
 
 correct    01000000000111110101010100101111
-camada BV  01000000000111110101010100101110   <- one ulp low
+camada BV  01000000000111110101010100101110   <- one ulp low, BEFORE #145
 ```
+
+(That camada column is the pre-#145 behaviour, kept because it is the
+witness that identified the shared defect. Camada returns the correct
+value now; Z3 still returns the wrong one.)
 
 The correct value is confirmed three ways: exact rational arithmetic on
 `x*y + z`, the host CPU's hardware `fmaf()`, and bitwuzla's native FP.
@@ -63,6 +68,26 @@ answer bit-for-bit; Z3's *default* pipeline gets it right only because
 `propagate-values` folds the constants and its rewriter evaluates the FMA
 exactly, so the bit-blaster never runs on this input. A genuinely
 symbolic FMA hits the bug there too.
+
+A second, smaller witness in binary16, from cross-checking camada's BV
+encoding against z3's native FP symbolically. This one is *not*
+subnormal — it is a plain rounding error, so the defect is wider than the
+subnormal path:
+
+```
+fma(x, y, x)  with  x = 984.0        0110001110110000
+                    y = 3.546875     0100001100011000
+
+exact x*y+x  4474.125
+neighbours   4472 and 4476 (spacing 4), midpoint 4474.0
+             exact is ABOVE the midpoint, so RNE gives 4476
+
+camada BV    4476   0110110001011111   correct
+z3 native    4472   0110110001011110   rounds the wrong way
+```
+
+As with `mk_rem`, the query must be symbolic: constant operands are folded
+by `propagate-values` before `fpa2bv` runs, and z3 then answers correctly.
 
 This is the second subnormal-triggered defect found in that converter —
 see the `mk_rem` entry above — which suggests those paths are

--- a/regression/bvconformance.test.h
+++ b/regression/bvconformance.test.h
@@ -246,7 +246,8 @@ inline void fxp_gap_conformance(const camada::SMTSolverRef &solver) {
     // toward-zero integer part fits [-2, 1].
     int64_t Trunc = sv(A) >= 0 ? sv(A) / 4 : -((-sv(A)) / 4);
     All = solver->mkAnd(
-        All, solver->mkEqual(solver->mkFXPToBVOverflow(raw(A), 2, true),
+        All, solver->mkEqual(solver->mkFXPToBVOverflow(
+                                 raw(A), 2, true, camada::FXPRM::TowardZero),
                              solver->mkBool(Trunc < -2 || Trunc > 1)));
   }
   solver->addConstraint(All);

--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -599,6 +599,104 @@ inline void check_rem_pair_f64(const camada::SMTSolverRef &solver,
   REQUIRE(solver->check() == camada::checkResult::SAT);
 }
 
+// Multiply and divide against the host CPU, on subnormal operands.
+//
+// These are the inputs that caught a regression where multiply and divide
+// stopped normalizing their operands. round() renormalizes the
+// significand, so the change looked safe, but an unnormalized subnormal
+// reports an exponent understated by its leading-zero count and round()
+// cannot recover that: multiply returned a wrong subnormal product and
+// divide returned an infinity where the result is finite.
+inline void fp_muldiv_subnormal_host_oracle(const camada::SMTSolverRef &solver,
+                                            camada::FPEncoding Encoding) {
+  const float Sub = std::numeric_limits<float>::denorm_min();
+  const std::pair<float, float> Pairs[] = {
+      // Ordinary values, as a control.
+      {3.0f, 2.0f},
+      {-7.5f, 0.5f},
+      // Subnormal operands. A subnormal times a large value lands back in
+      // the normal range; a normal over a subnormal overflows the naive
+      // exponent difference.
+      {-128.5f, Sub},
+      {Sub, 1e38f},
+      {Sub * 3.0f, -1.6482427e38f},
+      {4.82425e-07f, -2.93883e-39f},
+      {1.0f, Sub},
+      {Sub, Sub},
+  };
+
+  for (auto [X, Y] : Pairs) {
+    for (bool IsDiv : {false, true}) {
+      solver->reset();
+      // Drive the operands through symbols pinned by equality rather than
+      // passing constants: a constant multiply is folded by the backend's
+      // rewriter and never reaches the bit-blast under test.
+      auto s = solver->mkFP32Sort(Encoding);
+      auto x = solver->mkSymbol("mdx", s);
+      auto y = solver->mkSymbol("mdy", s);
+      solver->addConstraint(solver->mkFPEqual(x, solver->mkFP32(X, Encoding)));
+      solver->addConstraint(solver->mkFPEqual(y, solver->mkFP32(Y, Encoding)));
+      auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, Encoding);
+      auto got = IsDiv ? solver->mkFPDiv(x, y, rm) : solver->mkFPMul(x, y, rm);
+      // volatile keeps the reference at float precision.
+      volatile float VX = X, VY = Y;
+      const float Want = IsDiv ? VX / VY : VX * VY;
+      auto want = solver->mkFP32(Want, Encoding);
+      // Compare IEEE bits: a wrong subnormal and an infinity where the
+      // result is finite both show up, and fp.eq would hide -0 vs +0.
+      INFO((IsDiv ? "div(" : "mul(") << X << ", " << Y << ") want " << Want);
+      solver->addConstraint(solver->mkNot(solver->mkEqual(
+          solver->mkIEEEFPToBV(got), solver->mkIEEEFPToBV(want))));
+      REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    }
+  }
+}
+
+// toIntegral on values that are already integers, across formats.
+//
+// The "exponent >= sbits-1, so x is already an integer" branch was gated
+// by a floating-point log2 test that reads 4.17 > 4 for binary16 and
+// disabled the branch outright, so toIntegral(14184.0) returned 0.5.
+// binary32 passed the same gate, which is why nothing here caught it —
+// hence the explicit narrow-format case.
+// The binary16 half runs under the BV encoding only, matching
+// fp_non_standard_widths: narrow formats are camada's own encoding, and
+// backends reject them natively (cvc5 requires --fp-exp, bitwuzla
+// --fpexp).
+inline void fp_tointegral_large_values_bv(const camada::SMTSolverRef &solver) {
+  const camada::FPEncoding Encoding = camada::FPEncoding::BV;
+  // Large binary16 values: every one of these is exactly an integer, so
+  // toIntegral must return it unchanged.
+  const std::string Halfs[] = {
+      "0110100000010000", // 2^11 * 1.0625
+      "0110110000010000", "0111000000010000",
+      "0111010000010000", "0111100000010000", // 14184-scale magnitudes
+  };
+  for (const std::string &Bits : Halfs) {
+    solver->reset();
+    auto x = solver->mkFPFromBin(Bits, 5, Encoding);
+    auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, Encoding);
+    INFO("binary16 toIntegral(" << Bits << ")");
+    solver->addConstraint(
+        solver->mkNot(solver->mkFPEqual(solver->mkFPtoIntegral(x, rm), x)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
+}
+
+inline void fp_tointegral_large_values(const camada::SMTSolverRef &solver,
+                                       camada::FPEncoding Encoding) {
+  // binary32, which took the other side of the gate and stayed correct.
+  for (float V : {16777216.0f, 14184.0f, 1e30f, -1e30f, -14184.0f}) {
+    solver->reset();
+    auto x = solver->mkFP32(V, Encoding);
+    auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, Encoding);
+    INFO("binary32 toIntegral(" << V << ")");
+    solver->addConstraint(
+        solver->mkNot(solver->mkFPEqual(solver->mkFPtoIntegral(x, rm), x)));
+    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  }
+}
+
 // FMA against the host CPU's fused multiply-add, which is exact per
 // IEEE-754: one rounding of x*y+z, never two. The subnormal cases are the
 // point — camada's bit-blast inherited a one-ulp error from Z3's

--- a/regression/fxp.test.h
+++ b/regression/fxp.test.h
@@ -261,12 +261,12 @@ inline void fxp_exhaustive_semantics(const camada::SMTSolverRef &solver) {
             break;
           case Op::Mul:
             Ref = refMul(F, A, B);
-            Value = solver->mkFXPMul(EA, EB);
+            Value = solver->mkFXPMul(EA, EB, camada::FXPRM::TowardNegative);
             Pred = solver->mkFXPMulOverflow(EA, EB);
             break;
           case Op::Div:
             Ref = refDiv(F, A, B);
-            Value = solver->mkFXPDiv(EA, EB);
+            Value = solver->mkFXPDiv(EA, EB, camada::FXPRM::TowardNegative);
             Pred = solver->mkFXPDivOverflow(EA, EB);
             Conjuncts.push_back(
                 boolIs(solver, solver->mkFXPDivByZero(EB), Ref.DivByZero));
@@ -306,8 +306,9 @@ fxp_boundary_overflow_semantics(const camada::SMTSolverRef &solver) {
     A = mkConst(solver, F, 89);
     B = mkConst(solver, F, 23);
     // ... and the truncated value is exactly the boundary.
-    solver->addConstraint(
-        solver->mkFXPEqual(solver->mkFXPMul(A, B), mkConst(solver, F, 127)));
+    solver->addConstraint(solver->mkFXPEqual(
+        solver->mkFXPMul(A, B, camada::FXPRM::TowardNegative),
+        mkConst(solver, F, 127)));
     REQUIRE(solver->check() == camada::checkResult::SAT);
   }
   // 127 * 16 = 2032 = max*16 exactly: representable, NOT an overflow.
@@ -346,21 +347,25 @@ inline void fxp_rounding_semantics(const camada::SMTSolverRef &solver) {
   // (-3/16) / 2.0: exact raw quotient -1.5, not representable; floor
   // gives raw -2 (toward zero would give -1 — Clang floors, per the
   // execution oracle).
-  Conjuncts.push_back(
-      solver->mkFXPEqual(solver->mkFXPDiv(C(-3), C(32)), C(-2)));
+  Conjuncts.push_back(solver->mkFXPEqual(
+      solver->mkFXPDiv(C(-3), C(32), camada::FXPRM::TowardNegative), C(-2)));
   // (3/16) / 2.0: exact raw quotient 1.5 -> raw 1.
-  Conjuncts.push_back(solver->mkFXPEqual(solver->mkFXPDiv(C(3), C(32)), C(1)));
+  Conjuncts.push_back(solver->mkFXPEqual(
+      solver->mkFXPDiv(C(3), C(32), camada::FXPRM::TowardNegative), C(1)));
   // (-1/16) * (8/16): exact -0.5 raw; floor -> -1 raw (not 0).
-  Conjuncts.push_back(solver->mkFXPEqual(solver->mkFXPMul(C(-1), C(8)), C(-1)));
+  Conjuncts.push_back(solver->mkFXPEqual(
+      solver->mkFXPMul(C(-1), C(8), camada::FXPRM::TowardNegative), C(-1)));
   // ( 1/16) * (8/16): exact 0.5 raw; floor -> 0 raw.
-  Conjuncts.push_back(solver->mkFXPEqual(solver->mkFXPMul(C(1), C(8)), C(0)));
+  Conjuncts.push_back(solver->mkFXPEqual(
+      solver->mkFXPMul(C(1), C(8), camada::FXPRM::TowardNegative), C(0)));
   requireAllHold(solver, Conjuncts);
 
   // Fixed -> integer rounds toward zero: -1.5 -> -1 (a plain arithmetic
   // shift would floor to -2).
   solver->reset();
   camada::SMTExprRef MinusOneHalf = mkConst(solver, F, uint64_t(-24) & 0xFF);
-  camada::SMTExprRef AsInt = solver->mkFXPToBV(MinusOneHalf, 8);
+  camada::SMTExprRef AsInt =
+      solver->mkFXPToBV(MinusOneHalf, 8, camada::FXPRM::TowardZero);
   solver->addConstraint(solver->mkEqual(AsInt, solver->mkBVFromDec(-1, 8)));
   REQUIRE(solver->check() == camada::checkResult::SAT);
 
@@ -370,8 +375,8 @@ inline void fxp_rounding_semantics(const camada::SMTSolverRef &solver) {
   solver->reset();
   camada::SMTExprRef MinusOneQ3 = mkConst(solver, F, uint64_t(-28) & 0xFF);
   RefFormat Narrow{8, 1, true};
-  camada::SMTExprRef Converted =
-      solver->mkFXPToFXP(MinusOneQ3, mkSort(solver, Narrow));
+  camada::SMTExprRef Converted = solver->mkFXPToFXP(
+      MinusOneQ3, mkSort(solver, Narrow), camada::FXPRM::TowardNegative);
   solver->addConstraint(solver->mkFXPEqual(
       Converted, mkConst(solver, Narrow, uint64_t(-4) & 0xFF)));
   REQUIRE(solver->check() == camada::checkResult::SAT);
@@ -394,10 +399,12 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
       camada::SMTExprRef V = mkConst(solver, From, Raw);
       camada::SMTSortRef ToSort = mkSort(solver, To);
       // Widening never overflows...
-      Conjuncts.push_back(solver->mkNot(solver->mkFXPToFXPOverflow(V, ToSort)));
+      Conjuncts.push_back(solver->mkNot(solver->mkFXPToFXPOverflow(
+          V, ToSort, camada::FXPRM::TowardNegative)));
       // ...and is exact: converting up compares equal to the original
       // (mkFXPEqual scale-aligns across the two formats).
-      Conjuncts.push_back(solver->mkFXPEqual(solver->mkFXPToFXP(V, ToSort), V));
+      Conjuncts.push_back(solver->mkFXPEqual(
+          solver->mkFXPToFXP(V, ToSort, camada::FXPRM::TowardNegative), V));
     }
     requireAllHold(solver, Conjuncts);
   }
@@ -408,7 +415,8 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
     solver->reset();
     RefFormat U{4, 2, false}, S4{4, 2, true};
     camada::SMTExprRef V = mkConst(solver, U, 8);
-    solver->addConstraint(solver->mkFXPToFXPOverflow(V, mkSort(solver, S4)));
+    solver->addConstraint(solver->mkFXPToFXPOverflow(
+        V, mkSort(solver, S4), camada::FXPRM::TowardNegative));
     REQUIRE(solver->check() == camada::checkResult::SAT);
   }
 
@@ -417,7 +425,8 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
     solver->reset();
     RefFormat S4{4, 2, true}, U{4, 2, false};
     camada::SMTExprRef V = mkConst(solver, S4, uint64_t(-1) & 0xF);
-    solver->addConstraint(solver->mkFXPToFXPOverflow(V, mkSort(solver, U)));
+    solver->addConstraint(solver->mkFXPToFXPOverflow(
+        V, mkSort(solver, U), camada::FXPRM::TowardNegative));
     REQUIRE(solver->check() == camada::checkResult::SAT);
   }
 
@@ -428,14 +437,15 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
     camada::SMTSortRef WideSrc = solver->mkFXPSort(70, 35, true);
     camada::SMTSortRef WideDst = solver->mkFXPSort(140, 70, true);
     camada::SMTExprRef X = solver->mkSymbol("fxp_wide_x", WideSrc);
-    solver->addConstraint(solver->mkFXPToFXPOverflow(X, WideDst));
+    solver->addConstraint(
+        solver->mkFXPToFXPOverflow(X, WideDst, camada::FXPRM::TowardNegative));
     REQUIRE(solver->check() == camada::checkResult::UNSAT);
     solver->reset();
     WideSrc = solver->mkFXPSort(70, 35, true);
     WideDst = solver->mkFXPSort(140, 70, true);
     X = solver->mkSymbol("fxp_wide_x", WideSrc);
-    solver->addConstraint(
-        solver->mkNot(solver->mkFXPEqual(solver->mkFXPToFXP(X, WideDst), X)));
+    solver->addConstraint(solver->mkNot(solver->mkFXPEqual(
+        solver->mkFXPToFXP(X, WideDst, camada::FXPRM::TowardNegative), X)));
     REQUIRE(solver->check() == camada::checkResult::UNSAT);
   }
 
@@ -447,7 +457,8 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
     camada::SMTSortRef Fmt = solver->mkFXPSort(16, 4, true);
     camada::SMTExprRef I = solver->mkSymbol("fxp_int_x", solver->mkBVSort(8));
     camada::SMTExprRef AsFXP = solver->mkFXPFromBV(I, SrcSigned, Fmt);
-    camada::SMTExprRef Back = solver->mkFXPToBV(AsFXP, 8);
+    camada::SMTExprRef Back =
+        solver->mkFXPToBV(AsFXP, 8, camada::FXPRM::TowardZero);
     solver->addConstraint(solver->mkNot(solver->mkEqual(Back, I)));
     REQUIRE(solver->check() == camada::checkResult::UNSAT);
   }
@@ -611,13 +622,13 @@ inline void fxp_sat_exhaustive_semantics(const camada::SMTSolverRef &solver) {
             break;
           case Op::Mul:
             Ref = refMulSat(F, A, B);
-            Value = solver->mkFXPMulSat(EA, EB);
+            Value = solver->mkFXPMulSat(EA, EB, camada::FXPRM::TowardNegative);
             break;
           case Op::Div:
             if (B == 0)
               continue;
             Ref = refDivSat(F, A, B);
-            Value = solver->mkFXPDivSat(EA, EB);
+            Value = solver->mkFXPDivSat(EA, EB, camada::FXPRM::TowardNegative);
             break;
           case Op::Neg:
             Ref = refNegSat(F, A);
@@ -689,9 +700,10 @@ inline void fxp_sat_conversion_semantics(const camada::SMTSolverRef &solver) {
       for (uint64_t RA = 0; RA < Count; ++RA) {
         int64_t A = refDecode(From, RA);
         camada::SMTExprRef EA = mkConst(solver, From, RA);
-        Conjuncts.push_back(
-            solver->mkFXPEqual(solver->mkFXPToFXPSat(EA, mkSort(solver, To)),
-                               mkConst(solver, To, toFXPSatRef(From, To, A))));
+        Conjuncts.push_back(solver->mkFXPEqual(
+            solver->mkFXPToFXPSat(EA, mkSort(solver, To),
+                                  camada::FXPRM::TowardNegative),
+            mkConst(solver, To, toFXPSatRef(From, To, A))));
       }
       requireAllHold(solver, Conjuncts);
     }
@@ -708,7 +720,8 @@ inline void fxp_sat_conversion_semantics(const camada::SMTSolverRef &solver) {
           std::string Bits =
               refBits(IntF, toBVSatRef(From, ToWidth, ToSigned, A));
           Conjuncts.push_back(
-              solver->mkEqual(solver->mkFXPToBVSat(EA, ToWidth, ToSigned),
+              solver->mkEqual(solver->mkFXPToBVSat(EA, ToWidth, ToSigned,
+                                                   camada::FXPRM::TowardZero),
                               solver->mkBVFromBin(Bits, ToWidth)));
         }
         requireAllHold(solver, Conjuncts);
@@ -751,7 +764,7 @@ inline void fxp_symbolic_shift_semantics(const camada::SMTSolverRef &solver) {
 // integer per the tie rule, then rescale — rather than mirroring the
 // encoding's bias-and-mask shape, so the fixtures pin that the two agree.
 inline uint64_t refRound(const RefFormat &F, int64_t A, unsigned Digits,
-                         camada::FXPRoundTie Tie) {
+                         camada::FXPRM Tie) {
   if (Digits >= F.FracBits)
     return refWrap(F, A);
   unsigned Shift = F.FracBits - Digits;
@@ -759,21 +772,33 @@ inline uint64_t refRound(const RefFormat &F, int64_t A, unsigned Digits,
   int64_t Q = refFloorDiv(A, Unit); // floor, so Rem is never negative
   int64_t Rem = A - Q * Unit;
   int64_t Half = Unit / 2;
-  if (Rem > Half)
-    ++Q;
-  else if (Rem == Half) {
-    switch (Tie) {
-    case camada::FXPRoundTie::TowardPositive:
+  // The directed modes never look at the halfway point.
+  switch (Tie) {
+  case camada::FXPRM::TowardNegative:
+    break; // Q is already the floor
+  case camada::FXPRM::TowardPositive:
+    if (Rem)
       ++Q;
-      break;
-    case camada::FXPRoundTie::AwayFromZero:
-      if (A >= 0)
+    break;
+  case camada::FXPRM::TowardZero:
+    if (Rem && A < 0)
+      ++Q; // floor is one unit too low for negatives
+    break;
+  case camada::FXPRM::NearestTiesTowardPositive:
+  case camada::FXPRM::NearestTiesAwayFromZero:
+  case camada::FXPRM::NearestTiesToEven:
+    if (Rem > Half)
+      ++Q;
+    else if (Rem == Half) {
+      if (Tie == camada::FXPRM::NearestTiesTowardPositive)
         ++Q;
-      break;
-    case camada::FXPRoundTie::ToEven:
-      Q += Q & 1;
-      break;
+      else if (Tie == camada::FXPRM::NearestTiesAwayFromZero) {
+        if (A >= 0)
+          ++Q;
+      } else
+        Q += Q & 1;
     }
+    break;
   }
   int64_t V = Q * Unit;
   return refWrap(F, V > F.maxRaw() ? F.maxRaw() : V);
@@ -973,8 +998,13 @@ inline void fxp_exp_exhaustive(const camada::SMTSolverRef &solver) {
   }
 }
 
+// Correctly-rounded fixed-point square root: nearest, ties to even.
+// The loop yields the floor and leaves N as the remainder S - R*R, and
+// the true root exceeds the midpoint exactly when that remainder is
+// greater than R, since (R + 1/2)^2 = R*R + R + 1/4.
 inline uint64_t refSqrt(const RefFormat &F, uint64_t Raw) {
-  uint64_t N = Raw << F.FracBits;
+  const uint64_t S = Raw << F.FracBits;
+  uint64_t N = S;
   uint64_t R = 0, Bit = uint64_t(1) << 62;
   while (Bit > N)
     Bit >>= 2;
@@ -986,6 +1016,9 @@ inline uint64_t refSqrt(const RefFormat &F, uint64_t Raw) {
       R >>= 1;
     Bit >>= 2;
   }
+  const uint64_t Rem = S - R * R;
+  if (Rem > R || (Rem == R && (R & 1)))
+    ++R;
   return R;
 }
 
@@ -1000,9 +1033,10 @@ inline void fxp_sqrt_semantics(const camada::SMTSolverRef &solver) {
         solver->reset();
         camada::SMTExprRef All;
         for (uint64_t Raw = 0; Raw <= uint64_t(F.maxRaw()); ++Raw) {
-          camada::SMTExprRef C =
-              solver->mkFXPEqual(solver->mkFXPSqrt(mkConst(solver, F, Raw)),
-                                 mkConst(solver, F, refSqrt(F, Raw)));
+          camada::SMTExprRef C = solver->mkFXPEqual(
+              solver->mkFXPSqrt(mkConst(solver, F, Raw),
+                                camada::FXPRM::NearestTiesToEven),
+              mkConst(solver, F, refSqrt(F, Raw)));
           All = All ? solver->mkAnd(All, C) : C;
         }
         solver->addConstraint(All);
@@ -1012,24 +1046,42 @@ inline void fxp_sqrt_semantics(const camada::SMTSolverRef &solver) {
   }
 
   // The defining property, proved over ALL symbolic values rather than
-  // enumerated: r*r <= x < (r+1)*(r+1) at the format's scale. This is
-  // what "correctly rounded" means, and it is checkable precisely
-  // because the operation is exact.
+  // enumerated. Correct rounding to nearest means the true root lies
+  // within half an ulp of r, i.e. between the two midpoints:
+  //
+  //     (2r - 1)^2 <= 4*x + 1   and   4*x <= (2r + 1)^2
+  //
+  // at the format's scale. The `+ 1` on the lower bound matters: a tie
+  // rounded UP sits exactly one below (2r-1)^2, since 4*x is an integer
+  // and the midpoint squared is not. Ties satisfy both bounds either
+  // way, so this admits both directions; the exhaustive loop above is
+  // what pins ties-to-even.
   {
     solver->reset();
-    unsigned W = 12, N = 6, Wide = 2 * (W + N) + 4;
+    unsigned W = 12, N = 6, Wide = 2 * (W + N) + 6;
     camada::SMTSortRef F = solver->mkFXPSort(W, N, true);
     camada::SMTExprRef X = solver->mkSymbol("fxp_sqrt_x", F);
-    camada::SMTExprRef R = solver->mkFXPSqrt(X);
+    camada::SMTExprRef R =
+        solver->mkFXPSqrt(X, camada::FXPRM::NearestTiesToEven);
     auto ext = [&](const camada::SMTExprRef &E) {
       return solver->mkBVZeroExt(Wide - W, solver->mkFXPToRawBV(E));
     };
     camada::SMTExprRef Rx = ext(R), Xx = ext(X);
-    camada::SMTExprRef RR = solver->mkBVMul(Rx, Rx);
-    camada::SMTExprRef R1 = solver->mkBVAdd(Rx, solver->mkBVFromDec(1, Wide));
+    camada::SMTExprRef Two = solver->mkBVFromDec(2, Wide);
+    camada::SMTExprRef One = solver->mkBVFromDec(1, Wide);
     camada::SMTExprRef Xs = solver->mkBVShl(Xx, solver->mkBVFromDec(N, Wide));
-    camada::SMTExprRef Holds = solver->mkAnd(
-        solver->mkBVUle(RR, Xs), solver->mkBVUlt(Xs, solver->mkBVMul(R1, R1)));
+    camada::SMTExprRef FourX = solver->mkBVShl(Xs, Two);
+    camada::SMTExprRef TwoR = solver->mkBVMul(Rx, Two);
+    camada::SMTExprRef Lo = solver->mkBVSub(TwoR, One);
+    camada::SMTExprRef Hi = solver->mkBVAdd(TwoR, One);
+    // r == 0 has no lower midpoint; the lower bound is vacuous there.
+    camada::SMTExprRef RIsZero =
+        solver->mkEqual(Rx, solver->mkBVFromDec(0, Wide));
+    camada::SMTExprRef LoOk =
+        solver->mkOr(RIsZero, solver->mkBVUle(solver->mkBVMul(Lo, Lo),
+                                              solver->mkBVAdd(FourX, One)));
+    camada::SMTExprRef Holds =
+        solver->mkAnd(LoOk, solver->mkBVUle(FourX, solver->mkBVMul(Hi, Hi)));
     camada::SMTExprRef NonNeg = solver->mkNot(solver->mkFXPLt(
         X, solver->mkFXPFromBin(refBits(RefFormat{W, N, true}, 0),
                                 solver->mkFXPSort(W, N, true))));
@@ -1047,7 +1099,9 @@ inline void fxp_sqrt_semantics(const camada::SMTSolverRef &solver) {
     camada::SMTExprRef All;
     for (uint64_t Raw : {uint64_t(0x80), uint64_t(0xC0), uint64_t(0xFF)}) {
       camada::SMTExprRef C = solver->mkFXPEqual(
-          solver->mkFXPSqrt(mkConst(solver, F, Raw)), mkConst(solver, F, 0));
+          solver->mkFXPSqrt(mkConst(solver, F, Raw),
+                            camada::FXPRM::NearestTiesToEven),
+          mkConst(solver, F, 0));
       All = All ? solver->mkAnd(All, C) : C;
     }
     solver->addConstraint(All);
@@ -1060,9 +1114,9 @@ inline void fxp_round_semantics(const camada::SMTSolverRef &solver) {
   // signednesses, and all three tie rules: small enough to enumerate
   // every raw value, wide enough to exercise saturation, ties, and
   // negative rounding.
-  for (camada::FXPRoundTie Tie :
-       {camada::FXPRoundTie::TowardPositive, camada::FXPRoundTie::AwayFromZero,
-        camada::FXPRoundTie::ToEven}) {
+  for (camada::FXPRM Tie : {camada::FXPRM::NearestTiesTowardPositive,
+                            camada::FXPRM::NearestTiesAwayFromZero,
+                            camada::FXPRM::NearestTiesToEven}) {
     for (unsigned Width : {5u, 6u}) {
       for (unsigned Frac = 0; Frac < Width; ++Frac) {
         for (bool Signed : {true, false}) {
@@ -1095,23 +1149,46 @@ inline void fxp_round_semantics(const camada::SMTSolverRef &solver) {
   {
     solver->reset();
     RefFormat F{6, 4, true};
-    auto R = [&](int64_t Raw, unsigned D, camada::FXPRoundTie T) {
+    auto R = [&](int64_t Raw, unsigned D, camada::FXPRM T) {
       return solver->mkFXPRound(mkConst(solver, F, refWrap(F, Raw)), D, T);
     };
     auto C = [&](int64_t Raw) { return mkConst(solver, F, refWrap(F, Raw)); };
-    using camada::FXPRoundTie;
+    using camada::FXPRM;
     camada::SMTExprRef All = solver->mkAnd(
-        solver->mkFXPEqual(R(-8, 0, FXPRoundTie::TowardPositive), C(0)),
-        solver->mkFXPEqual(R(-8, 0, FXPRoundTie::AwayFromZero), C(-16)));
+        solver->mkFXPEqual(R(-8, 0, FXPRM::NearestTiesTowardPositive), C(0)),
+        solver->mkFXPEqual(R(-8, 0, FXPRM::NearestTiesAwayFromZero), C(-16)));
     All = solver->mkAnd(
-        All, solver->mkFXPEqual(R(-8, 0, FXPRoundTie::ToEven), C(0)));
+        All, solver->mkFXPEqual(R(-8, 0, FXPRM::NearestTiesToEven), C(0)));
     All = solver->mkAnd(
         All,
-        solver->mkAnd(
-            solver->mkFXPEqual(R(8, 0, FXPRoundTie::TowardPositive), C(16)),
-            solver->mkFXPEqual(R(8, 0, FXPRoundTie::AwayFromZero), C(16))));
+        solver->mkAnd(solver->mkFXPEqual(
+                          R(8, 0, FXPRM::NearestTiesTowardPositive), C(16)),
+                      solver->mkFXPEqual(
+                          R(8, 0, FXPRM::NearestTiesAwayFromZero), C(16))));
+    All = solver->mkAnd(
+        All, solver->mkFXPEqual(R(8, 0, FXPRM::NearestTiesToEven), C(0)));
+    // The directed modes never consult the halfway point: 0.5 (raw 8) and
+    // 0.75 (raw 12) round the same way under each, and -0.5 (raw -8)
+    // separates floor from truncate.
+    for (int64_t Raw : {int64_t(8), int64_t(12)}) {
+      All = solver->mkAnd(
+          All, solver->mkFXPEqual(R(Raw, 0, FXPRM::TowardZero), C(0)));
+      All = solver->mkAnd(
+          All, solver->mkFXPEqual(R(Raw, 0, FXPRM::TowardNegative), C(0)));
+      All = solver->mkAnd(
+          All, solver->mkFXPEqual(R(Raw, 0, FXPRM::TowardPositive), C(16)));
+    }
+    // Negative: truncate goes toward zero, floor goes away from it.
     All = solver->mkAnd(All,
-                        solver->mkFXPEqual(R(8, 0, FXPRoundTie::ToEven), C(0)));
+                        solver->mkFXPEqual(R(-8, 0, FXPRM::TowardZero), C(0)));
+    All = solver->mkAnd(
+        All, solver->mkFXPEqual(R(-8, 0, FXPRM::TowardNegative), C(-16)));
+    All = solver->mkAnd(
+        All, solver->mkFXPEqual(R(-8, 0, FXPRM::TowardPositive), C(0)));
+    // Exact values are unchanged by every mode.
+    for (camada::FXPRM M :
+         {FXPRM::TowardZero, FXPRM::TowardNegative, FXPRM::TowardPositive})
+      All = solver->mkAnd(All, solver->mkFXPEqual(R(16, 0, M), C(16)));
     solver->addConstraint(All);
     REQUIRE(solver->check() == camada::checkResult::SAT);
   }
@@ -1142,7 +1219,7 @@ inline void fxp_round_semantics(const camada::SMTSolverRef &solver) {
     for (auto &T : V) {
       camada::SMTExprRef C = solver->mkFXPEqual(
           solver->mkFXPRound(mkConst(solver, Fr, T.In), T.Digits,
-                             camada::FXPRoundTie::TowardPositive),
+                             camada::FXPRM::NearestTiesTowardPositive),
           mkConst(solver, Fr, T.Out));
       All = All ? solver->mkAnd(All, C) : C;
     }
@@ -1160,9 +1237,9 @@ inline void fxp_round_semantics(const camada::SMTSolverRef &solver) {
     camada::SMTSortRef Wide = solver->mkFXPSort(48, 31, true);
     camada::SMTExprRef X = solver->mkSymbol("fxp_round_x", Wide);
     camada::SMTExprRef Id = solver->mkFXPEqual(
-        solver->mkFXPRound(X, 31, camada::FXPRoundTie::TowardPositive), X);
+        solver->mkFXPRound(X, 31, camada::FXPRM::NearestTiesTowardPositive), X);
     camada::SMTExprRef R =
-        solver->mkFXPRound(X, 23, camada::FXPRoundTie::TowardPositive);
+        solver->mkFXPRound(X, 23, camada::FXPRM::NearestTiesTowardPositive);
     camada::SMTExprRef Max = solver->mkFXPFromBin(
         refBits(RefFormat{48, 31, true},
                 uint64_t(RefFormat{48, 31, true}.maxRaw())),
@@ -1219,20 +1296,22 @@ inline void fxp_fp_conversion_semantics(const camada::SMTSolverRef &solver,
     // into range.
     camada::SMTExprRef Ok = solver->mkBool(true);
     for (uint32_t Good : {0x3f7ffe00u, 0xbf800000u, 0x3f7ffe01u, 0xbf800001u})
-      Ok = solver->mkAnd(
-          Ok, solver->mkNot(solver->mkFPToFXPOverflow(fp32(Good), To)));
+      Ok = solver->mkAnd(Ok, solver->mkNot(solver->mkFPToFXPOverflow(
+                                 fp32(Good), To, camada::FXPRM::TowardZero)));
     // Undefined: values whose truncation falls outside (1.0 scales to
     // 32768, -1.000030518 to -32769), NaN, and +-infinity.
     for (uint32_t Bad :
          {0x3f800000u, 0xbf800100u, 0x7fc00000u, 0x7f800000u, 0xff800000u})
-      Ok = solver->mkAnd(Ok, solver->mkFPToFXPOverflow(fp32(Bad), To));
+      Ok = solver->mkAnd(Ok, solver->mkFPToFXPOverflow(
+                                 fp32(Bad), To, camada::FXPRM::TowardZero));
     // Toward zero, not floor: -0.7f scales to -22937.6, truncating to
     // -22937 (raw 0xa667); flooring would give -22938.
     Ok = solver->mkAnd(
         Ok,
-        solver->mkFXPEqual(solver->mkFPToFXP(fp32(0xbf333333), To),
-                           solver->mkFXPFromBin(
-                               refBits(RefFormat{16, 15, true}, 0xa667), To)));
+        solver->mkFXPEqual(
+            solver->mkFPToFXP(fp32(0xbf333333), To, camada::FXPRM::TowardZero),
+            solver->mkFXPFromBin(refBits(RefFormat{16, 15, true}, 0xa667),
+                                 To)));
     solver->addConstraint(Ok);
     REQUIRE(solver->check() == camada::checkResult::SAT);
   }
@@ -1290,10 +1369,10 @@ inline void fxp_fp_conversion_semantics(const camada::SMTSolverRef &solver,
       camada::SMTExprRef F =
           solver->mkFPFromBin(refBits(RefFormat{32, 0, false}, Bits), 8, Enc);
       Ok = solver->mkAnd(
-          Ok,
-          solver->mkFXPEqual(solver->mkFPToFXPSat(F, S15),
-                             solver->mkFXPFromBin(
-                                 refBits(RefFormat{16, 15, true}, Raw), S15)));
+          Ok, solver->mkFXPEqual(
+                  solver->mkFPToFXPSat(F, S15, camada::FXPRM::TowardZero),
+                  solver->mkFXPFromBin(refBits(RefFormat{16, 15, true}, Raw),
+                                       S15)));
     }
     solver->addConstraint(Ok);
     REQUIRE(solver->check() == camada::checkResult::SAT);
@@ -1309,8 +1388,9 @@ inline void fxp_fp_conversion_semantics(const camada::SMTSolverRef &solver,
     camada::SMTExprRef X = solver->mkSymbol("fxp_rt_x", Fmt);
     camada::SMTExprRef F = solver->mkFXPToFP(X, F32, camada::RM::ROUND_TO_EVEN);
     solver->addConstraint(solver->mkOr(
-        solver->mkNot(solver->mkFXPEqual(solver->mkFPToFXP(F, Fmt), X)),
-        solver->mkFPToFXPOverflow(F, Fmt)));
+        solver->mkNot(solver->mkFXPEqual(
+            solver->mkFPToFXP(F, Fmt, camada::FXPRM::TowardZero), X)),
+        solver->mkFPToFXPOverflow(F, Fmt, camada::FXPRM::TowardZero)));
     REQUIRE(solver->check() == camada::checkResult::UNSAT);
   }
 }

--- a/regression/fxporacle.test.h
+++ b/regression/fxporacle.test.h
@@ -66,10 +66,12 @@ inline void fxp_oracle_semantics(const camada::SMTSolverRef &solver) {
       R = solver->mkFXPSub(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0));
       break;
     case OrOp::Mul:
-      R = solver->mkFXPMul(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0));
+      R = solver->mkFXPMul(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0),
+                           camada::FXPRM::TowardNegative);
       break;
     case OrOp::Div:
-      R = solver->mkFXPDiv(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0));
+      R = solver->mkFXPDiv(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0),
+                           camada::FXPRM::TowardNegative);
       break;
     case OrOp::Neg:
       R = solver->mkFXPNeg(A);
@@ -87,10 +89,12 @@ inline void fxp_oracle_semantics(const camada::SMTSolverRef &solver) {
       R = solver->mkFXPSubSat(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0));
       break;
     case OrOp::MulSat:
-      R = solver->mkFXPMulSat(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0));
+      R = solver->mkFXPMulSat(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0),
+                              camada::FXPRM::TowardNegative);
       break;
     case OrOp::DivSat:
-      R = solver->mkFXPDivSat(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0));
+      R = solver->mkFXPDivSat(A, mkFXP(solver, V.b, V.w, V.n, V.s != 0),
+                              camada::FXPRM::TowardNegative);
       break;
     case OrOp::NegSat:
       R = solver->mkFXPNegSat(A);
@@ -107,8 +111,9 @@ inline void fxp_oracle_semantics(const camada::SMTSolverRef &solver) {
     const OrConv &V = kConvSat[I];
     camada::SMTExprRef A = mkFXP(solver, V.a, V.fw, V.fn, V.fs != 0);
     camada::SMTSortRef To = solver->mkFXPSort(V.tw, V.tn, V.ts != 0);
-    return solver->mkFXPEqual(solver->mkFXPToFXPSat(A, To),
-                              mkFXP(solver, V.r, V.tw, V.tn, V.ts != 0));
+    return solver->mkFXPEqual(
+        solver->mkFXPToFXPSat(A, To, camada::FXPRM::TowardNegative),
+        mkFXP(solver, V.r, V.tw, V.tn, V.ts != 0));
   });
 
   // In-range by generation-time filtering, so the plain conversion is
@@ -118,9 +123,10 @@ inline void fxp_oracle_semantics(const camada::SMTSolverRef &solver) {
   checkVectorsChunked(solver, 2 * NToBV, [&](std::size_t I) {
     const OrToBV &V = kToBV[I / 2];
     camada::SMTExprRef A = mkFXP(solver, V.a, V.fw, V.fn, V.fs != 0);
-    camada::SMTExprRef R = (I % 2) == 0
-                               ? solver->mkFXPToBV(A, V.tw)
-                               : solver->mkFXPToBVSat(A, V.tw, V.ts != 0);
+    camada::SMTExprRef R =
+        (I % 2) == 0 ? solver->mkFXPToBV(A, V.tw, camada::FXPRM::TowardZero)
+                     : solver->mkFXPToBVSat(A, V.tw, V.ts != 0,
+                                            camada::FXPRM::TowardZero);
     return solver->mkEqual(R, solver->mkBVFromBin(rawBits(V.r, V.tw), V.tw));
   });
 }
@@ -146,10 +152,10 @@ inline void fxp_oracle_mixed_semantics(const camada::SMTSolverRef &solver) {
       R = solver->mkFXPSub(A, B);
       break;
     case OrMixOp::Mul:
-      R = solver->mkFXPMul(A, B);
+      R = solver->mkFXPMul(A, B, camada::FXPRM::TowardNegative);
       break;
     case OrMixOp::Div:
-      R = solver->mkFXPDiv(A, B);
+      R = solver->mkFXPDiv(A, B, camada::FXPRM::TowardNegative);
       break;
     case OrMixOp::AddSat:
       R = solver->mkFXPAddSat(A, B);
@@ -160,16 +166,17 @@ inline void fxp_oracle_mixed_semantics(const camada::SMTSolverRef &solver) {
       Sat = true;
       break;
     case OrMixOp::MulSat:
-      R = solver->mkFXPMulSat(A, B);
+      R = solver->mkFXPMulSat(A, B, camada::FXPRM::TowardNegative);
       Sat = true;
       break;
     case OrMixOp::DivSat:
-      R = solver->mkFXPDivSat(A, B);
+      R = solver->mkFXPDivSat(A, B, camada::FXPRM::TowardNegative);
       Sat = true;
       break;
     }
     camada::SMTExprRef C =
-        Sat ? solver->mkFXPToFXPSat(R, To) : solver->mkFXPToFXP(R, To);
+        Sat ? solver->mkFXPToFXPSat(R, To, camada::FXPRM::TowardNegative)
+            : solver->mkFXPToFXP(R, To, camada::FXPRM::TowardNegative);
     return solver->mkFXPEqual(C, mkFXP(solver, V.r, V.rw, V.rn, V.rs != 0));
   });
 }
@@ -199,11 +206,13 @@ inline void fxp_oracle_fp_semantics(const camada::SMTSolverRef &solver,
     camada::SMTExprRef A = solver->mkFPFromBin(rawBits(V.a, V.fpw), EW, Enc);
     camada::SMTSortRef To = solver->mkFXPSort(V.tw, V.tn, V.ts != 0);
     camada::SMTExprRef R =
-        V.sat != 0 ? solver->mkFPToFXPSat(A, To) : solver->mkFPToFXP(A, To);
+        V.sat != 0 ? solver->mkFPToFXPSat(A, To, camada::FXPRM::TowardZero)
+                   : solver->mkFPToFXP(A, To, camada::FXPRM::TowardZero);
     camada::SMTExprRef Eq =
         solver->mkFXPEqual(R, mkFXP(solver, V.r, V.tw, V.tn, V.ts != 0));
     if (V.sat == 0)
-      Eq = solver->mkAnd(Eq, solver->mkNot(solver->mkFPToFXPOverflow(A, To)));
+      Eq = solver->mkAnd(Eq, solver->mkNot(solver->mkFPToFXPOverflow(
+                                 A, To, camada::FXPRM::TowardZero)));
     return Eq;
   });
 }

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -156,6 +156,11 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDARGTEST(fp_remainder_semantics, BVFP);
   RESETANDARGTEST(fp_fma_host_oracle, NativeFP);
   RESETANDARGTEST(fp_fma_host_oracle, BVFP);
+  RESETANDARGTEST(fp_muldiv_subnormal_host_oracle, NativeFP);
+  RESETANDARGTEST(fp_muldiv_subnormal_host_oracle, BVFP);
+  RESETANDARGTEST(fp_tointegral_large_values, NativeFP);
+  RESETANDARGTEST(fp_tointegral_large_values, BVFP);
+  RESETANDTEST(fp_tointegral_large_values_bv);
   RESETANDARGTEST(fp_remainder_host_oracle, NativeFP);
   RESETANDARGTEST(fp_remainder_host_oracle, BVFP);
   RESETANDTEST(arena_stress_test);

--- a/src/camada.h
+++ b/src/camada.h
@@ -96,27 +96,47 @@ enum class FPNegBehavior {
   PreserveNaNPayload,
 };
 
-/// Selects how `mkFXPRound` breaks ties. TR 18037 specifies that the
-/// `roundfx` family rounds to nearest but leaves the halfway direction to
-/// the implementation, and implementations differ, so the caller states
-/// which one it is modelling rather than inheriting one library's choice.
+/// Rounding direction for the fixed-point operations that discard bits.
 ///
-/// - TowardPositive: a halfway value rounds up, so 0.5 rounds to 1 and
-///   -0.5 rounds to 0. What LLVM libc does (it adds half an ulp and masks
-///   off the low bits), and the only direction verified against an
-///   executing implementation.
-/// - AwayFromZero: a halfway value rounds away from zero, so 0.5 rounds
-///   to 1 and -0.5 rounds to -1 — symmetric about zero, the convention
-///   most C programmers expect from `round()`.
-/// - ToEven: a halfway value rounds to whichever neighbour has a zero in
-///   the last kept bit, the unbiased choice IEEE-754 uses by default.
+/// Separate from `RM` rather than reusing it, because fixed point needs a
+/// mode IEEE-754 has no name for. TR 18037's `roundfx` rounds to nearest
+/// but leaves the halfway direction to the implementation, and LLVM libc
+/// breaks ties toward positive infinity — nearest for every other value.
+/// `RM::ROUND_TO_PLUS_INF` is a different operation: it rounds *all*
+/// values up, so 0.25 becomes 1 where nearest-ties-up leaves it 0. With no
+/// RM member denoting "nearest, ties toward +inf", reusing RM would have
+/// silently dropped the one `roundfx` direction verified against an
+/// executing implementation.
 ///
-/// All three saturate to the format's maximum when the rounding would
-/// carry past it, which every implementation surveyed agrees on.
-enum class FXPRoundTie {
+/// The three nearest modes differ only on exact halfway values:
+///
+/// - NearestTiesTowardPositive: 0.5 rounds to 1 and -0.5 rounds to 0.
+///   LLVM libc's `roundfx` (it adds half an ulp and masks off the low
+///   bits), and the only direction verified against a running libc.
+/// - NearestTiesAwayFromZero: 0.5 rounds to 1 and -0.5 rounds to -1 —
+///   symmetric about zero, what most C programmers expect from `round()`.
+///   Equivalent to `RM::ROUND_TO_AWAY`.
+/// - NearestTiesToEven: a halfway value rounds to whichever neighbour has
+///   a zero in the last kept bit, IEEE-754's default and the unbiased
+///   choice. Equivalent to `RM::ROUND_TO_EVEN`.
+///
+/// The directed modes never consult the halfway point:
+///
+/// - TowardZero: truncate. C's fixed-to-integer and float-to-fixed
+///   direction, pinned by the execution oracle.
+/// - TowardNegative: floor. What Clang's `-ffixed-point` division does —
+///   verified: -0.5 / 0.75 gives -0.671875, not -0.6640625.
+/// - TowardPositive: ceiling.
+///
+/// Every nearest mode saturates to the format's maximum when the rounding
+/// would carry past it, which every implementation surveyed agrees on.
+enum class FXPRM {
+  NearestTiesTowardPositive,
+  NearestTiesAwayFromZero,
+  NearestTiesToEven,
+  TowardZero,
+  TowardNegative,
   TowardPositive,
-  AwayFromZero,
-  ToEven,
 };
 
 /// Selects how the SMT-LIB backend lowers tuples on the wire.
@@ -760,14 +780,26 @@ public:
   /// Creates a fixed-point negation.
   virtual SMTExprRef mkFXPNeg(const SMTExprRef &Exp) = 0;
 
-  /// Creates a fixed-point multiplication (truncating: the exact product's
-  /// low fractional bits are dropped).
-  virtual SMTExprRef mkFXPMul(const SMTExprRef &LHS, const SMTExprRef &RHS) = 0;
+  /// Creates a fixed-point multiplication. The exact product carries twice
+  /// the fraction bits; Mode decides how the surplus is discarded.
+  ///
+  /// Pass FXPRM::TowardNegative to reproduce C, which truncates. A
+  /// consumer cannot recover any other mode from that result: the bits
+  /// that decide the rounding are gone once the product is narrowed, and
+  /// 41% of Q4.4 products differ between truncation and nearest.
+  virtual SMTExprRef mkFXPMul(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                              FXPRM Mode) = 0;
 
-  /// Creates a fixed-point division. The quotient rounds toward negative
-  /// infinity (floor), matching Clang's -ffixed-point behavior as pinned
-  /// by the execution oracle.
-  virtual SMTExprRef mkFXPDiv(const SMTExprRef &LHS, const SMTExprRef &RHS) = 0;
+  /// Creates a fixed-point division, rounding the quotient per Mode.
+  ///
+  /// Pass FXPRM::TowardNegative to reproduce C: Clang's -ffixed-point
+  /// floors, which the execution oracle pins (-0.5 / 0.75 gives
+  /// -0.671875, not the -0.6640625 that truncation would give). No
+  /// widening lets a consumer round differently after the fact — a
+  /// quotient like 1/3 never terminates, so composing a wider divide with
+  /// a narrowing step double-rounds.
+  virtual SMTExprRef mkFXPDiv(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                              FXPRM Mode) = 0;
 
   /// Creates a fixed-point left shift by a concrete amount.
   virtual SMTExprRef mkFXPShl(const SMTExprRef &Exp, unsigned Amount) = 0;
@@ -847,13 +879,13 @@ public:
   virtual SMTExprRef mkFXPNegSat(const SMTExprRef &Exp) = 0;
 
   /// Saturating fixed-point multiplication.
-  virtual SMTExprRef mkFXPMulSat(const SMTExprRef &LHS,
-                                 const SMTExprRef &RHS) = 0;
+  virtual SMTExprRef mkFXPMulSat(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                                 FXPRM Mode) = 0;
 
   /// Saturating fixed-point division. The value is meaningful only under
   /// the negation of mkFXPDivByZero.
-  virtual SMTExprRef mkFXPDivSat(const SMTExprRef &LHS,
-                                 const SMTExprRef &RHS) = 0;
+  virtual SMTExprRef mkFXPDivSat(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                                 FXPRM Mode) = 0;
 
   /// Saturating fixed-point left shift.
   virtual SMTExprRef mkFXPShlSat(const SMTExprRef &Exp, unsigned Amount) = 0;
@@ -882,18 +914,18 @@ public:
                                      const SMTExprRef &Amount) = 0;
 
   /// Converts between fixed-point formats (truncating on narrowing).
-  virtual SMTExprRef mkFXPToFXP(const SMTExprRef &Exp,
-                                const SMTSortRef &To) = 0;
+  virtual SMTExprRef mkFXPToFXP(const SMTExprRef &Exp, const SMTSortRef &To,
+                                FXPRM Mode) = 0;
 
   /// True iff the value does not fit the target format of a mkFXPToFXP
   /// conversion.
   virtual SMTExprRef mkFXPToFXPOverflow(const SMTExprRef &Exp,
-                                        const SMTSortRef &To) = 0;
+                                        const SMTSortRef &To, FXPRM Mode) = 0;
 
   /// Saturating fixed-point format conversion: out-of-range values clamp
   /// to the target format's min/max instead of being undefined.
-  virtual SMTExprRef mkFXPToFXPSat(const SMTExprRef &Exp,
-                                   const SMTSortRef &To) = 0;
+  virtual SMTExprRef mkFXPToFXPSat(const SMTExprRef &Exp, const SMTSortRef &To,
+                                   FXPRM Mode) = 0;
 
   /// Converts an integer bit-vector into a fixed-point value. SrcSigned is
   /// the signedness of the SOURCE integer type: it governs the value (C's
@@ -906,7 +938,8 @@ public:
   /// Converts a fixed-point value to an integer bit-vector of the given
   /// width, rounding toward zero (the direction TR 18037 specifies for
   /// fixed-point to integer conversion).
-  virtual SMTExprRef mkFXPToBV(const SMTExprRef &Exp, unsigned ToWidth) = 0;
+  virtual SMTExprRef mkFXPToBV(const SMTExprRef &Exp, unsigned ToWidth,
+                               FXPRM Mode) = 0;
 
   /// True iff the toward-zero integer part does not fit the target
   /// integer type's range: [0, 2^w-1] for an unsigned target,
@@ -915,13 +948,13 @@ public:
   /// 2^w either way; only this range report and mkFXPToBVSat's clamp
   /// depend on the target's signedness.
   virtual SMTExprRef mkFXPToBVOverflow(const SMTExprRef &Exp, unsigned ToWidth,
-                                       bool ToSigned) = 0;
+                                       bool ToSigned, FXPRM Mode) = 0;
 
   /// Saturating fixed-point to integer conversion (round toward zero,
   /// then clamp to the TARGET integer type's range — a negative source
   /// clamps to zero for an unsigned target.
   virtual SMTExprRef mkFXPToBVSat(const SMTExprRef &Exp, unsigned ToWidth,
-                                  bool ToSigned) = 0;
+                                  bool ToSigned, FXPRM Mode) = 0;
 
   /// Rounds a fixed-point value to Digits fractional bits, keeping the
   /// same format (the low fraction bits become zero) — TR 18037's
@@ -929,7 +962,7 @@ public:
   /// to the format's maximum when the rounding would carry past it.
   /// Digits >= the format's fraction width returns the value unchanged.
   virtual SMTExprRef mkFXPRound(const SMTExprRef &Exp, unsigned Digits,
-                                FXPRoundTie Tie) = 0;
+                                FXPRM Tie) = 0;
 
   /// Absolute value — TR 18037's `absfx`. Saturates: the most negative
   /// value of a signed format has no positive counterpart, so it maps to
@@ -948,10 +981,18 @@ public:
   /// wrapping. For unsigned formats it counts leading zeros.
   virtual SMTExprRef mkFXPCountls(const SMTExprRef &Exp, unsigned ToWidth) = 0;
 
-  /// Square root, rounded toward zero: the unique r in the operand's own
-  /// format with r*r <= x < (r+1)*(r+1) at the format's scale. Always
-  /// representable — square root contracts on [0, max] for every format,
-  /// so no saturation is possible.
+  /// Square root, correctly rounded to nearest with ties to even: the
+  /// representable value closest to the true square root at the format's
+  /// scale. Always representable — square root contracts on [0, max] for
+  /// every format, so no saturation is possible.
+  ///
+  /// Nearest rather than toward zero because camada is meant to serve as
+  /// an oracle: an implementation being checked against it should be
+  /// compared with the exact answer, not with a floor that is up to one
+  /// ulp below it. Nothing in TR 18037 pins the direction — the standard
+  /// has no sqrtfx — so unlike the truncating conversions elsewhere in
+  /// this API, which reproduce C's semantics deliberately, this one is
+  /// free to be exact.
   ///
   /// This is the exact mathematical operation, NOT a reproduction of any
   /// library's `sqrtfx`. LLVM libc computes a Sollya-generated linear
@@ -967,7 +1008,15 @@ public:
   /// them. There is no paired predicate because the condition is just
   /// `x < 0` — a consumer that needs to assert it writes
   /// mkFXPLt(x, zero), which produces the same term.
-  virtual SMTExprRef mkFXPSqrt(const SMTExprRef &Exp) = 0;
+  ///
+  /// Mode selects the rounding. Nothing in TR 18037 pins a direction --
+  /// the standard has no sqrtfx and the libc implementations are
+  /// approximations that disagree with each other -- so no mode is "the C
+  /// one"; pass a nearest mode for the exact answer, which is what an
+  /// implementation checked against camada should be compared with. The
+  /// operand is non-negative by construction, so TowardZero and
+  /// TowardNegative coincide, as do the two non-even tie directions.
+  virtual SMTExprRef mkFXPSqrt(const SMTExprRef &Exp, FXPRM Mode) = 0;
 
   /// Base-e exponential, correctly rounded to nearest with ties to even,
   /// saturating to the format's maximum where the true value does not fit
@@ -1010,19 +1059,20 @@ public:
   /// fixed-to-fixed narrowing (floor); both pinned by the execution
   /// oracle. The value is meaningful only under the negation of
   /// mkFPToFXPOverflow (out-of-range, infinity, and NaN stay UB in C).
-  virtual SMTExprRef mkFPToFXP(const SMTExprRef &Exp, const SMTSortRef &To) = 0;
+  virtual SMTExprRef mkFPToFXP(const SMTExprRef &Exp, const SMTSortRef &To,
+                               FXPRM Mode) = 0;
 
   /// True iff the float-to-fixed conversion is undefined: NaN, +-infinity,
   /// or the toward-zero result lies outside the target format's range.
   virtual SMTExprRef mkFPToFXPOverflow(const SMTExprRef &Exp,
-                                       const SMTSortRef &To) = 0;
+                                       const SMTSortRef &To, FXPRM Mode) = 0;
 
   /// Saturating float-to-fixed conversion, defined for every input:
   /// out-of-range values and +-infinity clamp to the format's rails, NaN
   /// converts to 0 (Clang's choice for _Sat targets; the TR leaves it
   /// undefined).
-  virtual SMTExprRef mkFPToFXPSat(const SMTExprRef &Exp,
-                                  const SMTSortRef &To) = 0;
+  virtual SMTExprRef mkFPToFXPSat(const SMTExprRef &Exp, const SMTSortRef &To,
+                                  FXPRM Mode) = 0;
 
   /// Creates an array select operation. It returns the element in position
   /// Index of Array.

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -1820,8 +1820,11 @@ SMTExprRef SMTSolverImpl::mkSBVtoFPImpl(const SMTExprRef &From,
   unsigned exp_worst_case_sz = static_cast<unsigned>(
       (log(static_cast<double>(bv_sz)) / log(static_cast<double>(2))) + 1.0);
 
-  if (exp_sz < exp_worst_case_sz) {
-    // exp_sz < exp_worst_case_sz and exp >= 0.
+  // `<=`, not `<`: round() reads the exponent as signed, so a value
+  // needing the full exp_sz bits is already unrepresentable and must be
+  // clamped before round() consumes it. The boundary case is a binary16
+  // target from a 64-bit operand, where both sides are 7.
+  if (exp_sz <= exp_worst_case_sz) {
     // Take the maximum legal exponent; this
     // allows us to keep the most precision.
     SMTExprRef max_exp = mkMaxExp(*this, exp_sz);
@@ -1916,8 +1919,11 @@ SMTExprRef SMTSolverImpl::mkUBVtoFPImpl(const SMTExprRef &From,
   unsigned exp_worst_case_sz = static_cast<unsigned>(
       (log(static_cast<double>(bv_sz)) / log(static_cast<double>(2))) + 1.0);
 
-  if (exp_sz < exp_worst_case_sz) {
-    // exp_sz < exp_worst_case_sz and exp >= 0.
+  // `<=`, not `<`: round() reads the exponent as signed, so a value
+  // needing the full exp_sz bits is already unrepresentable and must be
+  // clamped before round() consumes it. The boundary case is a binary16
+  // target from a 64-bit operand, where both sides are 7.
+  if (exp_sz <= exp_worst_case_sz) {
     // Take the maximum legal exponent; this
     // allows us to keep the most precision.
     SMTExprRef max_exp = mkMaxExp(*this, exp_sz);

--- a/src/camadafp.cpp
+++ b/src/camadafp.cpp
@@ -633,10 +633,15 @@ SMTExprRef SMTSolverImpl::mkFPMulImpl(const SMTExprRef &LHS,
   // else comes the actual multiplication.
   SMTExprRef a_sgn, a_sig, a_exp, a_lz;
   SMTExprRef b_sgn, b_sig, b_exp, b_lz;
-  // Unnormalized: round() renormalizes from the product's own leading
-  // zeros, so normalizing the operands first is duplicated work.
-  unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, false);
-  unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, false);
+  // Normalized. round() renormalizes the significand, but it cannot
+  // recover an exponent that was never right: an unnormalized subnormal
+  // reports an exponent understated by its leading-zero count, and the
+  // a_lz/b_lz subtractions below are what correct it.
+  unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, true);
+  unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, true);
+
+  SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
+  SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
 
   SMTExprRef a_sig_ext = mkBVZeroExt(sbits, a_sig);
   SMTExprRef b_sig_ext = mkBVZeroExt(sbits, b_sig);
@@ -647,8 +652,7 @@ SMTExprRef SMTSolverImpl::mkFPMulImpl(const SMTExprRef &LHS,
   SMTExprRef res_sgn, res_sig, res_exp;
   res_sgn = mkBVXor(a_sgn, b_sgn);
 
-  // Both leading-zero counts are zero above.
-  res_exp = mkBVAdd(a_exp_ext, b_exp_ext);
+  res_exp = mkBVAdd(mkBVSub(a_exp_ext, a_lz_ext), mkBVSub(b_exp_ext, b_lz_ext));
 
   SMTExprRef product = mkBVMul(a_sig_ext, b_sig_ext);
 
@@ -742,9 +746,10 @@ SMTExprRef SMTSolverImpl::mkFPDivImpl(const SMTExprRef &LHS,
 
   SMTExprRef a_sgn, a_sig, a_exp, a_lz;
   SMTExprRef b_sgn, b_sig, b_exp, b_lz;
-  // Unnormalized: round() renormalizes from the quotient's leading zeros.
-  unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, false);
-  unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, false);
+  // Normalized, for the same reason as multiply: an unnormalized
+  // subnormal reports an understated exponent that round() cannot fix.
+  unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, true);
+  unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, true);
 
   unsigned extra_bits = sbits + 2;
   SMTExprRef a_sig_ext = mkBVConcat(a_sig, mkBVFromDec(0, sbits + extra_bits));
@@ -755,8 +760,11 @@ SMTExprRef SMTSolverImpl::mkFPDivImpl(const SMTExprRef &LHS,
 
   SMTExprRef res_sgn = mkBVXor(a_sgn, b_sgn);
 
-  // Both leading-zero counts are zero above.
-  SMTExprRef res_exp = mkBVSub(a_exp_ext, b_exp_ext);
+  SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
+  SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
+
+  SMTExprRef res_exp =
+      mkBVSub(mkBVSub(a_exp_ext, a_lz_ext), mkBVSub(b_exp_ext, b_lz_ext));
 
   // b_sig_ext can't be 0 here, so it's safe to use OP_BUDIV_I
   SMTExprRef quotient = mkBVUDiv(a_sig_ext, b_sig_ext);
@@ -2136,10 +2144,19 @@ SMTExprRef SMTSolverImpl::mkFPtoIntegralImpl(const SMTExprRef &From,
   v4 = mkIte(rm_is_rtn, v4_rtn, v4);
   v4 = mkIte(rm_is_rtz, xzero, v4);
 
-  // exponent >= sbits-1 -> x
-  SMTExprRef exp_is_large = log2(sbits - 1) + 1 <= ebits - 1
-                                ? mkBVSle(mkBVFromDec(sbits - 1, ebits), a_exp)
-                                : mkBool(false);
+  // exponent >= sbits-1 -> x is already an integer, return it unchanged.
+  //
+  // The comparison is signed over ebits bits, so it is only meaningful
+  // when sbits-1 is representable as a positive signed ebits-bit value,
+  // i.e. sbits-1 <= 2^(ebits-1) - 1. Test that exactly: a floating-point
+  // log2 formulation reads 4.17 > 4 for binary16 (ebits 5, sbits 10) and
+  // wrongly disables this branch, leaving every large binary16 value to
+  // fall through the rounding path below and come back wrong.
+  bool exp_fits =
+      ebits >= 2 && ebits - 1 < 63 &&
+      static_cast<uint64_t>(sbits - 1) <= (UINT64_C(1) << (ebits - 1)) - 1;
+  SMTExprRef exp_is_large =
+      exp_fits ? mkBVSle(mkBVFromDec(sbits - 1, ebits), a_exp) : mkBool(false);
   const SMTExprRef &c5 = exp_is_large;
   const SMTExprRef &v5 = From;
 

--- a/src/camadafxp.cpp
+++ b/src/camadafxp.cpp
@@ -1476,8 +1476,12 @@ struct FPFXPParts {
   SMTExprRef TooLo; // !(Scaled > minRaw-1): below range or -infinity
 };
 
+// Mode is applied to the scaled value before the range bounds are
+// derived, so TooHi/TooLo describe the value that will actually be
+// converted. Testing the unrounded value would let a predicate report
+// "in range" for an input whose rounded result does not fit.
 FPFXPParts fpToFXPParts(SMTSolverImpl &S, const SMTExprRef &Exp,
-                        const FXPFormat &To) {
+                        const FXPFormat &To, FXPRM Mode) {
   SMTSortRef Src = Exp->Sort;
   SMTExprRef Val = Exp;
   unsigned SrcE = Src->getFPExponentWidth();
@@ -1516,6 +1520,7 @@ FPFXPParts fpToFXPParts(SMTSolverImpl &S, const SMTExprRef &Exp,
                       Enc),
         RNE); // exact power-of-two scale
   FPFXPParts P;
+  Scaled = roundFPToIntegral(S, Scaled, Mode);
   P.Scaled = Scaled;
   P.IsNaN = S.mkFPIsNaN(Exp);
   // The toward-zero result lands in range iff minRaw-1 < scaled < maxRaw+1
@@ -1594,17 +1599,16 @@ SMTExprRef SMTSolverImpl::mkFPToFXP(const SMTExprRef &Exp, const SMTSortRef &To,
   fatalErrorIf(!Exp->Sort->isFPSort(), "Expected floating-point expression");
   requireFXPSort(To);
   FXPFormat Target = formatOf(To);
-  FPFXPParts P = fpToFXPParts(*this, Exp, Target);
-  // fp.to_sbv / fp.to_ubv always round toward zero, so any other mode has
-  // to be applied in the FP domain first: round the scaled value to an
-  // integer under Mode, then convert exactly. Pass FXPRM::TowardZero for
+  // fp.to_sbv / fp.to_ubv always round toward zero, so any other mode is
+  // applied in the FP domain first -- fpToFXPParts rounds the scaled value
+  // under Mode, leaving this conversion exact. Pass FXPRM::TowardZero for
   // C's float->fixed direction (fixed->fixed narrowing floors instead;
   // both oracle-pinned). Out of range, for infinities, and for NaN the
   // result is solver-chosen, matching C's UB; gate with
   // mkFPToFXPOverflow.
-  SMTExprRef Scaled = roundFPToIntegral(*this, P.Scaled, Mode);
-  SMTExprRef Raw = Target.IsSigned ? mkFPtoSBV(Scaled, Target.Width)
-                                   : mkFPtoUBV(Scaled, Target.Width);
+  FPFXPParts P = fpToFXPParts(*this, Exp, Target, Mode);
+  SMTExprRef Raw = Target.IsSigned ? mkFPtoSBV(P.Scaled, Target.Width)
+                                   : mkFPtoUBV(P.Scaled, Target.Width);
   return rewrapExprImpl(*Raw, To, SMTExprKind::FPToFXP);
 }
 
@@ -1612,7 +1616,10 @@ SMTExprRef SMTSolverImpl::mkFPToFXPOverflow(const SMTExprRef &Exp,
                                             const SMTSortRef &To, FXPRM Mode) {
   fatalErrorIf(!Exp->Sort->isFPSort(), "Expected floating-point expression");
   requireFXPSort(To);
-  FPFXPParts P = fpToFXPParts(*this, Exp, formatOf(To));
+  // Round before testing the range, so the predicate agrees with
+  // mkFPToFXP: a value inside the target's range can round out of it, and
+  // reporting it as in-range would contradict the conversion.
+  FPFXPParts P = fpToFXPParts(*this, Exp, formatOf(To), Mode);
   return mkOr(P.IsNaN, mkOr(P.TooHi, P.TooLo));
 }
 
@@ -1621,11 +1628,12 @@ SMTExprRef SMTSolverImpl::mkFPToFXPSat(const SMTExprRef &Exp,
   fatalErrorIf(!Exp->Sort->isFPSort(), "Expected floating-point expression");
   requireFXPSort(To);
   FXPFormat Target = formatOf(To);
-  FPFXPParts P = fpToFXPParts(*this, Exp, Target);
+  FPFXPParts P = fpToFXPParts(*this, Exp, Target, Mode);
+  // P.Scaled is already rounded per Mode, so the conversion is exact.
   SMTExprRef Raw = Target.IsSigned ? mkFPtoSBV(P.Scaled, Target.Width)
                                    : mkFPtoUBV(P.Scaled, Target.Width);
   // NaN -> 0 (Clang's _Sat choice; the TR leaves it undefined), rails for
-  // out-of-range and +-infinity, toward-zero otherwise. NaN tests first:
+  // out-of-range and +-infinity, rounded per Mode otherwise. NaN first:
   // it fails both comparisons, so TooHi and TooLo both hold for it.
   SMTExprRef Res = mkIte(
       P.IsNaN, mkBVFromDec(0, Target.Width),

--- a/src/camadafxp.cpp
+++ b/src/camadafxp.cpp
@@ -208,6 +208,172 @@ SMTExprRef floorAdjustQuotient(SMTSolverImpl &S, const SMTExprRef &Quot,
                  S.mkBVSub(Quot, S.mkBVFromDec(1, W)), Quot);
 }
 
+// Rounds a floored quotient under a rounding mode.
+//
+// Division cannot use shiftRounded: the discarded part is a remainder
+// against an arbitrary divisor, not a fixed number of low bits, so the
+// halfway test is 2*|rem| against |divisor| rather than a bit pattern.
+// Quot must already be the floor (mkFXPDiv's floorAdjustQuotient), and L
+// and R are the operands it came from, all at width W.
+SMTExprRef roundQuotient(SMTSolverImpl &S, const SMTExprRef &Quot,
+                         const SMTExprRef &L, const SMTExprRef &R, unsigned W,
+                         bool Signed, FXPRM Mode) {
+  if (Mode == FXPRM::TowardNegative)
+    return Quot;
+  SMTExprRef Zero = S.mkBVFromDec(0, W);
+  SMTExprRef One = S.mkBVFromDec(1, W);
+  // Remainder in the floor convention: L - Quot*R, which has the sign of
+  // R and magnitude below |R|.
+  SMTExprRef Rem = S.mkBVSub(L, S.mkBVMul(Quot, R));
+  SMTExprRef Inexact = S.mkNot(S.mkEqual(Rem, Zero));
+  auto absOf = [&](const SMTExprRef &V) {
+    return Signed ? S.mkIte(S.mkBVSlt(V, Zero), S.mkBVNeg(V), V) : V;
+  };
+  // The quotient is negative when exactly one operand is.
+  SMTExprRef Neg =
+      Signed
+          ? S.mkAnd(Inexact, S.mkNot(S.mkEqual(S.mkBVExtract(W - 1, W - 1, L),
+                                               S.mkBVExtract(W - 1, W - 1, R))))
+          : S.mkBool(false);
+
+  switch (Mode) {
+  case FXPRM::TowardPositive:
+    return S.mkIte(Inexact, S.mkBVAdd(Quot, One), Quot);
+  case FXPRM::TowardZero:
+    return S.mkIte(S.mkAnd(Neg, Inexact), S.mkBVAdd(Quot, One), Quot);
+  default:
+    break;
+  }
+  // Nearest: compare twice the remainder against the divisor. Both are
+  // taken as magnitudes, and the doubling needs one extra bit.
+  SMTExprRef AR = S.mkBVZeroExt(1, absOf(Rem));
+  SMTExprRef AD = S.mkBVZeroExt(1, absOf(R));
+  SMTExprRef Twice = S.mkBVShl(AR, S.mkBVFromDec(1, W + 1));
+  SMTExprRef Above = S.mkBVUgt(Twice, AD);
+  SMTExprRef Tie = S.mkEqual(Twice, AD);
+  SMTExprRef TieUp;
+  switch (Mode) {
+  case FXPRM::NearestTiesTowardPositive:
+    TieUp = S.mkBool(true);
+    break;
+  case FXPRM::NearestTiesAwayFromZero:
+    TieUp = S.mkNot(Neg);
+    break;
+  default: // ties to even
+    TieUp = S.mkEqual(S.mkBVExtract(0, 0, Quot), S.mkBVFromDec(1, 1));
+    break;
+  }
+  return S.mkIte(S.mkOr(Above, S.mkAnd(Tie, TieUp)), S.mkBVAdd(Quot, One),
+                 Quot);
+}
+
+// Rounds an FP value to an integral FP value under a fixed-point mode.
+//
+// fp.to_sbv / fp.to_ubv always round toward zero, so mkFPToFXP applies
+// any other mode in the FP domain first and then converts exactly.
+//
+// FXPRM::NearestTiesTowardPositive has no FP counterpart -- IEEE-754 has
+// no "nearest, ties toward +inf" -- so it is built as: round to nearest
+// with ties away from zero, then correct the negative halfway cases,
+// which are the only inputs where the two disagree.
+SMTExprRef roundFPToIntegral(SMTSolverImpl &S, const SMTExprRef &V,
+                             FXPRM Mode) {
+  FPEncoding E = V->Sort->isBVFPSort() ? FPEncoding::BV : FPEncoding::Native;
+  auto integral = [&](RM R) { return S.mkFPtoIntegral(V, S.mkRM(R, E)); };
+  switch (Mode) {
+  case FXPRM::TowardZero:
+    return integral(RM::ROUND_TO_ZERO);
+  case FXPRM::TowardNegative:
+    return integral(RM::ROUND_TO_MINUS_INF);
+  case FXPRM::TowardPositive:
+    return integral(RM::ROUND_TO_PLUS_INF);
+  case FXPRM::NearestTiesToEven:
+    return integral(RM::ROUND_TO_EVEN);
+  case FXPRM::NearestTiesAwayFromZero:
+    return integral(RM::ROUND_TO_AWAY);
+  case FXPRM::NearestTiesTowardPositive:
+    break;
+  }
+  // Ties toward +inf: away-from-zero agrees everywhere except a negative
+  // exact halfway, where it goes down and this mode goes up. Detect that
+  // as "the two nearest roundings straddle" and take the ceiling there.
+  SMTExprRef Away = integral(RM::ROUND_TO_AWAY);
+  SMTExprRef Ceil = integral(RM::ROUND_TO_PLUS_INF);
+  SMTExprRef Floor = integral(RM::ROUND_TO_MINUS_INF);
+  // A halfway value is one whose floor and ceiling are equidistant, i.e.
+  // v - floor == ceil - v. Comparing doubled avoids a division.
+  SMTExprRef RmE = S.mkRM(RM::ROUND_TO_EVEN, E);
+  SMTExprRef Twice = S.mkFPAdd(V, V, RmE);
+  SMTExprRef Sum = S.mkFPAdd(Floor, Ceil, RmE);
+  SMTExprRef IsTie = S.mkFPEqual(Twice, Sum);
+  // "v < 0" without needing a zero constant: only a negative value has
+  // its ceiling strictly greater than its floor AND rounds away downward.
+  // Simpler: a negative v satisfies v + v < v, false for v >= 0.
+  SMTExprRef IsNeg = S.mkFPLt(Twice, V);
+  return S.mkIte(S.mkAnd(IsTie, IsNeg), Ceil, Away);
+}
+
+// Shifts Val right by Shift bits under a rounding mode, at Val's width.
+//
+// Every fixed-point operation that discards precision reduces to this:
+// multiply drops the doubled fraction bits, narrowing drops the
+// difference, fixed-to-integer drops all of them. Doing it in one place
+// means the modes cannot drift apart between operations.
+//
+// The dropped bits decide the direction, so they are read before the
+// shift; a caller that shifts first has already lost the information.
+SMTExprRef shiftRounded(SMTSolverImpl &S, const SMTExprRef &Val, unsigned Shift,
+                        unsigned W, bool Signed, FXPRM Mode) {
+  if (Shift == 0)
+    return Val;
+  SMTExprRef Zero = S.mkBVFromDec(0, W);
+  SMTExprRef Amount = S.mkBVFromDec(Shift, W);
+  // Arithmetic shift for signed values: the quotient must floor, which is
+  // what ashr does, and every mode is expressed as an adjustment from it.
+  SMTExprRef Floor = Signed ? S.mkBVAshr(Val, Amount) : S.mkBVLshr(Val, Amount);
+  SMTExprRef DropMask =
+      S.mkBVFromBin(std::string(W - Shift, '0') + std::string(Shift, '1'), W);
+  SMTExprRef Dropped = S.mkBVAnd(Val, DropMask);
+  SMTExprRef Inexact = S.mkNot(S.mkEqual(Dropped, Zero));
+  SMTExprRef One = S.mkBVFromDec(1, W);
+  SMTExprRef Neg = Signed ? S.mkBVSlt(Val, Zero) : S.mkBool(false);
+
+  switch (Mode) {
+  case FXPRM::TowardNegative:
+    return Floor;
+  case FXPRM::TowardPositive:
+    return S.mkIte(Inexact, S.mkBVAdd(Floor, One), Floor);
+  case FXPRM::TowardZero:
+    // Floor already truncates non-negative values; negatives need the
+    // dropped part added back.
+    return S.mkIte(S.mkAnd(Neg, Inexact), S.mkBVAdd(Floor, One), Floor);
+  case FXPRM::NearestTiesTowardPositive:
+  case FXPRM::NearestTiesAwayFromZero:
+  case FXPRM::NearestTiesToEven:
+    break;
+  }
+  // Nearest: compare the dropped part against half an ulp.
+  SMTExprRef Half = S.mkBVFromBin(std::string(W - Shift, '0') + "1" +
+                                      std::string(Shift ? Shift - 1 : 0, '0'),
+                                  W);
+  SMTExprRef Above = S.mkBVUgt(Dropped, Half);
+  SMTExprRef Tie = S.mkEqual(Dropped, Half);
+  SMTExprRef TieUp;
+  switch (Mode) {
+  case FXPRM::NearestTiesTowardPositive:
+    TieUp = S.mkBool(true);
+    break;
+  case FXPRM::NearestTiesAwayFromZero:
+    TieUp = S.mkNot(Neg);
+    break;
+  default: // NearestTiesToEven: up only when the kept bit is odd
+    TieUp = S.mkEqual(S.mkBVExtract(0, 0, Floor), S.mkBVFromDec(1, 1));
+    break;
+  }
+  return S.mkIte(S.mkOr(Above, S.mkAnd(Tie, TieUp)), S.mkBVAdd(Floor, One),
+                 Floor);
+}
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -285,31 +451,33 @@ SMTExprRef SMTSolverImpl::mkFXPNeg(const SMTExprRef &Exp) {
                         SMTExprKind::FXPNeg);
 }
 
-SMTExprRef SMTSolverImpl::mkFXPMul(const SMTExprRef &LHS,
-                                   const SMTExprRef &RHS) {
+SMTExprRef SMTSolverImpl::mkFXPMul(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                                   FXPRM Mode) {
   AlignedPair P = alignPair(*this, LHS, RHS);
   // The exact product of two W-bit values fits in 2W bits; drop the extra
-  // fraction bits of the raw product (floor), then take the low W bits.
+  // fraction bits of the raw product under Mode, then take the low W bits.
+  // The dropped bits decide the rounding and are gone after the shift, so
+  // no caller could recover this from a truncating result.
   SMTExprRef L = extendRaw(*this, P.LHS, P.Fmt.IsSigned, P.Fmt.Width);
   SMTExprRef R = extendRaw(*this, P.RHS, P.Fmt.IsSigned, P.Fmt.Width);
   SMTExprRef Prod = mkBVMul(L, R);
-  if (P.Fmt.FracBits != 0) {
-    SMTExprRef Amount = mkBVFromDec(P.Fmt.FracBits, 2 * P.Fmt.Width);
-    Prod = P.Fmt.IsSigned ? mkBVAshr(Prod, Amount) : mkBVLshr(Prod, Amount);
-  }
+  Prod = shiftRounded(*this, Prod, P.Fmt.FracBits, 2 * P.Fmt.Width,
+                      P.Fmt.IsSigned, Mode);
   return rewrapExprImpl(*mkBVExtract(P.Fmt.Width - 1, 0, Prod),
                         mkFXPSort(P.Fmt.Width, P.Fmt.FracBits, P.Fmt.IsSigned),
                         SMTExprKind::FXPMul);
 }
 
-SMTExprRef SMTSolverImpl::mkFXPDiv(const SMTExprRef &LHS,
-                                   const SMTExprRef &RHS) {
+SMTExprRef SMTSolverImpl::mkFXPDiv(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                                   FXPRM Mode) {
   AlignedPair P = alignPair(*this, LHS, RHS);
   // (lhs * 2^N) / rhs at double width: extend first, then scale the
-  // dividend — the shift cannot overflow 2W since N <= W. Inexact
-  // quotients round DOWN (floor), not toward zero: TR 18037 leaves the
-  // direction implementation-defined and Clang floors (LLVM sdiv.fix),
-  // pinned by the execution oracle (scripts/fxp_oracle_gen.py) — the
+  // dividend — the shift cannot overflow 2W since N <= W.
+  //
+  // The quotient is computed as a floor and then adjusted to Mode.
+  // FXPRM::TowardNegative reproduces C: TR 18037 leaves the direction
+  // implementation-defined and Clang floors (LLVM sdiv.fix), pinned by
+  // the execution oracle (scripts/fxp_oracle_gen.py) — the
   // C-integer-division analogy does not govern fixed-point.
   SMTExprRef L = extendRaw(*this, P.LHS, P.Fmt.IsSigned, P.Fmt.Width);
   SMTExprRef R = extendRaw(*this, P.RHS, P.Fmt.IsSigned, P.Fmt.Width);
@@ -318,6 +486,8 @@ SMTExprRef SMTSolverImpl::mkFXPDiv(const SMTExprRef &LHS,
   SMTExprRef Quot = P.Fmt.IsSigned ? mkBVSDiv(L, R) : mkBVUDiv(L, R);
   if (P.Fmt.IsSigned)
     Quot = floorAdjustQuotient(*this, Quot, L, R, 2 * P.Fmt.Width);
+  Quot =
+      roundQuotient(*this, Quot, L, R, 2 * P.Fmt.Width, P.Fmt.IsSigned, Mode);
   return rewrapExprImpl(*mkBVExtract(P.Fmt.Width - 1, 0, Quot),
                         mkFXPSort(P.Fmt.Width, P.Fmt.FracBits, P.Fmt.IsSigned),
                         SMTExprKind::FXPDiv);
@@ -392,7 +562,7 @@ SMTExprRef SMTSolverImpl::mkFXPNegSat(const SMTExprRef &Exp) {
 }
 
 SMTExprRef SMTSolverImpl::mkFXPMulSat(const SMTExprRef &LHS,
-                                      const SMTExprRef &RHS) {
+                                      const SMTExprRef &RHS, FXPRM Mode) {
   AlignedPair P = alignPair(*this, LHS, RHS);
   // Same 2W exact product and floor shift as mkFXPMul; clamp instead of
   // truncating. Unsigned products can set the top bit at 2W, so the
@@ -401,10 +571,8 @@ SMTExprRef SMTSolverImpl::mkFXPMulSat(const SMTExprRef &LHS,
   SMTExprRef L = extendRaw(*this, P.LHS, P.Fmt.IsSigned, P.Fmt.Width);
   SMTExprRef R = extendRaw(*this, P.RHS, P.Fmt.IsSigned, P.Fmt.Width);
   SMTExprRef Prod = mkBVMul(L, R);
-  if (P.Fmt.FracBits != 0) {
-    SMTExprRef Amount = mkBVFromDec(P.Fmt.FracBits, 2 * P.Fmt.Width);
-    Prod = P.Fmt.IsSigned ? mkBVAshr(Prod, Amount) : mkBVLshr(Prod, Amount);
-  }
+  Prod = shiftRounded(*this, Prod, P.Fmt.FracBits, 2 * P.Fmt.Width,
+                      P.Fmt.IsSigned, Mode);
   return rewrapExprImpl(
       *clampRaw(*this, Prod, 2 * P.Fmt.Width, P.Fmt, P.Fmt.IsSigned),
       mkFXPSort(P.Fmt.Width, P.Fmt.FracBits, P.Fmt.IsSigned),
@@ -412,7 +580,7 @@ SMTExprRef SMTSolverImpl::mkFXPMulSat(const SMTExprRef &LHS,
 }
 
 SMTExprRef SMTSolverImpl::mkFXPDivSat(const SMTExprRef &LHS,
-                                      const SMTExprRef &RHS) {
+                                      const SMTExprRef &RHS, FXPRM Mode) {
   AlignedPair P = alignPair(*this, LHS, RHS);
   // Same 2W scaled dividend and floored quotient as mkFXPDiv; clamp
   // instead of truncating. The signed min/-1 case lands above max at 2W
@@ -424,6 +592,8 @@ SMTExprRef SMTSolverImpl::mkFXPDivSat(const SMTExprRef &LHS,
   SMTExprRef Quot = P.Fmt.IsSigned ? mkBVSDiv(L, R) : mkBVUDiv(L, R);
   if (P.Fmt.IsSigned)
     Quot = floorAdjustQuotient(*this, Quot, L, R, 2 * P.Fmt.Width);
+  Quot =
+      roundQuotient(*this, Quot, L, R, 2 * P.Fmt.Width, P.Fmt.IsSigned, Mode);
   return rewrapExprImpl(
       *clampRaw(*this, Quot, 2 * P.Fmt.Width, P.Fmt, P.Fmt.IsSigned),
       mkFXPSort(P.Fmt.Width, P.Fmt.FracBits, P.Fmt.IsSigned),
@@ -685,36 +855,44 @@ std::pair<SMTExprRef, unsigned> wideForConversion(SMTSolverImpl &S,
 } // namespace
 
 SMTExprRef SMTSolverImpl::mkFXPToFXP(const SMTExprRef &Exp,
-                                     const SMTSortRef &To) {
+                                     const SMTSortRef &To, FXPRM Mode) {
   requireFXP(Exp);
   requireFXPSort(To);
   FXPFormat From = formatOf(Exp->Sort);
   FXPFormat Target = formatOf(To);
   auto [Raw, Wide] = wideForConversion(*this, Exp, Target);
   if (Target.FracBits > From.FracBits) {
+    // Widening the fraction is exact, so Mode never applies.
     Raw = mkBVShl(Raw, mkBVFromDec(Target.FracBits - From.FracBits, Wide));
   } else if (From.FracBits > Target.FracBits) {
-    // Narrowing the fraction truncates low bits (floor).
-    SMTExprRef Amount = mkBVFromDec(From.FracBits - Target.FracBits, Wide);
-    Raw = From.IsSigned ? mkBVAshr(Raw, Amount) : mkBVLshr(Raw, Amount);
+    Raw = shiftRounded(*this, Raw, From.FracBits - Target.FracBits, Wide,
+                       From.IsSigned, Mode);
   }
   return rewrapExprImpl(*mkBVExtract(Target.Width - 1, 0, Raw), To,
                         SMTExprKind::FXPToFXP);
 }
 
 SMTExprRef SMTSolverImpl::mkFXPToFXPOverflow(const SMTExprRef &Exp,
-                                             const SMTSortRef &To) {
+                                             const SMTSortRef &To, FXPRM Mode) {
   requireFXP(Exp);
   requireFXPSort(To);
   FXPFormat From = formatOf(Exp->Sort);
   FXPFormat Target = formatOf(To);
   auto [Raw, Wide] = wideForConversion(*this, Exp, Target);
-  // Compare the exact (pre-rounding) value: bring value and bounds to the
-  // *larger* fraction scale of the two formats so no fraction bit is
-  // dropped before the check; Wide has headroom for both shifts.
-  unsigned Scale = std::max(From.FracBits, Target.FracBits);
-  if (Scale > From.FracBits)
-    Raw = mkBVShl(Raw, mkBVFromDec(Scale - From.FracBits, Wide));
+  // Round FIRST, then compare against the bounds. Testing the exact value
+  // would be wrong for any mode that can round away from zero: a Q8.8
+  // value of 7.96875 fits a signed Q4.4 exactly (127) under truncation
+  // but rounds to 128 under nearest, which does not fit. The predicate
+  // has to agree with the conversion it describes.
+  if (From.FracBits > Target.FracBits)
+    Raw = shiftRounded(*this, Raw, From.FracBits - Target.FracBits, Wide,
+                       From.IsSigned, Mode);
+  // Bring value and bounds to a common scale; Wide has headroom for both.
+  unsigned Effective =
+      From.FracBits > Target.FracBits ? Target.FracBits : From.FracBits;
+  unsigned Scale = std::max(Effective, Target.FracBits);
+  if (Scale > Effective)
+    Raw = mkBVShl(Raw, mkBVFromDec(Scale - Effective, Wide));
   unsigned BoundShift = Scale - Target.FracBits;
   // The wide value is sign-correct thanks to the slack bit, so signed
   // comparisons are exact for both signednesses of the source.
@@ -724,21 +902,22 @@ SMTExprRef SMTSolverImpl::mkFXPToFXPOverflow(const SMTExprRef &Exp,
 }
 
 SMTExprRef SMTSolverImpl::mkFXPToFXPSat(const SMTExprRef &Exp,
-                                        const SMTSortRef &To) {
+                                        const SMTSortRef &To, FXPRM Mode) {
   requireFXP(Exp);
   requireFXPSort(To);
   FXPFormat From = formatOf(Exp->Sort);
   FXPFormat Target = formatOf(To);
-  // Same wide intermediate and fraction shifts as mkFXPToFXP (floor on
-  // narrowing), clamped instead of truncated. Wide's slack bit keeps the
-  // view sign-correct for both source signednesses, so the comparisons
-  // are signed (the overflow predicate's argument).
+  // Same wide intermediate and fraction shifts as mkFXPToFXP, clamped
+  // instead of truncated. Rounding happens before the clamp, so a value
+  // that rounds past the maximum saturates rather than wrapping. Wide's
+  // slack bit keeps the view sign-correct for both source signednesses,
+  // so the comparisons are signed (the overflow predicate's argument).
   auto [Raw, Wide] = wideForConversion(*this, Exp, Target);
   if (Target.FracBits > From.FracBits) {
     Raw = mkBVShl(Raw, mkBVFromDec(Target.FracBits - From.FracBits, Wide));
   } else if (From.FracBits > Target.FracBits) {
-    SMTExprRef Amount = mkBVFromDec(From.FracBits - Target.FracBits, Wide);
-    Raw = From.IsSigned ? mkBVAshr(Raw, Amount) : mkBVLshr(Raw, Amount);
+    Raw = shiftRounded(*this, Raw, From.FracBits - Target.FracBits, Wide,
+                       From.IsSigned, Mode);
   }
   return rewrapExprImpl(*clampRaw(*this, Raw, Wide, Target,
                                   /*SignedCmp=*/true),
@@ -754,48 +933,46 @@ SMTExprRef SMTSolverImpl::mkFXPFromBV(const SMTExprRef &Exp, bool SrcSigned,
   // source type's signedness fixes the value, the target format only the
   // representation. Overflow of this conversion is queryable through
   // mkFXPToFXPOverflow on the same reinterpretation.
+  // The source has no fraction bits, so widening to the target's scale
+  // is exact and the rounding mode cannot matter; any value would do.
   SMTSortRef IntSort = mkFXPSort(Exp->getWidth(), 0, SrcSigned);
-  return mkFXPToFXP(mkFXPFromRawBV(Exp, IntSort), To);
+  return mkFXPToFXP(mkFXPFromRawBV(Exp, IntSort), To, FXPRM::TowardNegative);
 }
 
-SMTExprRef SMTSolverImpl::mkFXPToBV(const SMTExprRef &Exp, unsigned ToWidth) {
+SMTExprRef SMTSolverImpl::mkFXPToBV(const SMTExprRef &Exp, unsigned ToWidth,
+                                    FXPRM Mode) {
   requireFXP(Exp);
   fatalErrorIf(ToWidth == 0, "Target width must be non-zero");
   FXPFormat From = formatOf(Exp->Sort);
-  // Round toward zero — the direction TR 18037 specifies for fixed-point to
-  // integer conversion. A plain arithmetic shift would floor (-1.5 -> -2);
-  // signed division by 2^N truncates toward zero (-1.5 -> -1). The target
-  // integer's signedness follows the source format's.
+  // Pass FXPRM::TowardZero for the direction TR 18037 specifies for
+  // fixed-point to integer conversion; shiftRounded implements it as a
+  // floor plus a correction for negatives, which is what the previous
+  // signed-division-by-2^N encoding computed (-1.5 -> -1, where a plain
+  // arithmetic shift would give -2). The target integer's signedness
+  // follows the source format's.
   unsigned Wide = std::max(From.Width, ToWidth + From.FracBits) + 1;
   SMTExprRef Raw = mkFXPToRawBV(Exp);
   Raw = extendRaw(*this, Raw, From.IsSigned, Wide - From.Width);
-  if (From.FracBits != 0) {
-    std::string PowBits(Wide, '0');
-    PowBits[Wide - 1 - From.FracBits] = '1';
-    SMTExprRef Pow = mkBVFromBin(PowBits, Wide);
-    Raw = From.IsSigned ? mkBVSDiv(Raw, Pow) : mkBVUDiv(Raw, Pow);
-  }
+  Raw = shiftRounded(*this, Raw, From.FracBits, Wide, From.IsSigned, Mode);
   return rewrapExprImpl(*mkBVExtract(ToWidth - 1, 0, Raw), mkBVSort(ToWidth),
                         SMTExprKind::FXPToBV);
 }
 
 SMTExprRef SMTSolverImpl::mkFXPToBVOverflow(const SMTExprRef &Exp,
-                                            unsigned ToWidth, bool ToSigned) {
+                                            unsigned ToWidth, bool ToSigned,
+                                            FXPRM Mode) {
   requireFXP(Exp);
   fatalErrorIf(ToWidth == 0, "Target width must be non-zero");
   FXPFormat From = formatOf(Exp->Sort);
-  // C converts to integer by taking the toward-zero integral part first;
-  // it is UB iff *that* does not fit the target. So unlike the mul/div and
-  // fixed-to-fixed predicates, this one checks the rounded quotient.
+  // C converts to integer by taking the toward-zero integral part first
+  // and is UB iff *that* does not fit; pass FXPRM::TowardZero for it.
+  // The check is on the ROUNDED value under Mode, so the predicate always
+  // agrees with the conversion it describes -- a value that fits when
+  // truncated can round out of range under a nearest mode.
   unsigned Wide = std::max(From.Width, ToWidth + From.FracBits) + 1;
   SMTExprRef Raw = mkFXPToRawBV(Exp);
   Raw = extendRaw(*this, Raw, From.IsSigned, Wide - From.Width);
-  if (From.FracBits != 0) {
-    std::string PowBits(Wide, '0');
-    PowBits[Wide - 1 - From.FracBits] = '1';
-    SMTExprRef Pow = mkBVFromBin(PowBits, Wide);
-    Raw = From.IsSigned ? mkBVSDiv(Raw, Pow) : mkBVUDiv(Raw, Pow);
-  }
+  Raw = shiftRounded(*this, Raw, From.FracBits, Wide, From.IsSigned, Mode);
   FXPFormat IntTarget{ToWidth, 0, ToSigned};
   SMTExprRef Max = mkBVFromBin(maxRawBits(IntTarget, Wide), Wide);
   SMTExprRef Min = mkBVFromBin(minRawBits(IntTarget, Wide), Wide);
@@ -803,22 +980,18 @@ SMTExprRef SMTSolverImpl::mkFXPToBVOverflow(const SMTExprRef &Exp,
 }
 
 SMTExprRef SMTSolverImpl::mkFXPToBVSat(const SMTExprRef &Exp, unsigned ToWidth,
-                                       bool ToSigned) {
+                                       bool ToSigned, FXPRM Mode) {
   requireFXP(Exp);
   fatalErrorIf(ToWidth == 0, "Target width must be non-zero");
   FXPFormat From = formatOf(Exp->Sort);
-  // Same toward-zero rounding as mkFXPToBV (signed division by 2^N),
-  // clamped to the integer target's range instead of truncated. Wide's
-  // slack bit keeps the comparisons sign-correct for both signednesses.
+  // Same rounding as mkFXPToBV under Mode, clamped to the integer
+  // target's range instead of truncated, so a value that rounds past the
+  // maximum saturates. Wide's slack bit keeps the comparisons
+  // sign-correct for both signednesses.
   unsigned Wide = std::max(From.Width, ToWidth + From.FracBits) + 1;
   SMTExprRef Raw = mkFXPToRawBV(Exp);
   Raw = extendRaw(*this, Raw, From.IsSigned, Wide - From.Width);
-  if (From.FracBits != 0) {
-    std::string PowBits(Wide, '0');
-    PowBits[Wide - 1 - From.FracBits] = '1';
-    SMTExprRef Pow = mkBVFromBin(PowBits, Wide);
-    Raw = From.IsSigned ? mkBVSDiv(Raw, Pow) : mkBVUDiv(Raw, Pow);
-  }
+  Raw = shiftRounded(*this, Raw, From.FracBits, Wide, From.IsSigned, Mode);
   FXPFormat IntTarget{ToWidth, 0, ToSigned};
   return rewrapExprImpl(*clampRaw(*this, Raw, Wide, IntTarget,
                                   /*SignedCmp=*/true),
@@ -830,7 +1003,7 @@ SMTExprRef SMTSolverImpl::mkFXPToBVSat(const SMTExprRef &Exp, unsigned ToWidth,
 // ---------------------------------------------------------------------------
 
 SMTExprRef SMTSolverImpl::mkFXPRound(const SMTExprRef &Exp, unsigned Digits,
-                                     FXPRoundTie Tie) {
+                                     FXPRM Tie) {
   requireFXP(Exp);
   FXPFormat F = formatOf(Exp->Sort);
   // Keeping at least every fraction bit is the identity; libc clamps a
@@ -852,19 +1025,41 @@ SMTExprRef SMTSolverImpl::mkFXPRound(const SMTExprRef &Exp, unsigned Digits,
   HalfBits[W - Shift] = '1'; // 2^(Shift-1), half an ulp of the result
   SMTExprRef Bias = mkBVFromBin(HalfBits, W);
   SMTExprRef One = mkBVFromDec(1, W);
+  SMTExprRef Zero = mkBVFromDec(0, W);
+  // Every mode is the same mask with a different bias. The nearest modes
+  // start from half an ulp and adjust; the directed modes never consult
+  // the halfway point at all.
+  SMTExprRef DroppedMask =
+      mkBVFromBin(std::string(W - Shift, '0') + std::string(Shift, '1'), W);
+  SMTExprRef HasDropped = mkNot(mkEqual(mkBVAnd(Raw, DroppedMask), Zero));
   switch (Tie) {
-  case FXPRoundTie::TowardPositive:
+  case FXPRM::NearestTiesTowardPositive:
     break;
-  case FXPRoundTie::AwayFromZero:
+  case FXPRM::NearestTiesAwayFromZero:
     // Only signed formats have negative values to bias differently.
     if (F.IsSigned)
-      Bias = mkBVSub(
-          Bias, mkIte(mkBVSlt(Raw, mkBVFromDec(0, W)), One, mkBVFromDec(0, W)));
+      Bias = mkBVSub(Bias, mkIte(mkBVSlt(Raw, Zero), One, Zero));
     break;
-  case FXPRoundTie::ToEven:
+  case FXPRM::NearestTiesToEven:
     // half - 1 + (lowest kept bit): a tie lands on the even neighbour.
     Bias = mkBVAdd(mkBVSub(Bias, One),
                    mkBVZeroExt(W - 1, mkBVExtract(Shift, Shift, Raw)));
+    break;
+  case FXPRM::TowardNegative:
+    // Masking alone floors, for both signednesses.
+    Bias = Zero;
+    break;
+  case FXPRM::TowardZero:
+    // Floor for non-negative values; for negatives, floor is one ulp too
+    // low whenever bits were actually dropped, so add them back.
+    Bias = F.IsSigned
+               ? mkIte(mkAnd(mkBVSlt(Raw, Zero), HasDropped), DroppedMask, Zero)
+               : Zero;
+    break;
+  case FXPRM::TowardPositive:
+    // Ceiling: masking floors, so push up by the dropped bits when any
+    // were nonzero.
+    Bias = mkIte(HasDropped, DroppedMask, Zero);
     break;
   }
   SMTExprRef Sum = mkBVAdd(Raw, Bias);
@@ -1126,7 +1321,7 @@ SMTExprRef SMTSolverImpl::mkFXPExp(const SMTExprRef &Exp) {
                         SMTExprKind::FXPExp);
 }
 
-SMTExprRef SMTSolverImpl::mkFXPSqrt(const SMTExprRef &Exp) {
+SMTExprRef SMTSolverImpl::mkFXPSqrt(const SMTExprRef &Exp, FXPRM Mode) {
   requireFXP(Exp);
   FXPFormat F = formatOf(Exp->Sort);
   // sqrt(raw/2^n) = sqrt(raw * 2^n) / 2^n, so the result's raw value is
@@ -1164,6 +1359,43 @@ SMTExprRef SMTSolverImpl::mkFXPSqrt(const SMTExprRef &Exp) {
     Root =
         mkBVOr(mkBVShl(Root, One), mkIte(Fits, One, mkBVFromDec(0, RadWidth)));
   }
+  // The loop leaves Root = floor(sqrt(Rad)) and Rem = Rad - Root^2
+  // exactly, so every mode is an adjustment from the floor. The true root
+  // lies above the midpoint between Root and Root+1 exactly when
+  // Rem > Root, since (Root + 1/2)^2 = Root^2 + Root + 1/4 and Rem is an
+  // integer; it is an exact tie when Rem == Root.
+  //
+  // A square root is never exactly representable unless Rem == 0, so the
+  // directed modes only need to know whether the result is inexact.
+  // Root+1 cannot overflow RadWidth: Root <= sqrt(2^RadWidth - 1) and
+  // RadWidth >= 2, so Root is at most 2^(RadWidth/2) - 1. The radicand is
+  // never negative here (negatives are pinned to zero below), so
+  // TowardZero and TowardNegative coincide.
+  SMTExprRef RemZero = mkEqual(Rem, mkBVFromDec(0, RadWidth));
+  SMTExprRef RoundUp;
+  switch (Mode) {
+  case FXPRM::TowardZero:
+  case FXPRM::TowardNegative:
+    RoundUp = mkBool(false);
+    break;
+  case FXPRM::TowardPositive:
+    RoundUp = mkNot(RemZero);
+    break;
+  case FXPRM::NearestTiesTowardPositive:
+  case FXPRM::NearestTiesAwayFromZero:
+    // The root is non-negative, so both tie directions round up. The
+    // Rem != 0 guard matters at Root == 0: an exact zero would otherwise
+    // satisfy Rem >= Root and round up to one.
+    RoundUp = mkAnd(mkNot(RemZero), mkBVUge(Rem, Root));
+    break;
+  case FXPRM::NearestTiesToEven: {
+    SMTExprRef RootOdd = mkEqual(mkBVExtract(0, 0, Root), mkBVFromDec(1, 1));
+    RoundUp = mkOr(mkBVUgt(Rem, Root), mkAnd(mkEqual(Rem, Root), RootOdd));
+    break;
+  }
+  }
+  Root = mkIte(RoundUp, mkBVAdd(Root, One), Root);
+
   SMTExprRef Res = mkBVExtract(F.Width - 1, 0, Root);
   // A negative operand has no real square root, and the zero-extension
   // above reads its two's-complement bits as a large positive radicand,
@@ -1357,24 +1589,27 @@ SMTExprRef SMTSolverImpl::mkFXPToFP(const SMTExprRef &Exp, const SMTSortRef &To,
   return rewrapExprImpl(*Res, To, SMTExprKind::FXPToFP);
 }
 
-SMTExprRef SMTSolverImpl::mkFPToFXP(const SMTExprRef &Exp,
-                                    const SMTSortRef &To) {
+SMTExprRef SMTSolverImpl::mkFPToFXP(const SMTExprRef &Exp, const SMTSortRef &To,
+                                    FXPRM Mode) {
   fatalErrorIf(!Exp->Sort->isFPSort(), "Expected floating-point expression");
   requireFXPSort(To);
   FXPFormat Target = formatOf(To);
   FPFXPParts P = fpToFXPParts(*this, Exp, Target);
-  // fp.to_sbv / fp.to_ubv round toward zero across all backends and the
-  // BV encoding — C's float->fixed direction (fixed->fixed narrowing
-  // floors instead; both oracle-pinned). Out of range, for infinities,
-  // and for NaN the result is solver-chosen, matching C's UB; gate with
+  // fp.to_sbv / fp.to_ubv always round toward zero, so any other mode has
+  // to be applied in the FP domain first: round the scaled value to an
+  // integer under Mode, then convert exactly. Pass FXPRM::TowardZero for
+  // C's float->fixed direction (fixed->fixed narrowing floors instead;
+  // both oracle-pinned). Out of range, for infinities, and for NaN the
+  // result is solver-chosen, matching C's UB; gate with
   // mkFPToFXPOverflow.
-  SMTExprRef Raw = Target.IsSigned ? mkFPtoSBV(P.Scaled, Target.Width)
-                                   : mkFPtoUBV(P.Scaled, Target.Width);
+  SMTExprRef Scaled = roundFPToIntegral(*this, P.Scaled, Mode);
+  SMTExprRef Raw = Target.IsSigned ? mkFPtoSBV(Scaled, Target.Width)
+                                   : mkFPtoUBV(Scaled, Target.Width);
   return rewrapExprImpl(*Raw, To, SMTExprKind::FPToFXP);
 }
 
 SMTExprRef SMTSolverImpl::mkFPToFXPOverflow(const SMTExprRef &Exp,
-                                            const SMTSortRef &To) {
+                                            const SMTSortRef &To, FXPRM Mode) {
   fatalErrorIf(!Exp->Sort->isFPSort(), "Expected floating-point expression");
   requireFXPSort(To);
   FPFXPParts P = fpToFXPParts(*this, Exp, formatOf(To));
@@ -1382,7 +1617,7 @@ SMTExprRef SMTSolverImpl::mkFPToFXPOverflow(const SMTExprRef &Exp,
 }
 
 SMTExprRef SMTSolverImpl::mkFPToFXPSat(const SMTExprRef &Exp,
-                                       const SMTSortRef &To) {
+                                       const SMTSortRef &To, FXPRM Mode) {
   fatalErrorIf(!Exp->Sort->isFPSort(), "Expected floating-point expression");
   requireFXPSort(To);
   FXPFormat Target = formatOf(To);

--- a/src/camadaimpl.h
+++ b/src/camadaimpl.h
@@ -589,10 +589,10 @@ public:
   SMTExprRef mkFXPSub(const SMTExprRef &LHS,
                       const SMTExprRef &RHS) override final;
   SMTExprRef mkFXPNeg(const SMTExprRef &Exp) override final;
-  SMTExprRef mkFXPMul(const SMTExprRef &LHS,
-                      const SMTExprRef &RHS) override final;
-  SMTExprRef mkFXPDiv(const SMTExprRef &LHS,
-                      const SMTExprRef &RHS) override final;
+  SMTExprRef mkFXPMul(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                      FXPRM Mode) override final;
+  SMTExprRef mkFXPDiv(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                      FXPRM Mode) override final;
   SMTExprRef mkFXPShl(const SMTExprRef &Exp, unsigned Amount) override final;
   SMTExprRef mkFXPShr(const SMTExprRef &Exp, unsigned Amount) override final;
   SMTExprRef mkFXPLt(const SMTExprRef &LHS,
@@ -617,20 +617,23 @@ public:
   SMTExprRef mkFXPNegOverflow(const SMTExprRef &Exp) override final;
   SMTExprRef mkFXPShlOverflow(const SMTExprRef &Exp,
                               unsigned Amount) override final;
-  SMTExprRef mkFXPToFXP(const SMTExprRef &Exp,
-                        const SMTSortRef &To) override final;
-  SMTExprRef mkFXPToFXPOverflow(const SMTExprRef &Exp,
-                                const SMTSortRef &To) override final;
+  SMTExprRef mkFXPToFXP(const SMTExprRef &Exp, const SMTSortRef &To,
+                        FXPRM Mode) override final;
+  SMTExprRef mkFXPToFXPOverflow(const SMTExprRef &Exp, const SMTSortRef &To,
+                                FXPRM Mode) override final;
   SMTExprRef mkFXPFromBV(const SMTExprRef &Exp, bool SrcSigned,
                          const SMTSortRef &To) override final;
-  SMTExprRef mkFXPToBV(const SMTExprRef &Exp, unsigned ToWidth) override final;
+  SMTExprRef mkFXPToBV(const SMTExprRef &Exp, unsigned ToWidth,
+                       FXPRM Mode) override final;
   SMTExprRef mkFXPToBVOverflow(const SMTExprRef &Exp, unsigned ToWidth,
-                               bool ToSigned) override final;
+                               bool ToSigned, FXPRM Mode) override final;
   SMTExprRef mkFXPAddSat(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
   SMTExprRef mkFXPSubSat(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
   SMTExprRef mkFXPNegSat(const SMTExprRef &Exp) override;
-  SMTExprRef mkFXPMulSat(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
-  SMTExprRef mkFXPDivSat(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
+  SMTExprRef mkFXPMulSat(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                         FXPRM Mode) override;
+  SMTExprRef mkFXPDivSat(const SMTExprRef &LHS, const SMTExprRef &RHS,
+                         FXPRM Mode) override;
   SMTExprRef mkFXPShlSat(const SMTExprRef &Exp, unsigned Amount) override;
   SMTExprRef mkFXPShlExpr(const SMTExprRef &Exp,
                           const SMTExprRef &Amount) override;
@@ -640,25 +643,25 @@ public:
                                   const SMTExprRef &Amount) override;
   SMTExprRef mkFXPShlSatExpr(const SMTExprRef &Exp,
                              const SMTExprRef &Amount) override;
-  SMTExprRef mkFXPToFXPSat(const SMTExprRef &Exp,
-                           const SMTSortRef &To) override;
+  SMTExprRef mkFXPToFXPSat(const SMTExprRef &Exp, const SMTSortRef &To,
+                           FXPRM Mode) override;
   SMTExprRef mkFXPToBVSat(const SMTExprRef &Exp, unsigned ToWidth,
-                          bool ToSigned) override;
+                          bool ToSigned, FXPRM Mode) override;
   SMTExprRef mkFXPRound(const SMTExprRef &Exp, unsigned Digits,
-                        FXPRoundTie Tie) override final;
+                        FXPRM Tie) override final;
   SMTExprRef mkFXPAbs(const SMTExprRef &Exp) override final;
   SMTExprRef mkFXPCountls(const SMTExprRef &Exp,
                           unsigned ToWidth) override final;
-  SMTExprRef mkFXPSqrt(const SMTExprRef &Exp) override final;
+  SMTExprRef mkFXPSqrt(const SMTExprRef &Exp, FXPRM Mode) override final;
   SMTExprRef mkFXPExp(const SMTExprRef &Exp) override final;
   SMTExprRef mkFXPToFP(const SMTExprRef &Exp, const SMTSortRef &To,
                        RM R) override final;
-  SMTExprRef mkFPToFXP(const SMTExprRef &Exp,
-                       const SMTSortRef &To) override final;
-  SMTExprRef mkFPToFXPOverflow(const SMTExprRef &Exp,
-                               const SMTSortRef &To) override final;
-  SMTExprRef mkFPToFXPSat(const SMTExprRef &Exp,
-                          const SMTSortRef &To) override final;
+  SMTExprRef mkFPToFXP(const SMTExprRef &Exp, const SMTSortRef &To,
+                       FXPRM Mode) override final;
+  SMTExprRef mkFPToFXPOverflow(const SMTExprRef &Exp, const SMTSortRef &To,
+                               FXPRM Mode) override final;
+  SMTExprRef mkFPToFXPSat(const SMTExprRef &Exp, const SMTSortRef &To,
+                          FXPRM Mode) override final;
   SMTExprRef mkArraySelect(const SMTExprRef &Array,
                            const SMTExprRef &Index) override final;
   SMTExprRef mkArrayStore(const SMTExprRef &Array, const SMTExprRef &Index,


### PR DESCRIPTION
Two pieces of work, both correctness. The FXP half arrived via #149, which
merged into this branch rather than master.

**Part 1 fixes a regression currently in master.** If the review scope is
too wide, that half is commits `7fb4877`..`d0a0403` and stands alone.

**Part 2 is an API break**: every fixed-point operation that discards
precision gains a required rounding-mode parameter.

---

# Part 1 — FP correctness (`7fb4877`..`d0a0403`)

Three wrong results in the BV-encoded FP layer, found by cross-checking
against each backend's native FP **symbolically** — asserting the two
disagree, so UNSAT proves equivalence over every input rather than a
sample — and all confirmed against the host CPU as a third oracle before
being treated as bugs.

## #144 is a merged correctness regression

#144 removed multiply and divide's operand normalization, reasoning that
`round()` renormalizes anyway. That is false for subnormals: `round()`
renormalizes the *significand*, but an unnormalized subnormal reports an
exponent understated by its leading-zero count, and the `a_lz`/`b_lz`
subtractions it deleted were what corrected that.

Bisected on the counterexamples, same build, only the commit differing:

| input | before #144 | master |
|---|---|---|
| `mul(-128.5, 1.4e-45)` | correct | wrong subnormal product |
| `div(4.8e-07, -2.9e-39)` | correct | **-inf** where the result is finite |

Both functions are restored to their pre-#144 form, verified line-by-line
identical.

This was my error, and the same failure shape I had diagnosed correctly in
FMA (#145) one function earlier. The measured win was also overstated:
under a fixed query shape multiply is 3.15x native, not the 8.26x #144
claimed.

## `toIntegral` returns garbage on narrow formats

Pre-existing, unrelated to #144.

```cpp
log2(sbits - 1) + 1 <= ebits - 1   // binary16: log2(9)+1 = 4.17 > 4
```

The guard asks whether `sbits-1` fits an `ebits`-wide signed compare — for
binary16, "does 9 fit in 5 signed bits (max 15)?", obviously yes — but the
floating-point formula answers no, so the "already an integer" branch is
permanently dead and large values fall through the rounding path:

```
toIntegral(14184.0)  ->  0.5
```

Correct through exponent 25, wrong from 26 up. binary32 and binary64 pass
the same guard, which is why nothing caught it. Now tested with exact
integer arithmetic.

## BV-to-FP exponent guard, ported from Z3

Z3's `53fa8f9cc` widened `<` to `<=` in `mk_to_fp_unsigned`. Camada
inherited the `<` in **both** the signed and unsigned paths — Z3's signed
one already had `<=`, so a literal port would have fixed half of it.

Not observably wrong: `ubv_to_fp` from a 64-bit BV to binary16 proves
equivalent to native over all inputs on bitwuzla and z3, before and after.
Ported because the boundary computes the right answer by accident rather
than by construction — the same shape as the `toIntegral` bug above.

## Regression tests

The suite passed with all three bugs present, so each fixture was
validated by confirming it **fails on the unfixed code** before being
kept. Two mistakes in the first attempt, both worth knowing:

- passing operands as constants lets the backend's rewriter fold the
  multiply, so the bit-blast under test is never reached — they are pinned
  through symbols by equality instead
- comparing with `fp.eq` hides sign-of-zero differences, so the comparison
  is on IEEE bits

## Two Z3 bugs documented, not fixed

Both still present in Z3 5.1.0, both verified camada-correct against the
host. Recorded in `docs/open-follow-ups.md` with standalone reproducers.

- **`mk_fma`**: line 1772 reduces `sticky_h1` where `sticky_h2` was
  computed two lines above. `fma(984.0, 3.546875, 984.0)` is exactly
  4474.125, above the 4472/4476 midpoint, so RNE gives 4476; Z3 returns
  4472. Notably **not** subnormal — a plain rounding error, so the defect
  is wider than first recorded.
- **`mk_rem`**: headroom of `2^ebits - 3` is insufficient with a subnormal
  divisor. Three witnesses across binary16 and binary32, up to ~116 ulp
  out.

Both need an explicit `(then fpa2bv simplify bit-blast smt)` tactic: the
default pipeline's `propagate-values` folds constant operands before the
bit-blaster runs, which is likely why they have survived.

---

# Part 2 — `FXPRM` (#149, plus `aae6fb8`)

Every fixed-point operation that discards precision now takes a required
`FXPRM`. No default, matching the FP surface where `mkFPAdd` has always
demanded a rounding mode — so the compiler flags all 36 call sites rather
than silently changing behaviour.

## Why it is not a knob

A rounding mode is part of an operation's specification. The scope rule in
`rejected-experiments.md` already covers this: *"inside a camada-owned
theory there is no backend, so completeness of semantics-bearing
operations is itself the capability"*, with the decisive test being
whether composition can reach the semantics. It cannot:

| operation | can a consumer get another mode? |
|---|---|
| `mkFXPDiv` | **No** — `1/3` never terminates, so widening only postpones the rounding and composition double-rounds |
| `mkFXPToFXP`, `mkFXPToBV` | **No** — narrowing *is* the operation; there is no wider intermediate |
| `mkFPToFXP` | **No** — the FP source can exceed every FXP format's exact range |
| `mkFXPMul` | **Sometimes** — widen-then-round is exact, but only while a wider format exists; a Q32.32 multiply at the 64-bit ceiling has nowhere to go |

41% of Q4.4 products differ between truncation and nearest, and the bits
that decide it are discarded inside the encoder.

## Why a separate enum

`RM`'s five members cannot express `FXPRoundTie::TowardPositive` — LLVM
libc's actual `roundfx` direction, and the only one verified against a
running implementation. `RM::ROUND_TO_PLUS_INF` is a *different
operation*: it rounds every value up, so 0.25 becomes 1 where
nearest-ties-up leaves it 0. They agree only on halfway values.

`FXPRM` therefore replaces `FXPRoundTie` with six members — three nearest
directions plus `TowardZero`, `TowardNegative`, `TowardPositive`.

## What C maps to

Confirmed by execution, not assumption:

- **fixed->fixed narrowing and division: `TowardNegative`.** Clang's
  `-ffixed-point` gives `-0.5 / 0.75 = -0.671875`, i.e. floor, not the
  `-0.6640625` truncation would give.
- **fixed->int and float->fixed: `TowardZero`**, per TR 18037.

Existing call sites pass these and get exactly what they had. The Clang
`-ffixed-point` oracle suite passes unchanged, which is the evidence that
path is intact.

## Predicates that changed, and one that did not

**The conversion overflow predicates now round before checking bounds.**
Testing the exact value was correct only while everything truncated: a
Q8.8 value of 7.96875 fits signed Q4.4 as 127 truncated but rounds to 128,
so eight consecutive inputs would have been reported in range while the
conversion overflowed.

**The arithmetic overflow predicates correctly take no mode.** Their bound
is the pre-rounding one scaled by 2^N, and no product or quotient inside
it can round out — verified exhaustively over Q4.4, zero cases either way.
A parameter there would have been noise.

`aae6fb8` fixes the same class of bug CI caught in the float-to-fixed
pair: both accepted a mode and ignored it, so `mkFPToFXPOverflow` tested
an unrounded value. Rounding now happens inside `fpToFXPParts`, which
makes every predicate consistent with its conversion by construction.

## Verification

Each helper was checked against an integer oracle **before** being wired
into any call site, since a bug there would have propagated everywhere —
12,288 cases for the shift, 17,424 for the quotient. Then end to end:

- all six modes for `mkFXPMul`/`mkFXPDiv` over Q4.4 operand pairs against
  an exact rational oracle
- all six for `mkFXPRound` over every signed and unsigned Q4.4 value
- all six for `mkFXPToFXP` narrowing and for `mkFXPSqrt`
- `mkFXPToBV`'s division-by-2^N encoding replaced by the shared helper,
  proved equivalent over the full signed range for shifts 0-8 first

No mismatches anywhere. Exhaustive checking caught a bug the reasoning
missed: the nearest non-even sqrt modes used `Rem >= Root`, true at
`Root == 0`, so `sqrt(0)` returned 1.

`mkFXPSqrt` also changed from floor to correctly-rounded, on a report that
the restoring loop stops at the floor. Nothing pins a direction there — TR
18037 has no `sqrtfx` and the libc implementations are mutually
inconsistent approximations — so it is the one FXP operation where no mode
is "the C one".

---

# Combined verification

- **233 tests pass** on all seven backends; CI green on Linux, macOS and
  Windows
- **binary16**: every predicate, comparison and conversion proved
  equivalent to native across all applicable rounding modes on bitwuzla,
  z3 and mathsat; `mul`, `div` and `toIntegral` across all five
- **binary32**: 160 checks proved equivalent, no camada disagreement
- `fptoFP` (#146, merged into master meanwhile) re-verified equivalent
  across all five modes alongside the mul/div revert — the two coexist

The only failures anywhere in that matrix were the two Z3 bugs above.
