### PR TITLE
Bump version to 0.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 set(CAMADA_VER_MAJOR 0)
-set(CAMADA_VER_MINOR 17)
+set(CAMADA_VER_MINOR 18)
 
 project(
   camada

--- a/regression/main.cpp
+++ b/regression/main.cpp
@@ -13,5 +13,5 @@ int main(int argc, char *argv[]) {
 // a quoting mistake there once shipped the literal macro names as the
 // version string, and nothing noticed.
 TEST_CASE("Camada version string", "[Camada]") {
-  REQUIRE(camada::getCamadaVersion() == "0.17");
+  REQUIRE(camada::getCamadaVersion() == "0.18");
 }


### PR DESCRIPTION
Version bump for v0.18. The headline is a soundness fix, but this release
also breaks include paths and several signatures, so consumers will need
to do more than bump a number.

Since v0.17:

- **#144 was a merged correctness regression, now reverted** (#148) — it
  removed multiply and divide's operand normalization on the grounds that
  round() renormalizes anyway. That is false for subnormals: an
  unnormalized subnormal reports an exponent understated by its
  leading-zero count, and the subtractions it deleted were what corrected
  that. Multiply returned wrong subnormal products; divide returned -inf
  where the result is finite. Present in v0.17.
- **toIntegral returned garbage on narrow formats** (#148) — a
  floating-point log2 guard read 4.17 > 4 for binary16 and disabled the
  "already an integer" branch outright, so toIntegral(14184.0) gave 0.5.
  Correct through exponent 25, wrong from 26 up; binary32 and binary64
  passed the same guard, which is why nothing caught it.
- **BREAKING: solver headers moved** (#150) — include
  <camada/solvers/z3solver.h> and <camada/core/camadaimpl.h>.
  <camada/camada.h> is unchanged and remains a single umbrella include.
  Taken deliberately while camada is pre-1.0 rather than keeping a flat
  prefix that contradicted the tree.
- **BREAKING: creation-time options move to SolverConfig** (#123) — the
  per-backend factory parameters are replaced by one struct, and the
  fixed-point operations that discard precision now take a required FXPRM
  rounding mode. UnsatAssumptionsMode is a plain bool named
  UseUnsatAssumptions.
- **BREAKING: supports() reports capability, not configuration** (#151) —
  a backend that makes core tracking opt-in now reports
  SolverFeature::UnsatAssumptions either way; ask the new
  produceUnsatAssumptions() whether an instance has it enabled. The
  creation-time options join the public interface alongside it.
- **Two Z3 bugs found and documented, not fixed here** (#148) — its
  fpa2bv FMA drops a sticky bit and mk_rem loses significand bits with a
  subnormal divisor, both still present in Z3 5.1.0 and both cases where
  camada now produces the exactly-rounded result. Reproducers are in
  docs/open-follow-ups.md; we owe the upstream report.

The FP work rests on cross-checking camada's BV encoding against each
backend's native FP symbolically — asserting the two disagree, so UNSAT
proves equivalence over every input rather than a sample. Every predicate,
comparison and conversion is proved equivalent at binary16 and binary32.

