### PR TITLE
Move FXPValue to camadatypes.h and size the enums explicitly

### DIFF
--- a/src/camada.h
+++ b/src/camada.h
@@ -871,15 +871,6 @@ public:
   /// significand and 1 hidden bit in the significand
   virtual SMTResult<double> getFP64(const SMTExprRef &Exp) = 0;
 
-  /// Exact fixed-point model value: the raw two's-complement bits plus the
-  /// format needed to interpret them (value = raw / 2^FracBits). Kept as a
-  /// binary string so any width round-trips exactly.
-  struct FXPValue {
-    std::string RawBits;
-    unsigned FracBits = 0;
-    bool IsSigned = false;
-  };
-
   /// If a model is available, returns the exact value of a given fixed-point
   /// expression.
   virtual SMTResult<FXPValue> getFXP(const SMTExprRef &Exp) = 0;

--- a/src/camadaexpr.h
+++ b/src/camadaexpr.h
@@ -22,13 +22,15 @@
 #ifndef CAMADAEXPR_H_
 #define CAMADAEXPR_H_
 
+#include <cstdint>
+
 #include "camadasort.h"
 
 namespace camada {
 
 class SMTExpr;
 
-enum class SMTExprKind {
+enum class SMTExprKind : std::uint8_t {
   Unknown,
   Symbol,
   BoolConst,

--- a/src/camadasort.h
+++ b/src/camadasort.h
@@ -23,6 +23,7 @@
 #define CAMADASORT_H_
 
 #include <cassert>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <variant>
@@ -32,8 +33,16 @@
 
 namespace camada {
 
-enum class SMTBackendKind { Bitwuzla, CVC5, MathSAT, STP, Yices, Z3, SMTLIB };
-enum class SMTSortKind {
+enum class SMTBackendKind : std::uint8_t {
+  Bitwuzla,
+  CVC5,
+  MathSAT,
+  STP,
+  Yices,
+  Z3,
+  SMTLIB
+};
+enum class SMTSortKind : std::uint8_t {
   Bool,
   Int,
   Real,

--- a/src/camadatypes.h
+++ b/src/camadatypes.h
@@ -22,6 +22,7 @@
 #ifndef CAMADATYPES_H_
 #define CAMADATYPES_H_
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
@@ -53,7 +54,7 @@ namespace camada {
 /// regression pins this), but model values are reported in the encoded
 /// representation — `getFP32` decodes BV back to `float`, `getBV`
 /// returns the raw bits when the sort was Native.
-enum class FPEncoding { Native, BV };
+enum class FPEncoding : bool { Native, BV };
 
 /// Selects how `mkArrayConst` lowers a constant array. Unlike `FPEncoding`
 /// this is not a sort property: lazily and natively lowered constant arrays
@@ -75,7 +76,7 @@ enum class FPEncoding { Native, BV };
 /// quantifier binder is unsupported (defaults are instantiated as ground
 /// constraints only, so a quantified body can observe uninstantiated
 /// indexes).
-enum class ConstArrayLowering { Auto, Native, Lazy };
+enum class ConstArrayLowering : std::uint8_t { Auto, Native, Lazy };
 
 /// Selects how Camada lowers `mkFPNeg` for backends whose native FP
 /// implementation diverges from the IEEE-754 sign-bit-flip semantics
@@ -89,7 +90,7 @@ enum class ConstArrayLowering { Auto, Native, Lazy };
 /// - PreserveNaNPayload: follow the SMT-LIB `fp.neg` definition, which
 ///   leaves NaN payloads (including the sign bit) unchanged. Cheaper to
 ///   emit on backends that natively implement this semantics.
-enum class FPNegBehavior {
+enum class FPNegBehavior : bool {
   FlipSignBit,
   PreserveNaNPayload,
 };
@@ -128,7 +129,7 @@ enum class FPNegBehavior {
 ///
 /// Every nearest mode saturates to the format's maximum when the rounding
 /// would carry past it, which every implementation surveyed agrees on.
-enum class FXPRM {
+enum class FXPRM : std::uint8_t {
   NearestTiesTowardPositive,
   NearestTiesAwayFromZero,
   NearestTiesToEven,
@@ -147,7 +148,7 @@ enum class FXPRM {
 ///   datatype declarations, so any standard SMT-LIB v2 solver can parse
 ///   it. Same encoding the non-native backends (bitwuzla/mathsat/stp/
 ///   yices) already use.
-enum class TupleEncoding { Native, Camada };
+enum class TupleEncoding : bool { Native, Camada };
 
 /// Selects how arrays are encoded, on the backends that accept it.
 ///
@@ -164,9 +165,9 @@ enum class TupleEncoding { Native, Camada };
 /// UF arguments/returns, and model queries need bool/BV index sorts. The
 /// mode forces the Camada tuple encoding — a native datatype cannot hold
 /// an array member that has no backend representation.
-enum class ArrayEncoding { Native, Ackermann };
+enum class ArrayEncoding : bool { Native, Ackermann };
 
-enum class RM {
+enum class RM : std::uint8_t {
   ROUND_TO_EVEN = 0,
   ROUND_TO_AWAY = 1,
   ROUND_TO_PLUS_INF = 2,
@@ -174,7 +175,7 @@ enum class RM {
   ROUND_TO_ZERO = 4,
 };
 
-enum class checkResult { SAT, UNSAT, UNKNOWN };
+enum class checkResult : std::uint8_t { SAT, UNSAT, UNKNOWN };
 
 /// Capabilities a backend may or may not implement, queryable through
 /// SMTSolver::supports() instead of discovering them through aborts or
@@ -185,7 +186,7 @@ enum class checkResult { SAT, UNSAT, UNKNOWN };
 /// through their SMTResult. On the SMT-LIB pipeline backend the bits
 /// describe what Camada emits — a particular child solver may still
 /// reject a construct at runtime.
-enum class SolverFeature {
+enum class SolverFeature : std::uint8_t {
   /// Int/Real sorts and arithmetic (mkIntSort, mkRealSort, mkArith*).
   IntRealArithmetic,
   /// Quantified formulas (mkForall, mkExists).
@@ -217,7 +218,7 @@ enum class SolverFeature {
 ///
 /// These are intended for user-triggerable failures such as unsupported
 /// features or model-query failures, not internal invariant violations.
-enum class SMTErrorCode {
+enum class SMTErrorCode : std::uint8_t {
   None,
   BackendError,
   InvalidModelValue,
@@ -239,6 +240,23 @@ enum class SMTErrorCode {
 /// methods; everything here is frozen because changing it mid-flight
 /// would strand already-built terms or already-configured contexts.
 struct SolverConfig {
+  /// Caller-chosen logic. Empty (the default) keeps each backend's
+  /// built-in choice. SMT-LIB: emitted verbatim as `(set-logic ...)`, no
+  /// negotiation, child rejection is fatal (one-shot model children are
+  /// dropped instead). Yices: the context logic (default QF_AUFBV).
+  /// MathSAT: the default-configuration logic (default AUFBV; ignored by
+  /// the constructor taking a caller-built msat_config).
+  std::string Logic;
+
+  /// SMT-LIB one-shot mode only: deadline in milliseconds for each
+  /// protocol ack from the auxiliary model solver. Acks are instantaneous
+  /// for any conforming child; one that stays silent past the deadline
+  /// does not speak the `:print-success` protocol and is dropped, costing
+  /// only counterexample support. Does not apply to the read of the model
+  /// solver's own verdict, which may legitimately take as long as the
+  /// solve.
+  unsigned OneShotModelAckTimeoutMs = 5000;
+
   /// Array encoding (see ArrayEncoding). All backends.
   ArrayEncoding Arrays = ArrayEncoding::Native;
 
@@ -265,23 +283,6 @@ struct SolverConfig {
   /// enables unsat_core per query, MathSAT and Yices track natively)
   /// ignore this and always support core extraction.
   bool UseUnsatAssumptions = false;
-
-  /// Caller-chosen logic. Empty (the default) keeps each backend's
-  /// built-in choice. SMT-LIB: emitted verbatim as `(set-logic ...)`, no
-  /// negotiation, child rejection is fatal (one-shot model children are
-  /// dropped instead). Yices: the context logic (default QF_AUFBV).
-  /// MathSAT: the default-configuration logic (default AUFBV; ignored by
-  /// the constructor taking a caller-built msat_config).
-  std::string Logic;
-
-  /// SMT-LIB one-shot mode only: deadline in milliseconds for each
-  /// protocol ack from the auxiliary model solver. Acks are instantaneous
-  /// for any conforming child; one that stays silent past the deadline
-  /// does not speak the `:print-success` protocol and is dropped, costing
-  /// only counterexample support. Does not apply to the read of the model
-  /// solver's own verdict, which may legitimately take as long as the
-  /// solve.
-  unsigned OneShotModelAckTimeoutMs = 5000;
 };
 
 /// Structured error payload carried by `SMTResult<T>` on failure.
@@ -354,6 +355,15 @@ private:
 struct ArrayModel {
   SMTExprRef Base;
   std::vector<std::pair<SMTExprRef, SMTExprRef>> Entries;
+};
+
+/// Exact fixed-point model value: the raw two's-complement bits plus the
+/// format needed to interpret them (value = raw / 2^FracBits). Kept as a
+/// binary string so any width round-trips exactly.
+struct FXPValue {
+  std::string RawBits;
+  unsigned FracBits = 0;
+  bool IsSigned = false;
 };
 
 } // namespace camada

--- a/src/theories/camadafxp.cpp
+++ b/src/theories/camadafxp.cpp
@@ -1649,14 +1649,13 @@ SMTExprRef SMTSolverImpl::mkFPToFXPSat(const SMTExprRef &Exp,
 // Model query
 // ---------------------------------------------------------------------------
 
-SMTResult<SMTSolver::FXPValue> SMTSolverImpl::getFXP(const SMTExprRef &Exp) {
+SMTResult<FXPValue> SMTSolverImpl::getFXP(const SMTExprRef &Exp) {
   requireFXP(Exp);
   SMTResult<std::string> Bits = getBVInBin(mkFXPToRawBV(Exp));
   if (!Bits)
     return Bits.error();
-  return SMTSolver::FXPValue{std::move(Bits.value()),
-                             Exp->Sort->getFXPFracBits(),
-                             Exp->Sort->isFXPSignedSort()};
+  return FXPValue{std::move(Bits.value()), Exp->Sort->getFXPFracBits(),
+                  Exp->Sort->isFXPSignedSort()};
 }
 
 } // namespace camada


### PR DESCRIPTION
Two small cleanups in the type declarations. No behaviour change.

## FXPValue moves out of the API

It was a struct definition sitting between two virtual methods in
`camada.h`, interrupting the method list:

```cpp
virtual SMTResult<double> getFP64(const SMTExprRef &Exp) = 0;

struct FXPValue { ... };            // <- here

virtual SMTResult<FXPValue> getFXP(const SMTExprRef &Exp) = 0;
```

It is the same kind of thing as `SMTError`, `SMTResult` and `ArrayModel`,
so it joins them in `camadatypes.h`. Its two uses lose the `SMTSolver::`
qualification they needed while it was nested.

## Enums name their underlying type

`bool` for the four that are permanently binary -- `FPEncoding`,
`TupleEncoding`, `ArrayEncoding`, `FPNegBehavior` -- and `uint8_t` for the
rest, including `SMTExprKind` at 145 enumerators (110 spare). All were 4
bytes; all are now 1.

## Reordering SolverConfig

The sizing alone left the small members padding out the struct.
Reordering -- `std::string`, then the 4-byte counter, then the byte-sized
enums -- recovers it:

| | bytes |
|---|---|
| before | 56 |
| after sizing | 48 |
| after reordering | **40** |

Nothing aggregate-initialises `SolverConfig` positionally; every caller
default-constructs and assigns by name, so the order is not part of the
interface in practice.

## Where this does not help, measured

Worth recording so nobody expects more than it gives:

- **`SMTExpr` and `SMTSort` are unchanged**, 32 bytes either way.
  Alignment padding around their pointer members absorbs the smaller
  `Kind` entirely -- and those are the structs with millions of instances,
  so the memory win from the enum sizing is zero where it would have
  mattered.
- **`SMTError` and `FXPValue` are already optimal.** A `std::string`
  forces 8-byte alignment, so their tail padding cannot be recovered by
  any ordering.

The real saving is 16 bytes per *solver*, which is negligible. The benefit
is that the types now state what they are: a two-state enum says so, and
`SolverConfig` has no interior padding.

237 tests pass; clean under `clang -Wall -Wextra -pedantic -Werror`.
