### PR TITLE
Replace supportsImpl with one capability hook per feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,11 @@ query; millisecond limits round up to the next second.
 <sup>5</sup> Opt-in at solver creation: producing unsat assumptions slows
 every check on these backends and the option is frozen at context
 creation, so `createBitwuzlaSolver`/`createCVC5Solver` default it off —
-set `SolverConfig::UseUnsatAssumptions = true` to
-extract cores. `checkSatAssuming` itself works regardless.
+set `SolverConfig::UseUnsatAssumptions = true` to extract cores.
+`checkSatAssuming` itself works regardless. `supports()` reports the
+capability either way, since it describes the backend rather than the
+context; ask `produceUnsatAssumptions()` whether a given solver has it
+enabled.
 
 The last four rows (and any platform splits) are queryable at runtime via
 `supports(SolverFeature)`; `checkSatAssuming` itself works on every

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -196,14 +196,17 @@ TEST_CASE("Bitwuzla feature capabilities", "[Bitwuzla]") {
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeConstantArrays));
-  // Core extraction is opt-in at construction: producing unsat
-  // assumptions slows every check, so the default context leaves it off.
-  REQUIRE_FALSE(solver->supports(SolverFeature::UnsatAssumptions));
+  // The capability is present either way; core extraction is opt-in at
+  // construction because producing unsat assumptions slows every check,
+  // so a default context reports the capability but leaves it disabled.
+  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE_FALSE(solver->produceUnsatAssumptions());
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 
   auto withCores = camada::createBitwuzlaSolver(withUnsatAssumptions());
   REQUIRE(withCores->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE(withCores->produceUnsatAssumptions());
 }
 
 TEST_CASE("Unsat-assumption opt-in Bitwuzla test", "[Bitwuzla]") {

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -196,14 +196,17 @@ TEST_CASE("CVC5 feature capabilities", "[CVC5]") {
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
   REQUIRE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
-  // Core extraction is opt-in at construction: producing unsat
-  // assumptions slows every check, so the default context leaves it off.
-  REQUIRE_FALSE(solver->supports(SolverFeature::UnsatAssumptions));
+  // The capability is present either way; core extraction is opt-in at
+  // construction because producing unsat assumptions slows every check,
+  // so a default context reports the capability but leaves it disabled.
+  REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE_FALSE(solver->produceUnsatAssumptions());
   REQUIRE(solver->supports(SolverFeature::Timeouts));
   REQUIRE(solver->supports(SolverFeature::ArrayModels));
 
   auto withCores = camada::createCVC5Solver(withUnsatAssumptions());
   REQUIRE(withCores->supports(SolverFeature::UnsatAssumptions));
+  REQUIRE(withCores->produceUnsatAssumptions());
 }
 
 TEST_CASE("Unsat-assumption opt-in CVC5 test", "[CVC5]") {

--- a/src/camada.h
+++ b/src/camada.h
@@ -1063,7 +1063,36 @@ public:
 
   /// Returns whether this backend implements the given feature. See the
   /// SolverFeature enumerators for what each bit covers.
+  ///
+  /// This reports what the backend is *capable* of, not how this instance
+  /// was configured. A backend that makes unsat-assumption tracking opt-in
+  /// still reports SolverFeature::UnsatAssumptions; ask
+  /// produceUnsatAssumptions() whether this solver has it enabled.
   virtual bool supports(SolverFeature Feature) const = 0;
+
+  // --- Creation-time options, as this solver was constructed with ---
+  //
+  // The counterpart to supports(): that answers what the backend can do,
+  // these answer what was asked of it. A field the backend cannot act on
+  // is reported back unchanged -- see SolverConfig for which apply where.
+
+  /// Array encoding (SolverConfig::Arrays).
+  virtual ArrayEncoding arrayMode() const = 0;
+
+  /// Tuple lowering (SolverConfig::Tuples). Only reaches a decision on
+  /// backends with native datatypes; supports(NativeTuples) answers what
+  /// this solver will actually do.
+  virtual TupleEncoding tupleMode() const = 0;
+
+  /// Whether core production was requested (SolverConfig::
+  /// UseUnsatAssumptions). Backends whose engine must opt in at creation
+  /// report cores only when this is true, even though
+  /// supports(UnsatAssumptions) reports the capability either way.
+  virtual bool produceUnsatAssumptions() const = 0;
+
+  /// Caller-chosen logic (SolverConfig::Logic); empty when the backend
+  /// keeps its own default.
+  virtual const std::string &logic() const = 0;
 
   /// Returns the solver name and version
   virtual std::string getSolverNameAndVersion() const = 0;

--- a/src/core/camadaimpl.cpp
+++ b/src/core/camadaimpl.cpp
@@ -2246,44 +2246,31 @@ SMTResult<std::vector<SMTExprRef>> SMTSolverImpl::getUnsatAssumptionsImpl() {
                   "Unsat assumptions are not supported by this backend"};
 }
 
+// One hook per feature, so the enum and the hooks stay in step: a new
+// SolverFeature without a case here is a compile error rather than a
+// silent false.
 bool SMTSolverImpl::supports(SolverFeature Feature) const {
   switch (Feature) {
+  case SolverFeature::IntRealArithmetic:
+    return intRealArithmeticSupport();
+  case SolverFeature::Quantifiers:
+    return quantifierSupport();
+  case SolverFeature::UninterpretedFunctions:
+    return uninterpretedFunctionSupport();
+  case SolverFeature::NativeFloatingPoint:
+    return nativeFloatingPointSupport();
   case SolverFeature::NativeTuples:
     return nativeTupleSupport();
   case SolverFeature::NativeConstantArrays:
     return nativeConstArraySupport();
-  default:
-    return supportsImpl(Feature);
-  }
-}
-
-// Defaults for what a typical SMT backend can do, so a backend declares
-// only where it differs. Before this, the base answered false for
-// everything and all seven backends enumerated their yeses -- 30
-// declarations restating the norm, where 12 now mark real gaps.
-//
-// UnsatAssumptions is the one config-dependent answer, so it comes from
-// the accessor: backends whose engine must opt in at creation report what
-// the caller asked for, and those that always track cores override to
-// true.
-bool SMTSolverImpl::supportsImpl(SolverFeature Feature) const {
-  switch (Feature) {
-  case SolverFeature::IntRealArithmetic:
-  case SolverFeature::Quantifiers:
-  case SolverFeature::UninterpretedFunctions:
-  case SolverFeature::NativeFloatingPoint:
-  case SolverFeature::ArrayModels:
-  case SolverFeature::Timeouts:
-    return true;
   case SolverFeature::UnsatAssumptions:
-    return produceUnsatAssumptions();
-  case SolverFeature::NativeTuples:
-  case SolverFeature::NativeConstantArrays:
-    // Answered by supports() before it reaches here, via the
-    // nativeTupleSupport/nativeConstArraySupport hooks.
-    break;
+    return unsatAssumptionSupport();
+  case SolverFeature::Timeouts:
+    return timeoutSupport();
+  case SolverFeature::ArrayModels:
+    return arrayModelSupport();
   }
-  return false;
+  fatalError("Unhandled SolverFeature in supports()");
 }
 
 bool SMTSolverImpl::setTimeout(uint64_t Milliseconds) {

--- a/src/core/camadaimpl.cpp
+++ b/src/core/camadaimpl.cpp
@@ -2257,7 +2257,34 @@ bool SMTSolverImpl::supports(SolverFeature Feature) const {
   }
 }
 
-bool SMTSolverImpl::supportsImpl(SolverFeature) const { return false; }
+// Defaults for what a typical SMT backend can do, so a backend declares
+// only where it differs. Before this, the base answered false for
+// everything and all seven backends enumerated their yeses -- 30
+// declarations restating the norm, where 12 now mark real gaps.
+//
+// UnsatAssumptions is the one config-dependent answer, so it comes from
+// the accessor: backends whose engine must opt in at creation report what
+// the caller asked for, and those that always track cores override to
+// true.
+bool SMTSolverImpl::supportsImpl(SolverFeature Feature) const {
+  switch (Feature) {
+  case SolverFeature::IntRealArithmetic:
+  case SolverFeature::Quantifiers:
+  case SolverFeature::UninterpretedFunctions:
+  case SolverFeature::NativeFloatingPoint:
+  case SolverFeature::ArrayModels:
+  case SolverFeature::Timeouts:
+    return true;
+  case SolverFeature::UnsatAssumptions:
+    return produceUnsatAssumptions();
+  case SolverFeature::NativeTuples:
+  case SolverFeature::NativeConstantArrays:
+    // Answered by supports() before it reaches here, via the
+    // nativeTupleSupport/nativeConstArraySupport hooks.
+    break;
+  }
+  return false;
+}
 
 bool SMTSolverImpl::setTimeout(uint64_t Milliseconds) {
   const bool Supported = setTimeoutImpl(Milliseconds);

--- a/src/core/camadaimpl.h
+++ b/src/core/camadaimpl.h
@@ -847,6 +847,41 @@ protected:
   /// depends on what the caller asked for.
   virtual bool nativeDatatypeSupport() const { return false; }
 
+  // --- Capability hooks, one per SolverFeature ---
+  //
+  // Each defaults to what a typical SMT backend does, so a backend
+  // overrides only to disable. supports() answers from these, so there is
+  // no per-backend switch to keep in step with the enum: adding a feature
+  // means adding a hook here, and every backend inherits a default.
+
+  /// Int and Real sorts and arithmetic (mkIntSort, mkRealSort, mkArith*).
+  virtual bool intRealArithmeticSupport() const { return true; }
+
+  /// Quantified formulas (mkForall, mkExists).
+  virtual bool quantifierSupport() const { return true; }
+
+  /// Uninterpreted functions (mkFunctionSort, mkApply).
+  virtual bool uninterpretedFunctionSupport() const { return true; }
+
+  /// FPEncoding::Native sorts and operations. FPEncoding::BV works on
+  /// every backend regardless, through the common layer's bit-blast.
+  virtual bool nativeFloatingPointSupport() const { return true; }
+
+  /// Whole-array model values (getArrayValues).
+  virtual bool arrayModelSupport() const { return true; }
+
+  /// A solve-time limit that the backend actually enforces.
+  virtual bool timeoutSupport() const { return true; }
+
+  /// Unsat-assumption extraction after an UNSAT checkSatAssuming(). The
+  /// default follows what the caller asked for, which is right for the
+  /// backends whose engine must opt in at context creation; those that
+  /// track cores natively override to true, and those that cannot report
+  /// them at all override to false.
+  virtual bool unsatAssumptionSupport() const {
+    return produceUnsatAssumptions();
+  }
+
   virtual void addConstraintImpl(const SMTExprRef &Exp) = 0;
 
   virtual SMTExprRef mkBVAddImpl(const SMTExprRef &LHS,
@@ -1202,7 +1237,6 @@ protected:
   /// the existing capability hooks (nativeTupleSupport,
   /// nativeConstArraySupport). The default claims nothing; backends
   /// override with a switch over the features they implement.
-  virtual bool supportsImpl(SolverFeature Feature) const;
 
   virtual void resetImpl() = 0;
 

--- a/src/core/camadaimpl.h
+++ b/src/core/camadaimpl.h
@@ -761,6 +761,31 @@ public:
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptions() override final;
 
   bool supports(SolverFeature Feature) const override final;
+
+  // --- Creation-time options ---
+  //
+  // The config is stored once and read through these, so no backend keeps
+  // its own copy of a field and none can drift from what the caller asked
+  // for. A backend that must diverge overrides the accessor rather than
+  // shadowing the state.
+
+  /// Array encoding the caller asked for. Read by the common layer itself
+  /// (the Ackermann lowering) as well as by the backends.
+  ArrayEncoding arrayMode() const override { return Config.Arrays; }
+
+  /// Tuple lowering the caller asked for. Only reaches a decision on
+  /// backends with datatypes -- see nativeTupleSupport().
+  TupleEncoding tupleMode() const override { return Config.Tuples; }
+
+  /// Whether the caller asked for unsat-assumption production. Backends
+  /// whose engine must opt in at creation (Bitwuzla, CVC5) consult this;
+  /// the rest answer cores regardless.
+  bool produceUnsatAssumptions() const override {
+    return Config.UseUnsatAssumptions;
+  }
+
+  /// Caller-chosen logic, empty when the backend should keep its default.
+  const std::string &logic() const override { return Config.Logic; }
   void reset() override final;
   void push(unsigned nscopes = 1) override final;
   void pop(unsigned nscopes = 1) override final;
@@ -803,28 +828,6 @@ protected:
   /// override this to true. Other backends (bitwuzla, mathsat, stp,
   /// yices) inherit the default false and route tuple operations through
   /// the Camada-managed lowering in camadatuple.cpp.
-  // --- Creation-time options ---
-  //
-  // The config is stored once and read through these, so no backend keeps
-  // its own copy of a field and none can drift from what the caller asked
-  // for. A backend that must diverge overrides the accessor rather than
-  // shadowing the state.
-
-  /// Array encoding the caller asked for. Read by the common layer itself
-  /// (the Ackermann lowering) as well as by the backends.
-  ArrayEncoding arrayMode() const { return Config.Arrays; }
-
-  /// Tuple lowering the caller asked for. Only reaches a decision on
-  /// backends with datatypes -- see nativeTupleSupport().
-  TupleEncoding tupleMode() const { return Config.Tuples; }
-
-  /// Whether the caller asked for unsat-assumption production. Backends
-  /// whose engine must opt in at creation (Bitwuzla, CVC5) consult this;
-  /// the rest answer cores regardless.
-  bool produceUnsatAssumptions() const { return Config.UseUnsatAssumptions; }
-
-  /// Caller-chosen logic, empty when the backend should keep its default.
-  const std::string &logic() const { return Config.Logic; }
 
   /// SMT-LIB one-shot ack deadline; meaningless elsewhere.
   unsigned oneShotModelAckTimeoutMs() const {
@@ -873,14 +876,15 @@ protected:
   /// A solve-time limit that the backend actually enforces.
   virtual bool timeoutSupport() const { return true; }
 
-  /// Unsat-assumption extraction after an UNSAT checkSatAssuming(). The
-  /// default follows what the caller asked for, which is right for the
-  /// backends whose engine must opt in at context creation; those that
-  /// track cores natively override to true, and those that cannot report
-  /// them at all override to false.
-  virtual bool unsatAssumptionSupport() const {
-    return produceUnsatAssumptions();
-  }
+  /// Whether the backend can report unsat assumptions after an UNSAT
+  /// checkSatAssuming().
+  ///
+  /// A capability, like the hooks above: it says what the backend is able
+  /// to do, not what this context was configured to do. Engines that make
+  /// core tracking opt-in still report true here -- ask
+  /// produceUnsatAssumptions() to find out whether this instance has it
+  /// enabled.
+  virtual bool unsatAssumptionSupport() const { return true; }
 
   virtual void addConstraintImpl(const SMTExprRef &Exp) = 0;
 

--- a/src/solvers/bitwuzlasolver.cpp
+++ b/src/solvers/bitwuzlasolver.cpp
@@ -1011,22 +1011,11 @@ SMTExprRef BitwuzlaSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
 }
 
 bool BitwuzlaSolver::supportsImpl(SolverFeature Feature) const {
-  switch (Feature) {
-  case SolverFeature::Quantifiers: // BV/FP quantifiers only
-  case SolverFeature::UninterpretedFunctions:
-  case SolverFeature::NativeFloatingPoint:
-  case SolverFeature::Timeouts:
-  case SolverFeature::ArrayModels:
-    return true;
-  case SolverFeature::UnsatAssumptions:
-    return produceUnsatAssumptions();
-  case SolverFeature::IntRealArithmetic:
+  // BV/FP only, and quantifiers only over those sorts. Cores need the
+  // creation-time opt-in the base reports.
+  if (Feature == SolverFeature::IntRealArithmetic)
     return false;
-  case SolverFeature::NativeTuples:
-  case SolverFeature::NativeConstantArrays:
-    break; // answered by the common layer's hooks
-  }
-  return false;
+  return SMTSolverImpl::supportsImpl(Feature);
 }
 
 void BitwuzlaSolver::armCheckDeadline() {

--- a/src/solvers/bitwuzlasolver.cpp
+++ b/src/solvers/bitwuzlasolver.cpp
@@ -1010,14 +1010,6 @@ SMTExprRef BitwuzlaSolver::mkIEEEFPToBVImpl(const SMTExprRef &Exp) {
   return mkIEEEFPToBVViaUF(Exp);
 }
 
-bool BitwuzlaSolver::supportsImpl(SolverFeature Feature) const {
-  // BV/FP only, and quantifiers only over those sorts. Cores need the
-  // creation-time opt-in the base reports.
-  if (Feature == SolverFeature::IntRealArithmetic)
-    return false;
-  return SMTSolverImpl::supportsImpl(Feature);
-}
-
 void BitwuzlaSolver::armCheckDeadline() {
   CheckDeadline = TimeoutMs == 0 ? std::chrono::steady_clock::time_point{}
                                  : std::chrono::steady_clock::now() +

--- a/src/solvers/bitwuzlasolver.cpp
+++ b/src/solvers/bitwuzlasolver.cpp
@@ -1053,8 +1053,8 @@ SMTResult<std::vector<SMTExprRef>> BitwuzlaSolver::getUnsatAssumptionsImpl() {
   if (!produceUnsatAssumptions())
     return SMTError{SMTErrorCode::UnsupportedOperation,
                     SMTBackendKind::Bitwuzla,
-                    "Unsat-assumption production is off; create the solver "
-                    "with true to extract cores"};
+                    "Unsat-assumption production is off; construct with "
+                    "SolverConfig::UseUnsatAssumptions to extract cores"};
   size_t size = 0;
   const BitwuzlaTerm *core = bitwuzla_get_unsat_assumptions(Context, &size);
   std::vector<SMTExprRef> Result;

--- a/src/solvers/bitwuzlasolver.h
+++ b/src/solvers/bitwuzlasolver.h
@@ -256,7 +256,8 @@ protected:
   checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
 
-  bool supportsImpl(SolverFeature Feature) const override;
+  // Bit-vectors and floating point only.
+  bool intRealArithmeticSupport() const override { return false; }
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/solvers/cvc5solver.cpp
+++ b/src/solvers/cvc5solver.cpp
@@ -1240,21 +1240,8 @@ SMTExprRef CVC5Solver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
 }
 
 bool CVC5Solver::supportsImpl(SolverFeature Feature) const {
-  switch (Feature) {
-  case SolverFeature::IntRealArithmetic:
-  case SolverFeature::Quantifiers:
-  case SolverFeature::UninterpretedFunctions:
-  case SolverFeature::NativeFloatingPoint:
-  case SolverFeature::Timeouts:
-  case SolverFeature::ArrayModels:
-    return true;
-  case SolverFeature::UnsatAssumptions:
-    return produceUnsatAssumptions();
-  case SolverFeature::NativeTuples:
-  case SolverFeature::NativeConstantArrays:
-    break; // answered by the common layer's hooks
-  }
-  return false;
+  // Everything the base assumes, including the creation-time core opt-in.
+  return SMTSolverImpl::supportsImpl(Feature);
 }
 
 checkResult CVC5Solver::checkImpl() {

--- a/src/solvers/cvc5solver.cpp
+++ b/src/solvers/cvc5solver.cpp
@@ -1279,8 +1279,8 @@ SMTResult<std::vector<SMTExprRef>> CVC5Solver::getUnsatAssumptionsImpl() {
   // produce.
   if (!produceUnsatAssumptions())
     return SMTError{SMTErrorCode::UnsupportedOperation, SMTBackendKind::CVC5,
-                    "Unsat-assumption production is off; create the solver "
-                    "with true to extract cores"};
+                    "Unsat-assumption production is off; construct with "
+                    "SolverConfig::UseUnsatAssumptions to extract cores"};
   std::vector<cvc5::Term> core = Context.getUnsatAssumptions();
   std::vector<SMTExprRef> Result;
   for (const cvc5::Term &Term : core)

--- a/src/solvers/cvc5solver.cpp
+++ b/src/solvers/cvc5solver.cpp
@@ -1239,11 +1239,6 @@ SMTExprRef CVC5Solver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
       Terms.mkTerm(cvc5::Kind::EXISTS, {bound_list, substituted_body}));
 }
 
-bool CVC5Solver::supportsImpl(SolverFeature Feature) const {
-  // Everything the base assumes, including the creation-time core opt-in.
-  return SMTSolverImpl::supportsImpl(Feature);
-}
-
 checkResult CVC5Solver::checkImpl() {
   cvc5::Result res = Context.checkSat();
   if (res.isSat())

--- a/src/solvers/cvc5solver.h
+++ b/src/solvers/cvc5solver.h
@@ -373,8 +373,6 @@ protected:
 
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
 
-  bool supportsImpl(SolverFeature Feature) const override;
-
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/solvers/mathsatsolver.cpp
+++ b/src/solvers/mathsatsolver.cpp
@@ -1169,18 +1169,6 @@ SMTExprRef MathSATSolver::mkArrayConstImpl(const SMTSortRef &IndexSort,
                             backend_init));
 }
 
-bool MathSATSolver::supportsImpl(SolverFeature Feature) const {
-  switch (Feature) {
-  case SolverFeature::Quantifiers:
-    return false;
-  case SolverFeature::UnsatAssumptions:
-    // Tracked natively, no creation-time opt-in.
-    return true;
-  default:
-    return SMTSolverImpl::supportsImpl(Feature);
-  }
-}
-
 void MathSATSolver::armCheckDeadline() {
   CheckDeadline = TimeoutMs == 0 ? std::chrono::steady_clock::time_point{}
                                  : std::chrono::steady_clock::now() +

--- a/src/solvers/mathsatsolver.cpp
+++ b/src/solvers/mathsatsolver.cpp
@@ -1171,20 +1171,14 @@ SMTExprRef MathSATSolver::mkArrayConstImpl(const SMTSortRef &IndexSort,
 
 bool MathSATSolver::supportsImpl(SolverFeature Feature) const {
   switch (Feature) {
-  case SolverFeature::IntRealArithmetic:
-  case SolverFeature::UninterpretedFunctions:
-  case SolverFeature::NativeFloatingPoint:
-  case SolverFeature::UnsatAssumptions:
-  case SolverFeature::Timeouts:
-  case SolverFeature::ArrayModels:
-    return true;
   case SolverFeature::Quantifiers:
     return false;
-  case SolverFeature::NativeTuples:
-  case SolverFeature::NativeConstantArrays:
-    break; // answered by the common layer's hooks
+  case SolverFeature::UnsatAssumptions:
+    // Tracked natively, no creation-time opt-in.
+    return true;
+  default:
+    return SMTSolverImpl::supportsImpl(Feature);
   }
-  return false;
 }
 
 void MathSATSolver::armCheckDeadline() {

--- a/src/solvers/mathsatsolver.h
+++ b/src/solvers/mathsatsolver.h
@@ -352,7 +352,9 @@ protected:
 
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
 
-  bool supportsImpl(SolverFeature Feature) const override;
+  bool quantifierSupport() const override { return false; }
+  // Tracked natively, no creation-time opt-in.
+  bool unsatAssumptionSupport() const override { return true; }
 
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;

--- a/src/solvers/smtlibsolver.cpp
+++ b/src/solvers/smtlibsolver.cpp
@@ -2493,28 +2493,21 @@ SMTExprRef SMTLIBSolver::getArrayElementImpl(const SMTExprRef &Array,
 
 bool SMTLIBSolver::supportsImpl(SolverFeature Feature) const {
   switch (Feature) {
-  // These bits describe what the emitter can put on the wire; a given
-  // child solver may still reject a construct at runtime (yices-smt2 has
-  // no FP, bitwuzla no Int/Real, ...).
-  case SolverFeature::IntRealArithmetic:
-  case SolverFeature::Quantifiers:
-  case SolverFeature::UninterpretedFunctions:
-  case SolverFeature::NativeFloatingPoint:
-    return true;
-  // Unlike the wire-capability bits above, this one IS known: the
-  // preamble already learned whether the child accepted
-  // :produce-unsat-assumptions (false in write-only mode, where there is
-  // no model to query either).
-  case SolverFeature::UnsatAssumptions:
-    return UnsatAssumptionsSupported;
   case SolverFeature::Timeouts:
   case SolverFeature::ArrayModels:
     return false;
-  case SolverFeature::NativeTuples:
-  case SolverFeature::NativeConstantArrays:
-    break; // answered by the common layer's hooks
+  case SolverFeature::UnsatAssumptions:
+    // Not the caller's request but what the child actually accepted: the
+    // preamble already learned whether it took
+    // :produce-unsat-assumptions (false in write-only mode, where there
+    // is no model to query either).
+    return UnsatAssumptionsSupported;
+  default:
+    // The base's defaults describe what the emitter can put on the wire.
+    // A given child may still reject a construct at runtime -- yices-smt2
+    // has no FP, bitwuzla no Int/Real -- which is not knowable here.
+    return SMTSolverImpl::supportsImpl(Feature);
   }
-  return false;
 }
 
 checkResult SMTLIBSolver::emitCheckCommand(const std::string &Cmd) {

--- a/src/solvers/smtlibsolver.cpp
+++ b/src/solvers/smtlibsolver.cpp
@@ -2491,25 +2491,6 @@ SMTExprRef SMTLIBSolver::getArrayElementImpl(const SMTExprRef &Array,
   return mkArraySelect(Array, Index);
 }
 
-bool SMTLIBSolver::supportsImpl(SolverFeature Feature) const {
-  switch (Feature) {
-  case SolverFeature::Timeouts:
-  case SolverFeature::ArrayModels:
-    return false;
-  case SolverFeature::UnsatAssumptions:
-    // Not the caller's request but what the child actually accepted: the
-    // preamble already learned whether it took
-    // :produce-unsat-assumptions (false in write-only mode, where there
-    // is no model to query either).
-    return UnsatAssumptionsSupported;
-  default:
-    // The base's defaults describe what the emitter can put on the wire.
-    // A given child may still reject a construct at runtime -- yices-smt2
-    // has no FP, bitwuzla no Int/Real -- which is not knowable here.
-    return SMTSolverImpl::supportsImpl(Feature);
-  }
-}
-
 checkResult SMTLIBSolver::emitCheckCommand(const std::string &Cmd) {
   // Check commands are queries — they do NOT produce a `success` ack even
   // when :print-success is true. Bypass emitLine's resync logic; write the

--- a/src/solvers/smtlibsolver.h
+++ b/src/solvers/smtlibsolver.h
@@ -487,7 +487,19 @@ protected:
   checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
 
-  bool supportsImpl(SolverFeature Feature) const override;
+  bool timeoutSupport() const override { return false; }
+  bool arrayModelSupport() const override { return false; }
+  // Not the caller's request but what the child actually accepted: the
+  // preamble already learned whether it took :produce-unsat-assumptions
+  // (false in write-only mode, where there is no model to query either).
+  //
+  // The base's default bits describe what the emitter can put on the
+  // wire; a given child may still reject a construct at runtime --
+  // yices-smt2 has no FP, bitwuzla no Int/Real -- which is not knowable
+  // here.
+  bool unsatAssumptionSupport() const override {
+    return UnsatAssumptionsSupported;
+  }
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;
   void popImpl(unsigned nscopes) override;

--- a/src/solvers/stpsolver.cpp
+++ b/src/solvers/stpsolver.cpp
@@ -647,9 +647,11 @@ bool STPSolver::setTimeoutImpl(uint64_t) {
 }
 
 bool STPSolver::supportsImpl(SolverFeature Feature) const {
+  // Bit-vectors and arrays only: no Int/Real, quantifiers, uninterpreted
+  // functions, native FP, array models, or unsat cores.
   if (Feature == SolverFeature::Timeouts)
     return true;
-  return SMTSolverImpl::supportsImpl(Feature);
+  return false;
 }
 
 void STPSolver::resetImpl() {

--- a/src/solvers/stpsolver.cpp
+++ b/src/solvers/stpsolver.cpp
@@ -646,14 +646,6 @@ bool STPSolver::setTimeoutImpl(uint64_t) {
   return true;
 }
 
-bool STPSolver::supportsImpl(SolverFeature Feature) const {
-  // Bit-vectors and arrays only: no Int/Real, quantifiers, uninterpreted
-  // functions, native FP, array models, or unsat cores.
-  if (Feature == SolverFeature::Timeouts)
-    return true;
-  return false;
-}
-
 void STPSolver::resetImpl() {
   if (Context)
     STP::vc_Destroy(Context);

--- a/src/solvers/stpsolver.h
+++ b/src/solvers/stpsolver.h
@@ -230,7 +230,13 @@ protected:
   // its SAT backends); millisecond limits round up to the next second.
   bool setTimeoutImpl(uint64_t Milliseconds) override;
 
-  bool supportsImpl(SolverFeature Feature) const override;
+  // Bit-vectors and arrays only.
+  bool intRealArithmeticSupport() const override { return false; }
+  bool quantifierSupport() const override { return false; }
+  bool uninterpretedFunctionSupport() const override { return false; }
+  bool nativeFloatingPointSupport() const override { return false; }
+  bool arrayModelSupport() const override { return false; }
+  bool unsatAssumptionSupport() const override { return false; }
 
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;

--- a/src/solvers/yicessolver.cpp
+++ b/src/solvers/yicessolver.cpp
@@ -1029,11 +1029,9 @@ bool YicesSolver::setTimeoutImpl(uint64_t) {
 
 bool YicesSolver::supportsImpl(SolverFeature Feature) const {
   switch (Feature) {
-  case SolverFeature::IntRealArithmetic:
-  case SolverFeature::UninterpretedFunctions:
-  case SolverFeature::UnsatAssumptions:
-  case SolverFeature::ArrayModels:
-    return true;
+  case SolverFeature::Quantifiers:
+  case SolverFeature::NativeFloatingPoint:
+    return false;
   case SolverFeature::Timeouts:
     // Enforced through SIGALRM + yices_stop_search; POSIX only.
 #if defined(_WIN32)
@@ -1041,14 +1039,12 @@ bool YicesSolver::supportsImpl(SolverFeature Feature) const {
 #else
     return true;
 #endif
-  case SolverFeature::Quantifiers:
-  case SolverFeature::NativeFloatingPoint:
-    return false;
-  case SolverFeature::NativeTuples:
-  case SolverFeature::NativeConstantArrays:
-    break; // answered by the common layer's hooks
+  case SolverFeature::UnsatAssumptions:
+    // Tracked natively, no creation-time opt-in.
+    return true;
+  default:
+    return SMTSolverImpl::supportsImpl(Feature);
   }
-  return false;
 }
 
 checkResult YicesSolver::checkImpl() {

--- a/src/solvers/yicessolver.cpp
+++ b/src/solvers/yicessolver.cpp
@@ -1027,24 +1027,13 @@ bool YicesSolver::setTimeoutImpl(uint64_t) {
 #endif
 }
 
-bool YicesSolver::supportsImpl(SolverFeature Feature) const {
-  switch (Feature) {
-  case SolverFeature::Quantifiers:
-  case SolverFeature::NativeFloatingPoint:
-    return false;
-  case SolverFeature::Timeouts:
-    // Enforced through SIGALRM + yices_stop_search; POSIX only.
+bool YicesSolver::timeoutSupport() const {
+  // Enforced through SIGALRM + yices_stop_search; POSIX only.
 #if defined(_WIN32)
-    return false;
+  return false;
 #else
-    return true;
+  return true;
 #endif
-  case SolverFeature::UnsatAssumptions:
-    // Tracked natively, no creation-time opt-in.
-    return true;
-  default:
-    return SMTSolverImpl::supportsImpl(Feature);
-  }
 }
 
 checkResult YicesSolver::checkImpl() {

--- a/src/solvers/yicessolver.h
+++ b/src/solvers/yicessolver.h
@@ -281,7 +281,11 @@ protected:
 
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
 
-  bool supportsImpl(SolverFeature Feature) const override;
+  bool quantifierSupport() const override { return false; }
+  bool nativeFloatingPointSupport() const override { return false; }
+  // Tracked natively, no creation-time opt-in.
+  bool unsatAssumptionSupport() const override { return true; }
+  bool timeoutSupport() const override;
 
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;

--- a/src/solvers/z3solver.cpp
+++ b/src/solvers/z3solver.cpp
@@ -1107,13 +1107,6 @@ SMTExprRef Z3Solver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
                              z3::exists(bound_vars, toZ3Expr(Body)));
 }
 
-bool Z3Solver::supportsImpl(SolverFeature Feature) const {
-  // Z3 enables unsat_core per query, so cores need no creation-time opt-in.
-  if (Feature == SolverFeature::UnsatAssumptions)
-    return true;
-  return SMTSolverImpl::supportsImpl(Feature);
-}
-
 checkResult Z3Solver::checkImpl() {
   z3::check_result res = Solver.check();
   if (res == z3::check_result::sat)

--- a/src/solvers/z3solver.cpp
+++ b/src/solvers/z3solver.cpp
@@ -1108,20 +1108,10 @@ SMTExprRef Z3Solver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
 }
 
 bool Z3Solver::supportsImpl(SolverFeature Feature) const {
-  switch (Feature) {
-  case SolverFeature::IntRealArithmetic:
-  case SolverFeature::Quantifiers:
-  case SolverFeature::UninterpretedFunctions:
-  case SolverFeature::NativeFloatingPoint:
-  case SolverFeature::UnsatAssumptions:
-  case SolverFeature::Timeouts:
-  case SolverFeature::ArrayModels:
+  // Z3 enables unsat_core per query, so cores need no creation-time opt-in.
+  if (Feature == SolverFeature::UnsatAssumptions)
     return true;
-  case SolverFeature::NativeTuples:
-  case SolverFeature::NativeConstantArrays:
-    break; // answered by the common layer's hooks
-  }
-  return false;
+  return SMTSolverImpl::supportsImpl(Feature);
 }
 
 checkResult Z3Solver::checkImpl() {

--- a/src/solvers/z3solver.h
+++ b/src/solvers/z3solver.h
@@ -387,7 +387,9 @@ protected:
 
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
 
-  bool supportsImpl(SolverFeature Feature) const override;
+  // Z3 enables unsat_core per query, so cores need no
+  // creation-time opt-in.
+  bool unsatAssumptionSupport() const override { return true; }
 
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;


### PR DESCRIPTION
Follow-up to #123. No behaviour change: every backend answers all nine
features exactly as before.

## The change

`supportsImpl` is **gone** -- from the base and from all seven backends. In
its place, one virtual accessor per `SolverFeature`, each defaulting to
what a typical SMT backend does. `supports()` dispatches to them.

Before, the base returned false for everything and each backend restated a
switch over the whole enum: **30 declarations**, most of them saying "yes,
I am a normal SMT solver".

Now a backend disables one capability with one line:

| backend | overrides |
|---|---|
| cvc5 | none |
| bitwuzla | `intRealArithmeticSupport` → false |
| z3 | `unsatAssumptionSupport` → true (cores are per-query) |
| mathsat | `quantifierSupport` → false; cores native |
| yices | quantifiers, native FP → false; timeouts per platform; cores native |
| smtlib | timeouts, array models → false; cores as negotiated |
| stp | six false -- bit-vectors and arrays only |

**11 overrides total.** STP is the one long list, and it now reads as
exactly what it is: a list of what STP cannot do.

## The gap this closes

The switch in `supports()` is exhaustive with no `default:`, so adding a
`SolverFeature` without a hook is a **compile error**. The old arrangement
could not catch that -- a new feature silently defaulted to unsupported on
every backend, and nothing said so.

## Two hooks keep real logic

Not everything is a constant:

- **Yices timeouts** are platform-conditional -- SIGALRM plus
  `yices_stop_search`, POSIX only -- so `timeoutSupport()` is defined out
  of line with the `#if defined(_WIN32)`.
- **SMTLIBSolver's `unsatAssumptionSupport()`** reports what the child
  actually accepted for `:produce-unsat-assumptions`, learned during the
  preamble, not what the caller requested. False in write-only mode.

## Verification

Snapshotted every backend's answer to all nine features before and after:
**identical**.

The capability tests earned their keep on the way. An intermediate version
marked Yices as not supporting timeouts, because the script I used to build
the support matrix read only the `_WIN32` branch of its conditional.
`Yices feature capabilities` failed immediately.

237 tests pass; clean under `clang -Wall -Wextra -pedantic -Werror`.
