### PR TITLE
Fix the threading contract, the NativeTuples capability, and API naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ __pycache__/
 
 # Build directories
 build*/
+.build-release/
+
+# Extracted release tarball (scripts/release-consumer smoke test)
+release/
 
 # clangd/editor index
 .cache/

--- a/README.md
+++ b/README.md
@@ -550,17 +550,17 @@ int main() {
   camada::SMTExprRef notEq = solver->mkNot(eq);
 
   solver->addConstraint(notEq);
-  camada::checkResult result = solver->check();
+  camada::CheckResult result = solver->check();
 
-  if (result == camada::checkResult::SAT) {
+  if (result == camada::CheckResult::SAT) {
     /* Query the model for the value of the exprs */
 
     /* Dump the model */
     solver->dumpModel();
 
-  } else if (result == camada::checkResult::UNSAT) {
+  } else if (result == camada::CheckResult::UNSAT) {
     /* The formula is unsatisfiable */
-  } else if (result == camada::checkResult::UNKNOWN) {
+  } else if (result == camada::CheckResult::UNKNOWN) {
     /* Timeout (see setTimeout) or the solver gave up on the formula */
   }
 }

--- a/regression/ackarray.test.h
+++ b/regression/ackarray.test.h
@@ -24,7 +24,7 @@ inline void ack_read_congruence(const camada::SMTSolverRef &solver) {
   solver->addConstraint(solver->mkEqual(i, c3));
   solver->addConstraint(solver->mkNot(solver->mkEqual(
       solver->mkArraySelect(a, i), solver->mkArraySelect(a, c3))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Distinct index terms are free to hold different values — and forced
@@ -40,13 +40,13 @@ inline void ack_distinct_index_reads(const camada::SMTSolverRef &solver) {
       solver->mkEqual(solver->mkArraySelect(a, i), solver->mkBVFromDec(1, 8)));
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(a, j), solver->mkBVFromDec(2, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   solver->push();
   solver->addConstraint(solver->mkEqual(i, j));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   solver->pop();
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Store/select semantics: a store is visible at its own index and
@@ -63,14 +63,14 @@ inline void ack_store_select_semantics(const camada::SMTSolverRef &solver) {
   solver->push();
   solver->addConstraint(
       solver->mkNot(solver->mkEqual(solver->mkArraySelect(b, i), v)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   solver->pop();
 
   solver->push();
   solver->addConstraint(solver->mkNot(solver->mkEqual(i, j)));
   solver->addConstraint(solver->mkNot(solver->mkEqual(
       solver->mkArraySelect(b, j), solver->mkArraySelect(a, j))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   solver->pop();
 }
 
@@ -88,7 +88,7 @@ inline void ack_equality_before_reads(const camada::SMTSolverRef &solver) {
   auto k = solver->mkSymbol("k", idxsort);
   solver->addConstraint(solver->mkNot(solver->mkEqual(
       solver->mkArraySelect(a, k), solver->mkArraySelect(b, k))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Prototype bug 3: `a != b` with no other constraints must be
@@ -101,7 +101,7 @@ inline void ack_disequality_witness(const camada::SMTSolverRef &solver) {
   auto b = solver->mkSymbol("b", arrsort);
 
   solver->addConstraint(solver->mkNot(solver->mkEqual(a, b)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Prototype bug 7: equality over ite-arrays must decide the condition,
@@ -119,7 +119,7 @@ inline void ack_ite_array_semantics(const camada::SMTSolverRef &solver) {
 
   solver->push();
   solver->addConstraint(solver->mkEqual(solver->mkArraySelect(x, i), one));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto cval = solver->getBool(c);
   REQUIRE(cval);
   REQUIRE(cval.value());
@@ -127,7 +127,7 @@ inline void ack_ite_array_semantics(const camada::SMTSolverRef &solver) {
 
   solver->addConstraint(solver->mkNot(c));
   solver->addConstraint(solver->mkEqual(solver->mkArraySelect(x, i), one));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Prototype bug 5: model queries must not poison the assertion set — a
@@ -139,7 +139,7 @@ inline void ack_model_query_stability(const camada::SMTSolverRef &solver) {
   auto v = solver->mkBVFromDec(9, 8);
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(a, solver->mkBVFromDec(1, 8)), v));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Constrained index: exact value. Unconstrained index: some stable
   // value, the same on a repeated query against the same model.
@@ -155,7 +155,7 @@ inline void ack_model_query_stability(const camada::SMTSolverRef &solver) {
   REQUIRE(at5bval);
   REQUIRE(at5aval.value() == at5bval.value());
 
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Prototype bug 6: a user symbol shaped like an internal leaf name must
@@ -169,7 +169,7 @@ inline void ack_internal_name_no_alias(const camada::SMTSolverRef &solver) {
   auto read = solver->mkArraySelect(a, solver->mkBVFromDec(3, 8));
 
   solver->addConstraint(solver->mkNot(solver->mkEqual(user, read)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Constant arrays: every index reads the initializer; stores layer on
@@ -187,7 +187,7 @@ inline void ack_const_array_semantics(const camada::SMTSolverRef &solver) {
     auto k = solver->mkSymbol("k", idxsort);
     solver->addConstraint(
         solver->mkNot(solver->mkEqual(solver->mkArraySelect(arr, k), init)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
     solver->pop();
   }
 
@@ -197,7 +197,7 @@ inline void ack_const_array_semantics(const camada::SMTSolverRef &solver) {
   auto b = solver->mkArrayStore(arr, i, v);
   solver->addConstraint(solver->mkNot(solver->mkEqual(
       solver->mkArraySelect(b, solver->mkBVFromDec(4, 8)), init)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // getArrayValues: stored indexes appear with their values; a constant
@@ -213,7 +213,7 @@ inline void ack_array_model_values(const camada::SMTSolverRef &solver) {
   auto k = solver->mkBVFromDec(1, 8);
   auto w = solver->mkBVFromDec(9, 8);
   solver->addConstraint(solver->mkEqual(solver->mkArraySelect(a, k), w));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto model = solver->getArrayValues(b);
   REQUIRE(model);
@@ -256,7 +256,7 @@ inline void ack_fp_element_semantics(const camada::SMTSolverRef &solver) {
   auto v = solver->mkFP32(1.5f, camada::FPEncoding::BV);
 
   solver->addConstraint(solver->mkEqual(solver->mkArraySelect(a, i), v));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto at3 = solver->getArrayElement(a, solver->mkBVFromDec(3, 8));
   auto fpval = solver->getFP32(at3);
   REQUIRE(fpval);
@@ -281,10 +281,10 @@ inline void ack_check_sat_assuming(const camada::SMTSolverRef &solver) {
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(a, j), solver->mkBVFromDec(2, 8)));
   REQUIRE(solver->checkSatAssuming({solver->mkEqual(i, j)}) ==
-          camada::checkResult::UNSAT);
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+          camada::CheckResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   REQUIRE(solver->checkSatAssuming({solver->mkNot(solver->mkEqual(i, j))}) ==
-          camada::checkResult::SAT);
+          camada::CheckResult::SAT);
 }
 
 // The fixtures that never mint a read variable inside a (push) scope.

--- a/regression/array.test.h
+++ b/regression/array.test.h
@@ -30,7 +30,7 @@ array(const camada::SMTSolverRef &solver,
 
   // Add the constraint to the solver, And check for satisfiability
   solver->addConstraint(eq);
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto selected = solver->getArrayElement(arr11, solver->mkBVFromDec(1, 2));
   REQUIRE(selected->Sort == elemsort);
   auto selected_res = solver->getBVInBin(selected);
@@ -57,7 +57,7 @@ inline void array_const_store_semantics(
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(updated, idx_other), init));
 
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto read_written = solver->getArrayElement(updated, idx_written);
   auto read_other = solver->getArrayElement(updated, idx_other);
@@ -96,7 +96,7 @@ inline void bool_array_const_store_semantics(
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(updated, idx_other), init));
 
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto read_written = solver->getArrayElement(updated, idx_written);
   auto read_other = solver->getArrayElement(updated, idx_other);
@@ -135,7 +135,7 @@ inline void array_const_survives_push_pop(
     auto sample_idx = solver->mkBVFromDec(3, idx);
     solver->addConstraint(
         solver->mkEqual(solver->mkArraySelect(a, sample_idx), fill));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Reset and re-establish every handle from scratch — handles created
@@ -156,7 +156,7 @@ inline void array_const_survives_push_pop(
     // confirms the const-array binding is still in force after the pop.
     solver->addConstraint(solver->mkNot(
         solver->mkEqual(solver->mkArraySelect(a, sample_idx), fill)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 
@@ -184,7 +184,7 @@ inline void wide_index_const_array_semantics(
     auto x = solver->mkArraySelect(updated, i);
     solver->addConstraint(solver->mkNot(solver->mkEqual(x, init)));
     solver->addConstraint(solver->mkNot(solver->mkEqual(x, stored)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 
   solver->reset();
@@ -202,7 +202,7 @@ inline void wide_index_const_array_semantics(
 
     solver->addConstraint(
         solver->mkEqual(solver->mkArraySelect(updated, idx_written), stored));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
 
     // The model query at an index the formula never touched must still
     // report the default, resolved from the tracked derivation chain.
@@ -238,7 +238,7 @@ inline void const_array_select_survives_pop(
 
   // The handle outlives the pop; the default must still bind it.
   solver->addConstraint(solver->mkNot(solver->mkEqual(sel, init)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // The lowerings interoperate: lazily and natively (or Auto-) lowered
@@ -272,7 +272,7 @@ inline void array_model_values(const camada::SMTSolverRef &solver) {
       solver->mkEqual(solver->mkArraySelect(arr, idx(1)), idx(10)));
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(arr, idx(2)), idx(20)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto Model = solver->getArrayValues(arr);
   if (!Model) {
@@ -294,7 +294,7 @@ inline void const_array_model_values(
   // Touch the array so every backend has it in the formula.
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(arr, idx(0)), idx(7)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto Model = solver->getArrayValues(arr);
   if (!Model) {
@@ -332,7 +332,7 @@ inline void array_equality_semantics(const camada::SMTSolverRef &solver) {
       solver->mkEqual(solver->mkArraySelect(a, idx(0)), idx(1)));
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(b, idx(0)), idx(2)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Same, with the selects observed BEFORE the equality is built — pins
   // the replay of already-observed indexes.
@@ -343,13 +343,13 @@ inline void array_equality_semantics(const camada::SMTSolverRef &solver) {
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(d, idx(0)), idx(2)));
   solver->addConstraint(solver->mkEqual(c, d));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Negative direction stays satisfiable: a difference can be exhibited.
   solver->reset();
   auto [e, f] = mk("e", "f");
   solver->addConstraint(solver->mkNot(solver->mkEqual(e, f)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Agreeing constraints under asserted equality are satisfiable.
   solver->reset();
@@ -359,7 +359,7 @@ inline void array_equality_semantics(const camada::SMTSolverRef &solver) {
       solver->mkEqual(solver->mkArraySelect(g, idx(0)), idx(5)));
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(h, idx(0)), idx(5)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Equality must be visible through store-derived terms: reading
   // store(a, j, v) at i != j reads a at i.
@@ -370,7 +370,7 @@ inline void array_equality_semantics(const camada::SMTSolverRef &solver) {
   auto qs = solver->mkArrayStore(q, idx(1), idx(42));
   solver->addConstraint(solver->mkNot(solver->mkEqual(
       solver->mkArraySelect(ps, idx(0)), solver->mkArraySelect(qs, idx(0)))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // ... and through ite-derived terms.
   solver->reset();
@@ -382,7 +382,7 @@ inline void array_equality_semantics(const camada::SMTSolverRef &solver) {
   solver->addConstraint(solver->mkNot(
       solver->mkEqual(solver->mkArraySelect(i1, solver->mkBVFromDec(0, 8)),
                       solver->mkArraySelect(i2, solver->mkBVFromDec(0, 8)))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Transitive chains close through observed-index congruence.
   solver->reset();
@@ -394,7 +394,7 @@ inline void array_equality_semantics(const camada::SMTSolverRef &solver) {
       solver->mkEqual(solver->mkArraySelect(t, idx(0)), idx(1)));
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(v, idx(0)), idx(2)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Polarity safety: the equality literal used under boolean structure.
   solver->reset();
@@ -407,7 +407,7 @@ inline void array_equality_semantics(const camada::SMTSolverRef &solver) {
       solver->mkEqual(solver->mkArraySelect(w, idx(0)), idx(1)));
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(x, idx(0)), idx(2)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Equality between an array symbol and a constant array — ESBMC's
@@ -428,7 +428,7 @@ inline void const_array_equality_semantics(
       solver->mkEqual(a, solver->mkArrayConst(indexsort, idx(7), Lowering)));
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(a, idx(3)), idx(7)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // reset() invalidates every handle; rebuild the sorts for the
   // contradiction direction.
@@ -440,7 +440,7 @@ inline void const_array_equality_semantics(
       solver->mkEqual(b, solver->mkArrayConst(indexsort, idx(7), Lowering)));
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(b, idx(3)), idx(9)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Derived-before-equality: a store built over the symbol BEFORE the
   // constant-array equality exists must still see the default at indexes
@@ -454,7 +454,7 @@ inline void const_array_equality_semantics(
       solver->mkEqual(c, solver->mkArrayConst(indexsort, idx(7), Lowering)));
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(cs, idx(3)), idx(9)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // A symbol array equated to one lazy const array, then disequated from a
@@ -478,7 +478,7 @@ inline void lazy_array_transitive_equality(
   solver->addConstraint(
       solver->mkEqual(c, solver->mkArrayConst(bv8, idx(9), Lowering)));
   solver->addConstraint(solver->mkNot(solver->mkEqual(b, c)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // But B's value is still pinned: reading B at any index must be 7, even
   // though B != C let the solver pick a witness where B and C differ.
@@ -495,7 +495,7 @@ inline void lazy_array_transitive_equality(
   auto m = solver->mkSymbol("lat_m", bv8);
   solver->addConstraint(
       solver->mkNot(solver->mkEqual(solver->mkArraySelect(b2, m), idx(7))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Regression for the reverted #103: cross-equality congruence at a
@@ -515,7 +515,7 @@ array_equality_witness_congruence(const camada::SMTSolverRef &solver) {
   solver->addConstraint(solver->mkEqual(a, b));
   solver->addConstraint(solver->mkEqual(a, c));
   solver->addConstraint(solver->mkNot(solver->mkEqual(b, c)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Regression for the reverted #103: a lazy root reached only through an
@@ -535,7 +535,7 @@ inline void lazy_array_equality_reached_defaults(
   auto b = solver->mkSymbol("erd_b", solver->mkArraySort(bv8, bv8));
   solver->addConstraint(solver->mkEqual(a, b));
   solver->addConstraint(solver->mkNot(solver->mkEqual(b, c)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Constant array whose initializer is itself a constant array —
@@ -561,7 +561,7 @@ inline void nested_const_array_semantics(
   auto j = solver->mkSymbol("j", bv8);
   auto deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
   solver->addConstraint(solver->mkNot(solver->mkEqual(deep, idx(7))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Store into the inner array at a concrete index, read elsewhere: the
   // written cell holds the stored value, every other cell the default.
@@ -575,7 +575,7 @@ inline void nested_const_array_semantics(
       solver->mkEqual(solver->mkArraySelect(innerStored, idx(2)), idx(99)),
       solver->mkEqual(solver->mkArraySelect(innerStored, k), idx(7)));
   solver->addConstraint(solver->mkNot(ok));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Negative direction must stay satisfiable: a deep read equal to a
   // value different from the default is impossible, but equal to the
@@ -588,7 +588,7 @@ inline void nested_const_array_semantics(
   j = solver->mkSymbol("j2", bv8);
   deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
   solver->addConstraint(solver->mkEqual(deep, idx(7)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   solver->reset();
   bv8 = solver->mkBVSort(8);
   inner = solver->mkArrayConst(bv8, idx(7), Lowering);
@@ -597,7 +597,7 @@ inline void nested_const_array_semantics(
   j = solver->mkSymbol("j3", bv8);
   deep = solver->mkArraySelect(solver->mkArraySelect(outer, i), j);
   solver->addConstraint(solver->mkEqual(deep, idx(8))); // != default 7
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Equality propagation: two equal nested const arrays agree on a deep
   // read even when one side was derived before the equality.
@@ -613,7 +613,7 @@ inline void nested_const_array_semantics(
       a, solver->mkArrayConst(bv8, solver->mkArrayConst(bv8, idx(5), Lowering),
                               Lowering)));
   solver->addConstraint(solver->mkNot(solver->mkEqual(aDeep, idx(5))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Model round-trip: getArrayElement on the outer returns an inner
   // array whose deep read matches the default.
@@ -625,7 +625,7 @@ inline void nested_const_array_semantics(
   solver->addConstraint(solver->mkEqual(
       solver->mkArraySelect(solver->mkArraySelect(outer, idx(0)), idx(0)),
       idx(7)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto innerModel = solver->getArrayElement(outer, idx(1));
   REQUIRE(innerModel->Sort == solver->mkArraySort(bv8, bv8));
   auto cell = solver->getBV(solver->getArrayElement(innerModel, idx(3)));
@@ -645,7 +645,7 @@ inline void nested_const_array_semantics(
   auto n2 = solver->mkSymbol("n2", innerSort);
   solver->addConstraint(solver->mkNot(solver->mkEqual(m1, n1)));
   solver->addConstraint(solver->mkNot(solver->mkEqual(m2, n2)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Adversarial negative direction with a lazy const array: a difference
   // claimed against the default must be a real one. select(outer,i) is the
@@ -665,7 +665,7 @@ inline void nested_const_array_semantics(
   auto j5 = solver->mkSymbol("j5", bv8);
   solver->addConstraint(
       solver->mkNot(solver->mkEqual(solver->mkArraySelect(sym, j5), idx(7))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // nested_const_array_semantics inside a pushed scope: the deep default
@@ -685,7 +685,7 @@ inline void nested_const_array_survives_pop(
   solver->pop();
 
   solver->addConstraint(solver->mkNot(solver->mkEqual(deep, idx(7))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 inline void const_array_lowering_interop(const camada::SMTSolverRef &solver) {
@@ -704,5 +704,5 @@ inline void const_array_lowering_interop(const camada::SMTSolverRef &solver) {
   auto sum = solver->mkBVAdd(solver->mkArraySelect(lazy, i),
                              solver->mkArraySelect(other, i));
   solver->addConstraint(solver->mkNot(solver->mkEqual(sum, one)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }

--- a/regression/bench/main.cpp
+++ b/regression/bench/main.cpp
@@ -323,7 +323,7 @@ void benchmarkArraySolve(camada::SMTSolver &solver, std::size_t iterations) {
           solver.mkBVFromDec(static_cast<int64_t>(40 + r), elem_sort)));
     }
 
-    sink += solver.check() == camada::checkResult::SAT;
+    sink += solver.check() == camada::CheckResult::SAT;
     solver.reset();
   }
 
@@ -371,12 +371,12 @@ void benchmarkFPConstruct(camada::SMTSolver &solver, std::size_t iterations) {
     auto a_bv = solver.mkBVFromDec(static_cast<int64_t>((i & 0xffff) + 1), 32);
     auto b_bv =
         solver.mkBVFromDec(static_cast<int64_t>(((i + 3) & 0xffff) + 1), 32);
-    auto a = solver.mkSBVtoFP(a_bv, fp32, rm);
-    auto b = solver.mkUBVtoFP(b_bv, fp32, rm);
+    auto a = solver.mkSBVToFP(a_bv, fp32, rm);
+    auto b = solver.mkUBVToFP(b_bv, fp32, rm);
     auto sum = solver.mkFPAdd(a, b, rm);
     auto div =
         solver.mkFPDiv(sum, solver.mkFP32(3.5f, camada::FPEncoding::BV), rm);
-    auto integral = solver.mkFPtoIntegral(div, rm);
+    auto integral = solver.mkFPToIntegral(div, rm);
     sink += solver.mkIEEEFPToBV(integral)->getWidth();
   }
 
@@ -392,8 +392,8 @@ void benchmarkFPFromBV(camada::SMTSolver &solver, std::size_t iterations) {
     auto a_bv = solver.mkBVFromDec(static_cast<int64_t>((i & 0xffff) + 1), 32);
     auto b_bv =
         solver.mkBVFromDec(static_cast<int64_t>(((i + 3) & 0xffff) + 1), 32);
-    auto a = solver.mkSBVtoFP(a_bv, fp32, rm);
-    auto b = solver.mkUBVtoFP(b_bv, fp32, rm);
+    auto a = solver.mkSBVToFP(a_bv, fp32, rm);
+    auto b = solver.mkUBVToFP(b_bv, fp32, rm);
     sink += a->getWidth() + b->getWidth();
   }
 
@@ -403,8 +403,8 @@ void benchmarkFPFromBV(camada::SMTSolver &solver, std::size_t iterations) {
 void benchmarkFPAddOnly(camada::SMTSolver &solver, std::size_t iterations) {
   auto fp32 = solver.mkFP32Sort(camada::FPEncoding::BV);
   auto rm = solver.mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
-  auto a = solver.mkSBVtoFP(solver.mkBVFromDec(123, 32), fp32, rm);
-  auto b = solver.mkUBVtoFP(solver.mkBVFromDec(456, 32), fp32, rm);
+  auto a = solver.mkSBVToFP(solver.mkBVFromDec(123, 32), fp32, rm);
+  auto b = solver.mkUBVToFP(solver.mkBVFromDec(456, 32), fp32, rm);
   volatile std::size_t sink = 0;
 
   for (std::size_t i = 0; i < iterations; ++i)
@@ -416,8 +416,8 @@ void benchmarkFPAddOnly(camada::SMTSolver &solver, std::size_t iterations) {
 void benchmarkFPDivOnly(camada::SMTSolver &solver, std::size_t iterations) {
   auto fp32 = solver.mkFP32Sort(camada::FPEncoding::BV);
   auto rm = solver.mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
-  auto a = solver.mkSBVtoFP(solver.mkBVFromDec(123, 32), fp32, rm);
-  auto b = solver.mkUBVtoFP(solver.mkBVFromDec(456, 32), fp32, rm);
+  auto a = solver.mkSBVToFP(solver.mkBVFromDec(123, 32), fp32, rm);
+  auto b = solver.mkUBVToFP(solver.mkBVFromDec(456, 32), fp32, rm);
   auto sum = solver.mkFPAdd(a, b, rm);
   auto denom = solver.mkFP32(3.5f, camada::FPEncoding::BV);
   volatile std::size_t sink = 0;
@@ -432,15 +432,15 @@ void benchmarkFPIntegralOnly(camada::SMTSolver &solver,
                              std::size_t iterations) {
   auto fp32 = solver.mkFP32Sort(camada::FPEncoding::BV);
   auto rm = solver.mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
-  auto a = solver.mkSBVtoFP(solver.mkBVFromDec(123, 32), fp32, rm);
-  auto b = solver.mkUBVtoFP(solver.mkBVFromDec(456, 32), fp32, rm);
+  auto a = solver.mkSBVToFP(solver.mkBVFromDec(123, 32), fp32, rm);
+  auto b = solver.mkUBVToFP(solver.mkBVFromDec(456, 32), fp32, rm);
   auto sum = solver.mkFPAdd(a, b, rm);
   auto div =
       solver.mkFPDiv(sum, solver.mkFP32(3.5f, camada::FPEncoding::BV), rm);
   volatile std::size_t sink = 0;
 
   for (std::size_t i = 0; i < iterations; ++i)
-    sink += solver.mkFPtoIntegral(div, rm)->getWidth();
+    sink += solver.mkFPToIntegral(div, rm)->getWidth();
 
   (void)sink;
 }
@@ -449,12 +449,12 @@ void benchmarkFPIEEEToBVOnly(camada::SMTSolver &solver,
                              std::size_t iterations) {
   auto fp32 = solver.mkFP32Sort(camada::FPEncoding::BV);
   auto rm = solver.mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
-  auto a = solver.mkSBVtoFP(solver.mkBVFromDec(123, 32), fp32, rm);
-  auto b = solver.mkUBVtoFP(solver.mkBVFromDec(456, 32), fp32, rm);
+  auto a = solver.mkSBVToFP(solver.mkBVFromDec(123, 32), fp32, rm);
+  auto b = solver.mkUBVToFP(solver.mkBVFromDec(456, 32), fp32, rm);
   auto sum = solver.mkFPAdd(a, b, rm);
   auto div =
       solver.mkFPDiv(sum, solver.mkFP32(3.5f, camada::FPEncoding::BV), rm);
-  auto integral = solver.mkFPtoIntegral(div, rm);
+  auto integral = solver.mkFPToIntegral(div, rm);
   volatile std::size_t sink = 0;
 
   for (std::size_t i = 0; i < iterations; ++i)
@@ -466,7 +466,7 @@ void benchmarkFPIEEEToBVOnly(camada::SMTSolver &solver,
 void benchmarkFPSqrtOnly(camada::SMTSolver &solver, std::size_t iterations) {
   auto fp32 = solver.mkFP32Sort(camada::FPEncoding::BV);
   auto rm = solver.mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
-  auto a = solver.mkUBVtoFP(solver.mkBVFromDec(456, 32), fp32, rm);
+  auto a = solver.mkUBVToFP(solver.mkBVFromDec(456, 32), fp32, rm);
   volatile std::size_t sink = 0;
 
   for (std::size_t i = 0; i < iterations; ++i)
@@ -478,8 +478,8 @@ void benchmarkFPSqrtOnly(camada::SMTSolver &solver, std::size_t iterations) {
 void benchmarkFPFMAOnly(camada::SMTSolver &solver, std::size_t iterations) {
   auto fp32 = solver.mkFP32Sort(camada::FPEncoding::BV);
   auto rm = solver.mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
-  auto x = solver.mkSBVtoFP(solver.mkBVFromDec(123, 32), fp32, rm);
-  auto y = solver.mkUBVtoFP(solver.mkBVFromDec(456, 32), fp32, rm);
+  auto x = solver.mkSBVToFP(solver.mkBVFromDec(123, 32), fp32, rm);
+  auto y = solver.mkUBVToFP(solver.mkBVFromDec(456, 32), fp32, rm);
   auto z = solver.mkFP32(1.25f, camada::FPEncoding::BV);
   volatile std::size_t sink = 0;
 
@@ -492,8 +492,8 @@ void benchmarkFPFMAOnly(camada::SMTSolver &solver, std::size_t iterations) {
 void benchmarkFPRemOnly(camada::SMTSolver &solver, std::size_t iterations) {
   auto fp32 = solver.mkFP32Sort(camada::FPEncoding::BV);
   auto rm = solver.mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
-  auto x = solver.mkSBVtoFP(solver.mkBVFromDec(123, 32), fp32, rm);
-  auto y = solver.mkUBVtoFP(solver.mkBVFromDec(456, 32), fp32, rm);
+  auto x = solver.mkSBVToFP(solver.mkBVFromDec(123, 32), fp32, rm);
+  auto y = solver.mkUBVToFP(solver.mkBVFromDec(456, 32), fp32, rm);
   volatile std::size_t sink = 0;
 
   for (std::size_t i = 0; i < iterations; ++i)
@@ -521,7 +521,7 @@ void benchmarkFPSolveAdd(camada::SMTSolver &solver, std::size_t iterations) {
     auto lhs = solver.mkFPAdd(x, y, rm);
     auto rhs = solver.mkFPAdd(y, x, rm);
     solver.addConstraint(solver.mkNot(solver.mkEqual(lhs, rhs)));
-    sink += solver.check() == camada::checkResult::UNSAT;
+    sink += solver.check() == camada::CheckResult::UNSAT;
     solver.reset();
   }
 
@@ -543,7 +543,7 @@ void benchmarkFPSolveFMA(camada::SMTSolver &solver, std::size_t iterations) {
     auto lhs = solver.mkFPFMA(x, y, z, rm);
     auto rhs = solver.mkFPFMA(y, x, z, rm);
     solver.addConstraint(solver.mkNot(solver.mkEqual(lhs, rhs)));
-    sink += solver.check() == camada::checkResult::UNSAT;
+    sink += solver.check() == camada::CheckResult::UNSAT;
     solver.reset();
   }
 
@@ -567,7 +567,7 @@ void benchmarkFPSolveSqrt(camada::SMTSolver &solver, std::size_t iterations) {
     solver.addConstraint(solver.mkFPLe(x, y));
     solver.addConstraint(solver.mkNot(
         solver.mkFPLe(solver.mkFPSqrt(x, rm), solver.mkFPSqrt(y, rm))));
-    sink += solver.check() == camada::checkResult::UNSAT;
+    sink += solver.check() == camada::CheckResult::UNSAT;
     solver.reset();
   }
 
@@ -586,7 +586,7 @@ void benchmarkFPSolveRem(camada::SMTSolver &solver, std::size_t iterations) {
     auto lhs = solver.mkFPRem(x, y);
     auto rhs = solver.mkFPRem(x, solver.mkFPNeg(y));
     solver.addConstraint(solver.mkNot(solver.mkEqual(lhs, rhs)));
-    sink += solver.check() == camada::checkResult::UNSAT;
+    sink += solver.check() == camada::CheckResult::UNSAT;
     solver.reset();
   }
 

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -222,7 +222,7 @@ TEST_CASE("Unsat-assumption opt-in Bitwuzla test", "[Bitwuzla]") {
   REQUIRE(solver->supports(camada::SolverFeature::UnsatAssumptions));
   auto a = solver->mkSymbol("a", solver->mkBoolSort());
   REQUIRE(solver->checkSatAssuming({a, solver->mkNot(a)}) ==
-          camada::checkResult::UNSAT);
+          camada::CheckResult::UNSAT);
   auto core = solver->getUnsatAssumptions();
   REQUIRE(core);
   REQUIRE(!core.value().empty());

--- a/regression/bvconformance.test.h
+++ b/regression/bvconformance.test.h
@@ -124,7 +124,7 @@ inline void bv_conformance_semantics(const camada::SMTSolverRef &solver) {
       }
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Comparisons, over every operand pair.
@@ -147,7 +147,7 @@ inline void bv_conformance_semantics(const camada::SMTSolverRef &solver) {
       }
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Unary operations and the width-changing ones, over every value.
@@ -172,11 +172,11 @@ inline void bv_conformance_semantics(const camada::SMTSolverRef &solver) {
       // Extensions preserve the value under their own signedness.
       All = solver->mkAnd(
           All, solver->mkEqual(
-                   solver->mkBVZeroExt(4, C(A)),
+                   solver->mkBVZeroExt(C(A), 4),
                    solver->mkBVFromBin(bvBits(A, 8), solver->mkBVSort(8))));
       All = solver->mkAnd(
           All, solver->mkEqual(
-                   solver->mkBVSignExt(4, C(A)),
+                   solver->mkBVSignExt(C(A), 4),
                    solver->mkBVFromBin(bvBits((uint64_t)sval(A) & 0xff, 8),
                                        solver->mkBVSort(8))));
       // Extract of the whole width is the identity; concat doubles it.
@@ -188,7 +188,7 @@ inline void bv_conformance_semantics(const camada::SMTSolverRef &solver) {
                                                    solver->mkBVSort(8))));
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Overflow predicates, over every operand pair. Each is true exactly
@@ -220,7 +220,7 @@ inline void bv_conformance_semantics(const camada::SMTSolverRef &solver) {
                                                B(sval(A) == SMin)));
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 }
 
@@ -251,7 +251,7 @@ inline void fxp_gap_conformance(const camada::SMTSolverRef &solver) {
                              solver->mkBool(Trunc < -2 || Trunc > 1)));
   }
   solver->addConstraint(All);
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 } // namespace camada_bv_conformance

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -226,7 +226,7 @@ TEST_CASE("Unsat-assumption opt-in CVC5 test", "[CVC5]") {
   REQUIRE(solver->supports(camada::SolverFeature::UnsatAssumptions));
   auto a = solver->mkSymbol("a", solver->mkBoolSort());
   REQUIRE(solver->checkSatAssuming({a, solver->mkNot(a)}) ==
-          camada::checkResult::UNSAT);
+          camada::CheckResult::UNSAT);
   auto core = solver->getUnsatAssumptions();
   REQUIRE(core);
   REQUIRE(!core.value().empty());

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -23,7 +23,11 @@ TEST_CASE("Camada tuples via config CVC5 test", "[CVC5]") {
   camada::SolverConfig Cfg;
   Cfg.Tuples = camada::TupleEncoding::Camada;
   auto cvc5 = camada::createCVC5Solver(Cfg);
-  REQUIRE_FALSE(cvc5->supports(camada::SolverFeature::NativeTuples));
+  // supports() reports the backend capability, so cvc5 still claims native
+  // datatypes here; tupleMode() is what says this instance will not use
+  // them.
+  REQUIRE(cvc5->supports(camada::SolverFeature::NativeTuples));
+  REQUIRE(cvc5->tupleMode() == camada::TupleEncoding::Camada);
   tuple_semantics(cvc5);
   cvc5->reset();
   tuple_with_array_field(cvc5);

--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -30,7 +30,7 @@ inline void fp_native_bv_predicate_parity(const camada::SMTSolverRef &solver) {
 
     REQUIRE(native_pred->getKind() == bv_pred->getKind());
     solver->addConstraint(solver->mkNot(solver->mkEqual(native_pred, bv_pred)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   };
 
   check_predicate("is_nan", [&](const camada::SMTExprRef &fp) {
@@ -43,7 +43,7 @@ inline void fp_native_bv_predicate_parity(const camada::SMTSolverRef &solver) {
     return solver->mkFPIsZero(fp);
   });
   check_predicate("is_denormal", [&](const camada::SMTExprRef &fp) {
-    return solver->mkFPIsDenormal(fp);
+    return solver->mkFPIsSubnormal(fp);
   });
   check_predicate("is_normal", [&](const camada::SMTExprRef &fp) {
     return solver->mkFPIsNormal(fp);
@@ -84,7 +84,7 @@ inline void fp_neg_nan_native_bv_parity(const camada::SMTSolverRef &solver) {
     INFO(name);
     solver->addConstraint(
         solver->mkNot(solver->mkEqual(native_neg, expected_native)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
     solver->reset();
     bits = solver->mkSymbol(name + "_bits_bv_expected", solver->mkBVSort(32));
@@ -100,7 +100,7 @@ inline void fp_neg_nan_native_bv_parity(const camada::SMTSolverRef &solver) {
             : solver->mkIte(solver->mkFPIsNaN(bv_fp), bits, flipped_bits);
     expected_bv = solver->mkBVToIEEEFP(expected_bits, bv_fp->Sort);
     solver->addConstraint(solver->mkNot(solver->mkEqual(bv_neg, expected_bv)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   };
 
   check_neg("fp_neg_flip_sign", camada::FPNegBehavior::FlipSignBit);
@@ -118,7 +118,7 @@ inline void fp_infinity_model_value(const camada::SMTSolverRef &solver,
   // SigWidth here counts the hidden bit (FP32 = 8 + 24).
   solver->addConstraint(
       solver->mkEqual(x, solver->mkInf(false, 8, 24, Encoding)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto bin = solver->getFPInBin(x);
   REQUIRE(bin);
@@ -134,7 +134,7 @@ inline void fp_nan_model_value(const camada::SMTSolverRef &solver,
   auto fp32 = solver->mkFP32Sort(Encoding);
   auto x = solver->mkSymbol("x", fp32);
   solver->addConstraint(solver->mkFPIsNaN(x));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto bin = solver->getFPInBin(x);
   REQUIRE(bin);
@@ -173,7 +173,7 @@ fp_neg_flip_nan_via_bv_round_trip(const camada::SMTSolverRef &solver,
   auto n_rest = solver->mkBVExtract(30, 0, negged_bits);
   solver->addConstraint(solver->mkEqual(n_rest, x_rest));
 
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void fp_arithmetics(const camada::SMTSolverRef &solver,
@@ -246,7 +246,7 @@ inline void fp_arithmetics(const camada::SMTSolverRef &solver,
   solver->addConstraint(fma_eq);
 
   // And check for satisfiability
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void fp_round_to_away(const camada::SMTSolverRef &solver,
@@ -276,7 +276,7 @@ inline void fp_round_to_away(const camada::SMTSolverRef &solver,
 
   solver->addConstraint(solver->mkEqual(even_sum, even_expected));
   solver->addConstraint(solver->mkEqual(away_sum, away_expected));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void fp_bv_conversions(const camada::SMTSolverRef &solver,
@@ -288,8 +288,8 @@ inline void fp_bv_conversions(const camada::SMTSolverRef &solver,
   REQUIRE(rtz->getKind() == camada::SMTExprKind::RMConst);
   REQUIRE(all_ones->getKind() == camada::SMTExprKind::BVConst);
 
-  auto signed_fp = solver->mkSBVtoFP(all_ones, fp32, rtz);
-  auto unsigned_fp = solver->mkUBVtoFP(all_ones, fp32, rtz);
+  auto signed_fp = solver->mkSBVToFP(all_ones, fp32, rtz);
+  auto unsigned_fp = solver->mkUBVToFP(all_ones, fp32, rtz);
   REQUIRE(signed_fp->getKind() == camada::SMTExprKind::SBVtoFP);
   REQUIRE(unsigned_fp->getKind() == camada::SMTExprKind::UBVtoFP);
 
@@ -298,15 +298,15 @@ inline void fp_bv_conversions(const camada::SMTSolverRef &solver,
   solver->addConstraint(solver->mkEqual(signed_fp, minus_one));
   solver->addConstraint(solver->mkEqual(unsigned_fp, two_fifty_five));
 
-  auto signed_bv = solver->mkFPtoSBV(signed_fp, 8);
-  auto unsigned_bv = solver->mkFPtoUBV(unsigned_fp, 8);
+  auto signed_bv = solver->mkFPToSBV(signed_fp, 8);
+  auto unsigned_bv = solver->mkFPToUBV(unsigned_fp, 8);
   REQUIRE(signed_bv->getKind() == camada::SMTExprKind::FPtoSBV);
   REQUIRE(unsigned_bv->getKind() == camada::SMTExprKind::FPtoUBV);
 
   solver->addConstraint(solver->mkEqual(signed_bv, all_ones));
   solver->addConstraint(solver->mkEqual(unsigned_bv, all_ones));
 
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Regression for the ESBMC fp.to_ieee_bv round-trip report: bit-exact
@@ -325,7 +325,7 @@ inline void fp_ieee_bv_bitexact_roundtrip(const camada::SMTSolverRef &solver,
     auto f = solver->mkBVToIEEEFP(b, fp32());
     solver->addConstraint(
         solver->mkNot(solver->mkEqual(solver->mkIEEEFPToBV(f), b)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
   solver->reset();
 
@@ -362,7 +362,7 @@ inline void fp_ieee_bv_bitexact_roundtrip(const camada::SMTSolverRef &solver,
     auto finalBits = solver->mkIEEEFPToBV(f);
     solver->addConstraint(solver->mkNot(
         solver->mkEqual(byteAt(finalBits, 0), solver->mkBVFromDec(0xDB, 8))));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
   solver->reset();
 
@@ -378,7 +378,7 @@ inline void fp_ieee_bv_bitexact_roundtrip(const camada::SMTSolverRef &solver,
     solver->pop();
     solver->addConstraint(
         solver->mkNot(solver->mkEqual(solver->mkIEEEFPToBV(g), pat)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 }
 
@@ -402,7 +402,7 @@ inline void fp_ieee_bv_consistency(const camada::SMTSolverRef &solver,
     auto by = solver->mkIEEEFPToBV(y);
     auto bz = solver->mkIEEEFPToBV(z);
     solver->addConstraint(solver->mkNot(solver->mkEqual(by, bz)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
   solver->reset();
 
@@ -412,7 +412,7 @@ inline void fp_ieee_bv_consistency(const camada::SMTSolverRef &solver,
     auto b1 = solver->mkIEEEFPToBV(f);
     auto b2 = solver->mkIEEEFPToBV(f);
     solver->addConstraint(solver->mkNot(solver->mkEqual(b1, b2)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
   solver->reset();
 
@@ -424,7 +424,7 @@ inline void fp_ieee_bv_consistency(const camada::SMTSolverRef &solver,
     auto bits = solver->mkIEEEFPToBV(f);
     solver->addConstraint(solver->mkNot(
         solver->mkEqual(bits, solver->mkBVFromDec(0x3FC00000, 32))));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 
@@ -447,7 +447,7 @@ inline void fp_ieee_bv_sort_identity(const camada::SMTSolverRef &solver,
   auto ibv = solver->mkSymbol("ibv_i", solver->mkBVSort(32));
   solver->addConstraint(solver->mkEqual(bits, ibv));
   solver->addConstraint(solver->mkEqual(fp, solver->mkFP32(1.5f, Encoding)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto v = solver->getBVInBin(ibv);
   REQUIRE(v);
   REQUIRE(v.value() == "00111111110000000000000000000000"); // 1.5f
@@ -456,32 +456,32 @@ inline void fp_ieee_bv_sort_identity(const camada::SMTSolverRef &solver,
 inline void fp_to_signed_bv_multiple_widths(const camada::SMTSolverRef &solver,
                                             camada::FPEncoding Encoding) {
   auto fp = solver->mkFP32(42.0f, Encoding);
-  auto sbv32 = solver->mkFPtoSBV(fp, 32);
+  auto sbv32 = solver->mkFPToSBV(fp, 32);
 
   REQUIRE(fp->getKind() == camada::SMTExprKind::FPConst);
   REQUIRE(sbv32->getKind() == camada::SMTExprKind::FPtoSBV);
 
   solver->addConstraint(solver->mkEqual(sbv32, solver->mkBVFromDec(42, 32)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   solver->reset();
   fp = solver->mkFP32(42.0f, Encoding);
-  auto sbv64 = solver->mkFPtoSBV(fp, 64);
+  auto sbv64 = solver->mkFPToSBV(fp, 64);
   REQUIRE(fp->getKind() == camada::SMTExprKind::FPConst);
   REQUIRE(sbv64->getKind() == camada::SMTExprKind::FPtoSBV);
   solver->addConstraint(solver->mkEqual(sbv64, solver->mkBVFromDec(42, 64)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   solver->reset();
   fp = solver->mkFP32(42.0f, Encoding);
-  sbv32 = solver->mkFPtoSBV(fp, 32);
-  sbv64 = solver->mkFPtoSBV(fp, 64);
+  sbv32 = solver->mkFPToSBV(fp, 32);
+  sbv64 = solver->mkFPToSBV(fp, 64);
   REQUIRE(fp->getKind() == camada::SMTExprKind::FPConst);
   REQUIRE(sbv32->getKind() == camada::SMTExprKind::FPtoSBV);
   REQUIRE(sbv64->getKind() == camada::SMTExprKind::FPtoSBV);
   solver->addConstraint(solver->mkEqual(sbv32, solver->mkBVFromDec(42, 32)));
   solver->addConstraint(solver->mkEqual(sbv64, solver->mkBVFromDec(42, 64)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Width 1 is the degenerate signed target: its range is [-1, 0], so 0
   // converts and -1 converts, while 42 is out of range. The BV encoding
@@ -491,10 +491,10 @@ inline void fp_to_signed_bv_multiple_widths(const camada::SMTSolverRef &solver,
   auto zero = solver->mkFP32(0.0f, Encoding);
   auto neg_one = solver->mkFP32(-1.0f, Encoding);
   solver->addConstraint(
-      solver->mkEqual(solver->mkFPtoSBV(zero, 1), solver->mkBVFromDec(0, 1)));
-  solver->addConstraint(solver->mkEqual(solver->mkFPtoSBV(neg_one, 1),
+      solver->mkEqual(solver->mkFPToSBV(zero, 1), solver->mkBVFromDec(0, 1)));
+  solver->addConstraint(solver->mkEqual(solver->mkFPToSBV(neg_one, 1),
                                         solver->mkBVFromDec(1, 1)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void fp_denormal_round_to_integral(const camada::SMTSolverRef &solver,
@@ -506,8 +506,8 @@ inline void fp_denormal_round_to_integral(const camada::SMTSolverRef &solver,
   auto rtp = solver->mkRM(camada::RM::ROUND_TO_PLUS_INF, Encoding);
   auto rtn = solver->mkRM(camada::RM::ROUND_TO_MINUS_INF, Encoding);
 
-  auto pos_rounded = solver->mkFPtoIntegral(pos_denorm, rtp);
-  auto neg_rounded = solver->mkFPtoIntegral(neg_denorm, rtn);
+  auto pos_rounded = solver->mkFPToIntegral(pos_denorm, rtp);
+  auto neg_rounded = solver->mkFPToIntegral(neg_denorm, rtn);
 
   REQUIRE(pos_denorm->getKind() == camada::SMTExprKind::FPConst);
   REQUIRE(neg_denorm->getKind() == camada::SMTExprKind::FPConst);
@@ -521,7 +521,7 @@ inline void fp_denormal_round_to_integral(const camada::SMTSolverRef &solver,
   solver->addConstraint(
       solver->mkEqual(neg_rounded, solver->mkFP32(-1.0f, Encoding)));
 
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void fp_div_overflow_to_inf(const camada::SMTSolverRef &solver,
@@ -541,7 +541,7 @@ inline void fp_div_overflow_to_inf(const camada::SMTSolverRef &solver,
   solver->addConstraint(solver->mkEqual(
       div, solver->mkFP32(std::numeric_limits<float>::infinity(), Encoding)));
 
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void fp_remainder_semantics(const camada::SMTSolverRef &solver,
@@ -559,7 +559,7 @@ inline void fp_remainder_semantics(const camada::SMTSolverRef &solver,
 
   solver->addConstraint(solver->mkEqual(rem, expected));
 
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Checks one concrete fp.rem result against the host CPU, which computes
@@ -579,7 +579,7 @@ inline void check_rem_pair_f32(const camada::SMTSolverRef &solver,
   else
     solver->addConstraint(
         solver->mkEqual(rem, solver->mkFP32(Expected, Encoding)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void check_rem_pair_f64(const camada::SMTSolverRef &solver,
@@ -596,7 +596,7 @@ inline void check_rem_pair_f64(const camada::SMTSolverRef &solver,
   else
     solver->addConstraint(
         solver->mkEqual(rem, solver->mkFP64(Expected, Encoding)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Multiply and divide against the host CPU, on subnormal operands.
@@ -647,7 +647,7 @@ inline void fp_muldiv_subnormal_host_oracle(const camada::SMTSolverRef &solver,
       INFO((IsDiv ? "div(" : "mul(") << X << ", " << Y << ") want " << Want);
       solver->addConstraint(solver->mkNot(solver->mkEqual(
           solver->mkIEEEFPToBV(got), solver->mkIEEEFPToBV(want))));
-      REQUIRE(solver->check() == camada::checkResult::UNSAT);
+      REQUIRE(solver->check() == camada::CheckResult::UNSAT);
     }
   }
 }
@@ -678,8 +678,8 @@ inline void fp_tointegral_large_values_bv(const camada::SMTSolverRef &solver) {
     auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, Encoding);
     INFO("binary16 toIntegral(" << Bits << ")");
     solver->addConstraint(
-        solver->mkNot(solver->mkFPEqual(solver->mkFPtoIntegral(x, rm), x)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+        solver->mkNot(solver->mkFPEqual(solver->mkFPToIntegral(x, rm), x)));
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 
@@ -692,8 +692,8 @@ inline void fp_tointegral_large_values(const camada::SMTSolverRef &solver,
     auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, Encoding);
     INFO("binary32 toIntegral(" << V << ")");
     solver->addConstraint(
-        solver->mkNot(solver->mkFPEqual(solver->mkFPtoIntegral(x, rm), x)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+        solver->mkNot(solver->mkFPEqual(solver->mkFPToIntegral(x, rm), x)));
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 
@@ -730,7 +730,7 @@ inline void fp_fma_host_oracle(const camada::SMTSolverRef &solver,
     auto want = solver->mkFP32(std::fma(X, Y, Z), Encoding);
     INFO("fma(" << X << ", " << Y << ", " << Z << ")");
     solver->addConstraint(solver->mkNot(solver->mkFPEqual(got, want)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 
@@ -805,7 +805,7 @@ inline void fp_non_standard_widths(const camada::SMTSolverRef &solver,
   REQUIRE(add->getKind() == camada::SMTExprKind::FPAdd);
 
   solver->addConstraint(solver->mkEqual(add, two));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void
@@ -820,7 +820,7 @@ fp_cancellation_and_normalization(const camada::SMTSolverRef &solver,
   auto eq = solver->mkEqual(sub, solver->mkFP32(1.0000001f - 1.0f, Encoding));
   solver->addConstraint(eq);
   solver->addConstraint(solver->mkFPIsNormal(sub));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Wide formats previously hit undefined behavior in the BV encoding's
@@ -849,7 +849,7 @@ inline void fp_wide_format_semantics(const camada::SMTSolverRef &solver) {
     auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
     solver->addConstraint(
         solver->mkNot(solver->mkEqual(solver->mkFPAdd(one, one, rm), two)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
     solver->reset();
   }
 
@@ -860,6 +860,6 @@ inline void fp_wide_format_semantics(const camada::SMTSolverRef &solver) {
     auto rm = solver->mkRM(camada::RM::ROUND_TO_EVEN, camada::FPEncoding::BV);
     solver->addConstraint(
         solver->mkNot(solver->mkEqual(solver->mkFPSqrt(four, rm), two)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }

--- a/regression/fpconformance.test.h
+++ b/regression/fpconformance.test.h
@@ -93,7 +93,7 @@ inline void fp_conformance_semantics(const camada::SMTSolverRef &solver,
       }
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // The properties that make those semantics distinctive, asserted
@@ -113,7 +113,7 @@ inline void fp_conformance_semantics(const camada::SMTSolverRef &solver,
     All = solver->mkAnd(All, solver->mkFPLe(PZero, NZero));
     All = solver->mkAnd(All, solver->mkNot(solver->mkFPLt(PZero, NZero)));
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Absolute value clears the sign, including on infinities; on NaN the
@@ -130,7 +130,7 @@ inline void fp_conformance_semantics(const camada::SMTSolverRef &solver,
         All = solver->mkAnd(All, solver->mkFPEqual(Abs, C(std::fabs(A))));
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // The NaN and infinity constructors agree with the same values built
@@ -151,7 +151,7 @@ inline void fp_conformance_semantics(const camada::SMTSolverRef &solver,
     All =
         solver->mkAnd(All, solver->mkFPIsInfinite(solver->mkInf64(true, Enc)));
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Widening float to double is exact, so converting and comparing
@@ -162,7 +162,7 @@ inline void fp_conformance_semantics(const camada::SMTSolverRef &solver,
     camada::SMTExprRef RNE = solver->mkRM(camada::RM::ROUND_TO_EVEN, Enc);
     camada::SMTExprRef All = solver->mkBool(true);
     for (float A : Vals) {
-      camada::SMTExprRef Wide = solver->mkFPtoFP(C(A), F64, RNE);
+      camada::SMTExprRef Wide = solver->mkFPToFP(C(A), F64, RNE);
       if (std::isnan(A)) {
         All = solver->mkAnd(All, solver->mkFPIsNaN(Wide));
         continue;
@@ -171,7 +171,7 @@ inline void fp_conformance_semantics(const camada::SMTSolverRef &solver,
       All = solver->mkAnd(All, solver->mkFPEqual(Wide, Want));
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 }
 

--- a/regression/fxp.test.h
+++ b/regression/fxp.test.h
@@ -208,7 +208,7 @@ inline void requireAllHold(const camada::SMTSolverRef &S,
   for (std::size_t I = 1; I < Conjuncts.size(); ++I)
     All = S->mkAnd(All, Conjuncts[I]);
   S->addConstraint(All);
-  REQUIRE(S->check() == camada::checkResult::SAT);
+  REQUIRE(S->check() == camada::CheckResult::SAT);
 }
 
 inline camada::SMTExprRef boolIs(const camada::SMTSolverRef &S,
@@ -301,7 +301,7 @@ fxp_boundary_overflow_semantics(const camada::SMTSolverRef &solver) {
     camada::SMTExprRef A = mkConst(solver, F, 89);
     camada::SMTExprRef B = mkConst(solver, F, 23);
     solver->addConstraint(solver->mkFXPMulOverflow(A, B));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     solver->reset();
     A = mkConst(solver, F, 89);
     B = mkConst(solver, F, 23);
@@ -309,7 +309,7 @@ fxp_boundary_overflow_semantics(const camada::SMTSolverRef &solver) {
     solver->addConstraint(solver->mkFXPEqual(
         solver->mkFXPMul(A, B, camada::FXPRM::TowardNegative),
         mkConst(solver, F, 127)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
   // 127 * 16 = 2032 = max*16 exactly: representable, NOT an overflow.
   {
@@ -317,7 +317,7 @@ fxp_boundary_overflow_semantics(const camada::SMTSolverRef &solver) {
     camada::SMTExprRef A = mkConst(solver, F, 127);
     camada::SMTExprRef B = mkConst(solver, F, 16);
     solver->addConstraint(solver->mkFXPMulOverflow(A, B));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
   // Division analog: 127/16 divided by 63/64... pick raws A=127, B=15:
   // exact = 127*16/15 = 135.4667 > 127 => overflow, truncation would give
@@ -326,11 +326,11 @@ fxp_boundary_overflow_semantics(const camada::SMTSolverRef &solver) {
     solver->reset();
     camada::SMTExprRef A = mkConst(solver, F, 127);
     solver->addConstraint(solver->mkFXPDivOverflow(A, mkConst(solver, F, 15)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     solver->reset();
     A = mkConst(solver, F, 127);
     solver->addConstraint(solver->mkFXPDivOverflow(A, mkConst(solver, F, 16)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 
@@ -367,7 +367,7 @@ inline void fxp_rounding_semantics(const camada::SMTSolverRef &solver) {
   camada::SMTExprRef AsInt =
       solver->mkFXPToBV(MinusOneHalf, 8, camada::FXPRM::TowardZero);
   solver->addConstraint(solver->mkEqual(AsInt, solver->mkBVFromDec(-1, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Fixed -> fixed narrowing floors: -1.75 in Q3.4 (raw -28) into Q6.1 is
   // exactly -3.5 at one fraction bit, which floors to raw -4 = -2.0 — the
@@ -379,7 +379,7 @@ inline void fxp_rounding_semantics(const camada::SMTSolverRef &solver) {
       MinusOneQ3, mkSort(solver, Narrow), camada::FXPRM::TowardNegative);
   solver->addConstraint(solver->mkFXPEqual(
       Converted, mkConst(solver, Narrow, uint64_t(-4) & 0xFF)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Conversion matrix across widths, fraction splits, and signedness —
@@ -417,7 +417,7 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
     camada::SMTExprRef V = mkConst(solver, U, 8);
     solver->addConstraint(solver->mkFXPToFXPOverflow(
         V, mkSort(solver, S4), camada::FXPRM::TowardNegative));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Negative into unsigned: overflow.
@@ -427,7 +427,7 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
     camada::SMTExprRef V = mkConst(solver, S4, uint64_t(-1) & 0xF);
     solver->addConstraint(solver->mkFXPToFXPOverflow(
         V, mkSort(solver, U), camada::FXPRM::TowardNegative));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Wide formats (past 64 bits, 128-bit-plus intermediates): widening a
@@ -439,14 +439,14 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
     camada::SMTExprRef X = solver->mkSymbol("fxp_wide_x", WideSrc);
     solver->addConstraint(
         solver->mkFXPToFXPOverflow(X, WideDst, camada::FXPRM::TowardNegative));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
     solver->reset();
     WideSrc = solver->mkFXPSort(70, 35, true);
     WideDst = solver->mkFXPSort(140, 70, true);
     X = solver->mkSymbol("fxp_wide_x", WideSrc);
     solver->addConstraint(solver->mkNot(solver->mkFXPEqual(
         solver->mkFXPToFXP(X, WideDst, camada::FXPRM::TowardNegative), X)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 
   // Integer bridges: mkFXPFromBV embeds exactly (round-trip through
@@ -460,7 +460,7 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
     camada::SMTExprRef Back =
         solver->mkFXPToBV(AsFXP, 8, camada::FXPRM::TowardZero);
     solver->addConstraint(solver->mkNot(solver->mkEqual(Back, I)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 
   // Source signedness governs the value: the same bits 0xFF are -1 as a
@@ -476,7 +476,7 @@ inline void fxp_conversion_matrix(const camada::SMTSolverRef &solver) {
     solver->addConstraint(
         solver->mkFXPEqual(solver->mkFXPFromBV(Bits, false, Fmt),
                            solver->mkFXPFromBin("0000111111110000", Fmt)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 }
 
@@ -495,19 +495,19 @@ inline void fxp_mixed_format_semantics(const camada::SMTSolverRef &solver) {
   REQUIRE(Sum->Sort->isFXPSignedSort());
   RefFormat Common{9, 4, true};
   solver->addConstraint(solver->mkFXPEqual(Sum, mkConst(solver, Common, 64)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Cross-format comparison: 1.25 (Q3.4) < 2.75 (U4.2).
   solver->reset();
   EA = mkConst(solver, A, 20);
   EB = mkConst(solver, B, 11);
   solver->addConstraint(solver->mkFXPLt(EA, EB));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   solver->reset();
   EA = mkConst(solver, A, 20);
   EB = mkConst(solver, B, 11);
   solver->addConstraint(solver->mkFXPGe(EA, EB));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Shifts: value semantics and the shifted-out-bits overflow predicate.
@@ -542,7 +542,7 @@ inline void fxp_model_and_constructs(const camada::SMTSolverRef &solver) {
   // Symbol + model query: x == 2.5 => getFXP(x) returns the exact raw bits.
   camada::SMTExprRef X = solver->mkSymbol("fxp_x", Fmt);
   solver->addConstraint(solver->mkFXPEqual(X, mkConst(solver, F, 40)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto Val = solver->getFXP(X);
   REQUIRE(Val);
   REQUIRE(Val.value().RawBits == refBits(F, 40));
@@ -556,7 +556,7 @@ inline void fxp_model_and_constructs(const camada::SMTSolverRef &solver) {
   camada::SMTExprRef RoundTrip =
       solver->mkFXPFromRawBV(solver->mkFXPToRawBV(X), Fmt);
   solver->addConstraint(solver->mkNot(solver->mkFXPEqual(RoundTrip, X)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // ITE over FXP values.
   solver->reset();
@@ -566,7 +566,7 @@ inline void fxp_model_and_constructs(const camada::SMTSolverRef &solver) {
       solver->mkIte(Cond, mkConst(solver, F, 16), mkConst(solver, F, 32));
   solver->addConstraint(solver->mkFXPEqual(Ite, mkConst(solver, F, 32)));
   solver->addConstraint(Cond);
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Arrays with FXP elements.
   solver->reset();
@@ -578,7 +578,7 @@ inline void fxp_model_and_constructs(const camada::SMTSolverRef &solver) {
       solver->mkArrayStore(A, Idx, mkConst(solver, F, 24));
   solver->addConstraint(solver->mkNot(solver->mkFXPEqual(
       solver->mkArraySelect(Stored, Idx), mkConst(solver, F, 24))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Push/pop: a constraint inside a scope disappears after pop.
   solver->reset();
@@ -587,9 +587,9 @@ inline void fxp_model_and_constructs(const camada::SMTSolverRef &solver) {
   solver->addConstraint(solver->mkFXPGt(X, mkConst(solver, F, 0)));
   solver->push();
   solver->addConstraint(solver->mkFXPLt(X, mkConst(solver, F, 0)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   solver->pop();
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Exhaustive 4-bit sweep of the saturating variants against the exact
@@ -751,7 +751,7 @@ inline void fxp_symbolic_shift_semantics(const camada::SMTSolverRef &solver) {
                         solver->mkEqual(solver->mkFXPShlOverflowExpr(X, KE),
                                         solver->mkFXPShlOverflow(X, K))));
       solver->addConstraint(solver->mkNot(Same));
-      REQUIRE(solver->check() == camada::checkResult::UNSAT);
+      REQUIRE(solver->check() == camada::CheckResult::UNSAT);
     }
   }
 }
@@ -852,7 +852,7 @@ inline void fxp_abs_countls_semantics(const camada::SMTSolverRef &solver) {
           All = All ? solver->mkAnd(All, C) : C;
         }
         solver->addConstraint(All);
-        REQUIRE(solver->check() == camada::checkResult::SAT);
+        REQUIRE(solver->check() == camada::CheckResult::SAT);
       }
     }
   }
@@ -865,7 +865,7 @@ inline void fxp_abs_countls_semantics(const camada::SMTSolverRef &solver) {
     RefFormat F{8, 7, true};
     solver->addConstraint(solver->mkFXPEqual(
         solver->mkFXPAbs(mkConst(solver, F, 0x80)), mkConst(solver, F, 0x7f)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Symbolic properties at a width no host sweep reaches: shifting left
@@ -880,7 +880,7 @@ inline void fxp_abs_countls_semantics(const camada::SMTSolverRef &solver) {
     camada::SMTExprRef N = solver->mkFXPCountls(X, 8);
     camada::SMTExprRef InRange = solver->mkBVUle(N, solver->mkBVFromDec(39, 8));
     solver->addConstraint(solver->mkNot(solver->mkAnd(Idem, InRange)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 
@@ -927,7 +927,7 @@ inline void fxp_exp_semantics(const camada::SMTSolverRef &solver) {
       All = All ? solver->mkAnd(All, C) : C;
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 }
 
@@ -954,7 +954,7 @@ inline void fxp_exp_exhaustive(const camada::SMTSolverRef &solver) {
         All = All ? solver->mkAnd(All, C) : C;
       }
       solver->addConstraint(All);
-      REQUIRE(solver->check() == camada::checkResult::SAT);
+      REQUIRE(solver->check() == camada::CheckResult::SAT);
     }
   }
 
@@ -975,7 +975,7 @@ inline void fxp_exp_exhaustive(const camada::SMTSolverRef &solver) {
       All = All ? solver->mkAnd(All, C) : C;
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // The wider formats are spot-checked; their exhaustive comparison
@@ -994,7 +994,7 @@ inline void fxp_exp_exhaustive(const camada::SMTSolverRef &solver) {
       All = All ? solver->mkAnd(All, C) : C;
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 }
 
@@ -1040,7 +1040,7 @@ inline void fxp_sqrt_semantics(const camada::SMTSolverRef &solver) {
           All = All ? solver->mkAnd(All, C) : C;
         }
         solver->addConstraint(All);
-        REQUIRE(solver->check() == camada::checkResult::SAT);
+        REQUIRE(solver->check() == camada::CheckResult::SAT);
       }
     }
   }
@@ -1064,7 +1064,7 @@ inline void fxp_sqrt_semantics(const camada::SMTSolverRef &solver) {
     camada::SMTExprRef R =
         solver->mkFXPSqrt(X, camada::FXPRM::NearestTiesToEven);
     auto ext = [&](const camada::SMTExprRef &E) {
-      return solver->mkBVZeroExt(Wide - W, solver->mkFXPToRawBV(E));
+      return solver->mkBVZeroExt(solver->mkFXPToRawBV(E), Wide - W);
     };
     camada::SMTExprRef Rx = ext(R), Xx = ext(X);
     camada::SMTExprRef Two = solver->mkBVFromDec(2, Wide);
@@ -1086,7 +1086,7 @@ inline void fxp_sqrt_semantics(const camada::SMTSolverRef &solver) {
         X, solver->mkFXPFromBin(refBits(RefFormat{W, N, true}, 0),
                                 solver->mkFXPSort(W, N, true))));
     solver->addConstraint(solver->mkAnd(NonNeg, solver->mkNot(Holds)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 
   // Negative operands: the result is pinned to zero rather than left as
@@ -1105,7 +1105,7 @@ inline void fxp_sqrt_semantics(const camada::SMTSolverRef &solver) {
       All = All ? solver->mkAnd(All, C) : C;
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 }
 
@@ -1134,7 +1134,7 @@ inline void fxp_round_semantics(const camada::SMTSolverRef &solver) {
               All = All ? solver->mkAnd(All, C) : C;
             }
             solver->addConstraint(All);
-            REQUIRE(solver->check() == camada::checkResult::SAT);
+            REQUIRE(solver->check() == camada::CheckResult::SAT);
           }
         }
       }
@@ -1190,7 +1190,7 @@ inline void fxp_round_semantics(const camada::SMTSolverRef &solver) {
          {FXPRM::TowardZero, FXPRM::TowardNegative, FXPRM::TowardPositive})
       All = solver->mkAnd(All, solver->mkFXPEqual(R(16, 0, M), C(16)));
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // LLVM libc's own RoundTest vectors, on _Fract (s.15). EPS is one ulp.
@@ -1224,7 +1224,7 @@ inline void fxp_round_semantics(const camada::SMTSolverRef &solver) {
       All = All ? solver->mkAnd(All, C) : C;
     }
     solver->addConstraint(All);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Symbolic properties at a width no host sweep reaches: rounding to the
@@ -1249,7 +1249,7 @@ inline void fxp_round_semantics(const camada::SMTSolverRef &solver) {
                         solver->mkBVFromDec(0, 8)),
         solver->mkFXPEqual(R, Max));
     solver->addConstraint(solver->mkNot(solver->mkAnd(Id, Low)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 
@@ -1277,7 +1277,7 @@ inline void fxp_fp_conversion_semantics(const camada::SMTSolverRef &solver,
         solver->mkFXPToFP(X, Half, camada::RM::ROUND_TO_EVEN);
     solver->addConstraint(solver->mkEqual(solver->mkIEEEFPToBV(R),
                                           solver->mkBVFromDec(0x0301, 16)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Overflow predicate boundaries and the toward-zero direction, s.15
@@ -1313,7 +1313,7 @@ inline void fxp_fp_conversion_semantics(const camada::SMTSolverRef &solver,
             solver->mkFXPFromBin(refBits(RefFormat{16, 15, true}, 0xa667),
                                  To)));
     solver->addConstraint(Ok);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Oracle-pinned vectors on the standard formats, run under BOTH
@@ -1375,7 +1375,7 @@ inline void fxp_fp_conversion_semantics(const camada::SMTSolverRef &solver,
                                        S15)));
     }
     solver->addConstraint(Ok);
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Symbolic round-trip: every s.7 value is exactly representable in
@@ -1391,7 +1391,7 @@ inline void fxp_fp_conversion_semantics(const camada::SMTSolverRef &solver,
         solver->mkNot(solver->mkFXPEqual(
             solver->mkFPToFXP(F, Fmt, camada::FXPRM::TowardZero), X)),
         solver->mkFPToFXPOverflow(F, Fmt, camada::FXPRM::TowardZero)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 

--- a/regression/fxporacle.test.h
+++ b/regression/fxporacle.test.h
@@ -48,7 +48,7 @@ inline void checkVectorsChunked(const camada::SMTSolverRef &S,
       All = All ? S->mkAnd(All, C) : C;
     }
     S->addConstraint(All);
-    REQUIRE(S->check() == camada::checkResult::SAT);
+    REQUIRE(S->check() == camada::CheckResult::SAT);
   }
 }
 

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Config logic MathSAT test", "[MathSAT]") {
   auto mathsat = camada::createMathSATSolver(Cfg);
   auto x = mathsat->mkSymbol("x", mathsat->mkBVSort(8));
   mathsat->addConstraint(mathsat->mkEqual(x, mathsat->mkBVFromDec(7, 8)));
-  REQUIRE(mathsat->check() == camada::checkResult::SAT);
+  REQUIRE(mathsat->check() == camada::CheckResult::SAT);
 }
 
 TEST_CASE("Ackermann arrays MathSAT test", "[MathSAT]") {
@@ -116,7 +116,7 @@ TEST_CASE("MathSAT reset reuses symbol names across sort changes",
   auto eight = mathsat->mkBVFromDec(8, 8);
   auto x_bv = mathsat->mkSymbol("x", mathsat->mkBVSort(8));
   mathsat->addConstraint(mathsat->mkEqual(x_bv, eight));
-  REQUIRE(mathsat->check() == camada::checkResult::SAT);
+  REQUIRE(mathsat->check() == camada::CheckResult::SAT);
   auto x_bv_res = mathsat->getBV(x_bv);
   REQUIRE(x_bv_res);
   REQUIRE(x_bv_res.value() == 8);
@@ -125,7 +125,7 @@ TEST_CASE("MathSAT reset reuses symbol names across sort changes",
 
   auto x_bool = mathsat->mkSymbol("x", mathsat->mkBoolSort());
   mathsat->addConstraint(x_bool);
-  REQUIRE(mathsat->check() == camada::checkResult::SAT);
+  REQUIRE(mathsat->check() == camada::CheckResult::SAT);
   auto x_bool_res = mathsat->getBool(x_bool);
   REQUIRE(x_bool_res);
   REQUIRE(x_bool_res.value());
@@ -136,7 +136,7 @@ TEST_CASE("MathSAT solver recreation reuses symbol names", "[MathSAT]") {
     auto mathsat = camada::createMathSATSolver();
     auto x_bv = mathsat->mkSymbol("x", mathsat->mkBVSort(4));
     mathsat->addConstraint(mathsat->mkEqual(x_bv, mathsat->mkBVFromDec(3, 4)));
-    REQUIRE(mathsat->check() == camada::checkResult::SAT);
+    REQUIRE(mathsat->check() == camada::CheckResult::SAT);
     auto x_bv_res = mathsat->getBV(x_bv);
     REQUIRE(x_bv_res);
     REQUIRE(x_bv_res.value() == 3);
@@ -146,7 +146,7 @@ TEST_CASE("MathSAT solver recreation reuses symbol names", "[MathSAT]") {
     auto mathsat = camada::createMathSATSolver();
     auto x_bool = mathsat->mkSymbol("x", mathsat->mkBoolSort());
     mathsat->addConstraint(mathsat->mkNot(x_bool));
-    REQUIRE(mathsat->check() == camada::checkResult::SAT);
+    REQUIRE(mathsat->check() == camada::CheckResult::SAT);
     auto x_bool_res = mathsat->getBool(x_bool);
     REQUIRE(x_bool_res);
     REQUIRE_FALSE(x_bool_res.value());

--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -20,7 +20,7 @@ inline void equal_ten(const camada::SMTSolverRef &solver) {
   solver->addConstraint(eq);
 
   // And check for satisfiability
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto f_res = solver->getBV(f);
   REQUIRE(f_res);
@@ -51,7 +51,7 @@ inline void fp_equal(const camada::SMTSolverRef &solver,
   solver->addConstraint(eqx);
 
   // And check for satisfiability
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto fx_res = solver->getFP32(fx);
   auto fy_res = solver->getFP64(fy);
   REQUIRE(fx_res);
@@ -66,7 +66,7 @@ inline void implies_semantics(const camada::SMTSolverRef &solver) {
   REQUIRE(f1->getKind() == camada::SMTExprKind::BoolConst);
   REQUIRE(implication->getKind() == camada::SMTExprKind::Implies);
   solver->addConstraint(solver->mkNot(implication));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 inline void implies_true_implies_false(const camada::SMTSolverRef &solver) {
@@ -77,21 +77,21 @@ inline void implies_true_implies_false(const camada::SMTSolverRef &solver) {
   auto implication = solver->mkImplies(t, f);
   REQUIRE(implication->getKind() == camada::SMTExprKind::Implies);
   solver->addConstraint(implication);
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 inline void solver_timeout_semantics(const camada::SMTSolverRef &solver) {
   if (!solver->setTimeout(150)) {
     // Backends without enforceable limits must report so and stay usable.
     solver->addConstraint(solver->mkBool(true));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     return;
   }
 
   // A generous limit must not affect an easy query.
   auto x = solver->mkSymbol("x", solver->mkBVSort(8));
   solver->addConstraint(solver->mkEqual(x, solver->mkBVFromDec(7, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Factoring a 64-bit semiprime exactly (the 128-bit extension rules out
   // wrap-around shortcuts) is far beyond a 150ms budget on every backend,
@@ -103,16 +103,16 @@ inline void solver_timeout_semantics(const camada::SMTSolverRef &solver) {
     auto b = solver->mkSymbol("b", solver->mkBVSort(64));
     constexpr uint64_t Semiprime = 4294967291ULL * 4294967279ULL;
     auto prod =
-        solver->mkBVMul(solver->mkBVZeroExt(64, a), solver->mkBVZeroExt(64, b));
+        solver->mkBVMul(solver->mkBVZeroExt(a, 64), solver->mkBVZeroExt(b, 64));
     auto k = solver->mkBVZeroExt(
-        64, solver->mkBVFromDec(static_cast<int64_t>(Semiprime), 64));
+        solver->mkBVFromDec(static_cast<int64_t>(Semiprime), 64), 64);
     solver->addConstraint(solver->mkEqual(prod, k));
     auto one = solver->mkBVFromDec(1, 64);
     solver->addConstraint(solver->mkBVUgt(a, one));
     solver->addConstraint(solver->mkBVUgt(b, one));
   };
   assertSemiprimeFactoring();
-  REQUIRE(solver->check() == camada::checkResult::UNKNOWN);
+  REQUIRE(solver->check() == camada::CheckResult::UNKNOWN);
 
   // The limit applies to assumption-based checks too. Rebuild the problem
   // from scratch first: an incremental solver resumes the interrupted
@@ -121,7 +121,7 @@ inline void solver_timeout_semantics(const camada::SMTSolverRef &solver) {
   // bitwuzla), turning this deterministic UNKNOWN into a flaky SAT.
   assertSemiprimeFactoring();
   auto t = solver->mkSymbol("t", solver->mkBoolSort());
-  REQUIRE(solver->checkSatAssuming({t}) == camada::checkResult::UNKNOWN);
+  REQUIRE(solver->checkSatAssuming({t}) == camada::CheckResult::UNKNOWN);
 
   // Clearing the limit must work from the just-timed-out state.
   REQUIRE(solver->setTimeout(0));
@@ -132,14 +132,14 @@ inline void solver_timeout_semantics(const camada::SMTSolverRef &solver) {
   // and answer instantly from the poisoned state instead of UNSAT.
   solver->push();
   solver->addConstraint(solver->mkBool(false));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   solver->pop();
 
   // Normal solving works again after the limit is cleared.
   solver->reset();
   auto y = solver->mkSymbol("y", solver->mkBVSort(8));
   solver->addConstraint(solver->mkEqual(y, solver->mkBVFromDec(9, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void check_sat_assuming_semantics(const camada::SMTSolverRef &solver) {
@@ -150,7 +150,7 @@ inline void check_sat_assuming_semantics(const camada::SMTSolverRef &solver) {
   // Assuming both false contradicts (or a b).
   const std::vector<camada::SMTExprRef> negBoth = {solver->mkNot(a),
                                                    solver->mkNot(b)};
-  REQUIRE(solver->checkSatAssuming(negBoth) == camada::checkResult::UNSAT);
+  REQUIRE(solver->checkSatAssuming(negBoth) == camada::CheckResult::UNSAT);
 
   auto core = solver->getUnsatAssumptions();
   if (core) {
@@ -158,7 +158,7 @@ inline void check_sat_assuming_semantics(const camada::SMTSolverRef &solver) {
     // re-checking under only the returned assumptions stays UNSAT.
     REQUIRE(!core.value().empty());
     REQUIRE(solver->checkSatAssuming(core.value()) ==
-            camada::checkResult::UNSAT);
+            camada::CheckResult::UNSAT);
   } else {
     REQUIRE(core.error().Code == camada::SMTErrorCode::UnsupportedOperation);
   }
@@ -166,11 +166,11 @@ inline void check_sat_assuming_semantics(const camada::SMTSolverRef &solver) {
   // A compound (non-literal) assumption must work too — backends whose
   // native API only accepts literals lower it through activation literals.
   REQUIRE(solver->checkSatAssuming({solver->mkNot(solver->mkOr(a, b))}) ==
-          camada::checkResult::UNSAT);
+          camada::CheckResult::UNSAT);
 
   // Assumptions are per-query: they do not persist into later checks.
-  REQUIRE(solver->checkSatAssuming({a}) == camada::checkResult::SAT);
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->checkSatAssuming({a}) == camada::CheckResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // After a check that was not an UNSAT checkSatAssuming, the unsat
   // assumptions are stale and querying them is an error.
@@ -178,13 +178,13 @@ inline void check_sat_assuming_semantics(const camada::SMTSolverRef &solver) {
 
   // Mutating the solver state after an UNSAT checkSatAssuming also
   // invalidates the unsat assumptions.
-  REQUIRE(solver->checkSatAssuming(negBoth) == camada::checkResult::UNSAT);
+  REQUIRE(solver->checkSatAssuming(negBoth) == camada::CheckResult::UNSAT);
   solver->push();
   REQUIRE(!solver->getUnsatAssumptions());
   solver->pop();
 
   // An empty assumption set degenerates to a plain check.
-  REQUIRE(solver->checkSatAssuming({}) == camada::checkResult::SAT);
+  REQUIRE(solver->checkSatAssuming({}) == camada::CheckResult::SAT);
 }
 
 // Extending by zero bits is a no-op, not an error: callers compute the
@@ -192,13 +192,13 @@ inline void check_sat_assuming_semantics(const camada::SMTSolverRef &solver) {
 // backend used to build a zero-width constant here and abort.
 inline void bv_extend_by_zero_semantics(const camada::SMTSolverRef &solver) {
   auto v = solver->mkBVFromBin("1010", 4);
-  auto z = solver->mkBVZeroExt(0, v);
-  auto s = solver->mkBVSignExt(0, v);
+  auto z = solver->mkBVZeroExt(v, 0);
+  auto s = solver->mkBVSignExt(v, 0);
   REQUIRE(z->getWidth() == 4);
   REQUIRE(s->getWidth() == 4);
   solver->addConstraint(
       solver->mkAnd(solver->mkEqual(z, v), solver->mkEqual(s, v)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // bvsrem takes the sign of the DIVIDEND and bvsdiv truncates toward zero
@@ -219,7 +219,7 @@ inline void bv_signed_div_rem_semantics(const camada::SMTSolverRef &solver) {
                  solver->mkEqual(solver->mkBVSDiv(d(C.A), d(C.B)), d(C.SDiv)),
                  solver->mkEqual(solver->mkBVSRem(d(C.A), d(C.B)), d(C.SRem))));
   solver->addConstraint(All);
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void bv_lshr_semantics(const camada::SMTSolverRef &solver) {
@@ -232,7 +232,7 @@ inline void bv_lshr_semantics(const camada::SMTSolverRef &solver) {
 
   solver->addConstraint(
       solver->mkEqual(result, solver->mkBVFromBin("0100", 4)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Prove each overflow predicate equivalent to an independent reference
@@ -252,7 +252,7 @@ inline void bv_overflow_semantics(const camada::SMTSolverRef &solver) {
                                   const camada::SMTExprRef &Ref) {
       INFO("width " << W << " " << Name);
       solver->addConstraint(solver->mkNot(solver->mkEqual(P, Ref)));
-      REQUIRE(solver->check() == camada::checkResult::UNSAT);
+      REQUIRE(solver->check() == camada::CheckResult::UNSAT);
       solver->reset();
     };
     const auto symbols = [&]() {
@@ -275,21 +275,21 @@ inline void bv_overflow_semantics(const camada::SMTSolverRef &solver) {
     {
       auto [x, y] = symbols();
       auto Exact =
-          solver->mkBVAdd(solver->mkBVSignExt(1, x), solver->mkBVSignExt(1, y));
+          solver->mkBVAdd(solver->mkBVSignExt(x, 1), solver->mkBVSignExt(y, 1));
       requireEquiv("saddo", solver->mkBVSAddOverflow(x, y),
                    signedOutOfRange(Exact, W + 1));
     }
     {
       auto [x, y] = symbols();
       auto Exact =
-          solver->mkBVAdd(solver->mkBVZeroExt(1, x), solver->mkBVZeroExt(1, y));
+          solver->mkBVAdd(solver->mkBVZeroExt(x, 1), solver->mkBVZeroExt(y, 1));
       requireEquiv("uaddo", solver->mkBVUAddOverflow(x, y),
                    unsignedOutOfRange(Exact, W + 1));
     }
     {
       auto [x, y] = symbols();
       auto Exact =
-          solver->mkBVSub(solver->mkBVSignExt(1, x), solver->mkBVSignExt(1, y));
+          solver->mkBVSub(solver->mkBVSignExt(x, 1), solver->mkBVSignExt(y, 1));
       requireEquiv("ssubo", solver->mkBVSSubOverflow(x, y),
                    signedOutOfRange(Exact, W + 1));
     }
@@ -298,7 +298,7 @@ inline void bv_overflow_semantics(const camada::SMTSolverRef &solver) {
       // iff the subtraction borrows.
       auto [x, y] = symbols();
       auto Exact =
-          solver->mkBVSub(solver->mkBVZeroExt(1, x), solver->mkBVZeroExt(1, y));
+          solver->mkBVSub(solver->mkBVZeroExt(x, 1), solver->mkBVZeroExt(y, 1));
       requireEquiv("usubo", solver->mkBVUSubOverflow(x, y),
                    solver->mkEqual(solver->mkBVExtract(W, W, Exact),
                                    solver->mkBVFromDec(1, 1)));
@@ -306,14 +306,14 @@ inline void bv_overflow_semantics(const camada::SMTSolverRef &solver) {
     {
       auto [x, y] = symbols();
       auto Exact =
-          solver->mkBVMul(solver->mkBVSignExt(W, x), solver->mkBVSignExt(W, y));
+          solver->mkBVMul(solver->mkBVSignExt(x, W), solver->mkBVSignExt(y, W));
       requireEquiv("smulo", solver->mkBVSMulOverflow(x, y),
                    signedOutOfRange(Exact, 2 * W));
     }
     {
       auto [x, y] = symbols();
       auto Exact =
-          solver->mkBVMul(solver->mkBVZeroExt(W, x), solver->mkBVZeroExt(W, y));
+          solver->mkBVMul(solver->mkBVZeroExt(x, W), solver->mkBVZeroExt(y, W));
       requireEquiv("umulo", solver->mkBVUMulOverflow(x, y),
                    unsignedOutOfRange(Exact, 2 * W));
     }
@@ -323,8 +323,8 @@ inline void bv_overflow_semantics(const camada::SMTSolverRef &solver) {
       // it is never an overflow, but SMT-LIB defines bvsdiv(x<0, 0) = +1,
       // which falls outside [SMin, SMax] when W == 1.
       auto [x, y] = symbols();
-      auto Exact = solver->mkBVSDiv(solver->mkBVSignExt(1, x),
-                                    solver->mkBVSignExt(1, y));
+      auto Exact = solver->mkBVSDiv(solver->mkBVSignExt(x, 1),
+                                    solver->mkBVSignExt(y, 1));
       auto NonZeroY =
           solver->mkNot(solver->mkEqual(y, solver->mkBVFromDec(0, W)));
       requireEquiv("sdivo", solver->mkBVSDivOverflow(x, y),
@@ -332,7 +332,7 @@ inline void bv_overflow_semantics(const camada::SMTSolverRef &solver) {
     }
     {
       auto x = solver->mkSymbol("ovf_x", solver->mkBVSort(W));
-      auto Exact = solver->mkBVNeg(solver->mkBVSignExt(1, x));
+      auto Exact = solver->mkBVNeg(solver->mkBVSignExt(x, 1));
       requireEquiv("nego", solver->mkBVNegOverflow(x),
                    signedOutOfRange(Exact, W + 1));
     }
@@ -346,7 +346,7 @@ inline void narrow_bv_decimal_model_value(const camada::SMTSolverRef &solver) {
   auto bv32 = solver->mkBVSort(32);
   auto x = solver->mkSymbol("x", bv32);
   solver->addConstraint(solver->mkEqual(x, solver->mkBVFromDec(-42, bv32)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto bin = solver->getBVInBin(x);
   REQUIRE(bin);
@@ -357,7 +357,7 @@ inline void narrow_bv_decimal_model_value(const camada::SMTSolverRef &solver) {
   auto bv3 = solver->mkBVSort(3);
   auto y = solver->mkSymbol("y", bv3);
   solver->addConstraint(solver->mkEqual(y, solver->mkBVFromDec(-1, bv3)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto bin3 = solver->getBVInBin(y);
   REQUIRE(bin3);
@@ -373,7 +373,7 @@ inline void wide_bv_decimal_model_value(const camada::SMTSolverRef &solver) {
   auto bv128 = solver->mkBVSort(128);
   auto x = solver->mkSymbol("x", bv128);
   solver->addConstraint(solver->mkEqual(x, solver->mkBVFromDec(42, bv128)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto bin = solver->getBVInBin(x);
   REQUIRE(bin);
@@ -389,14 +389,14 @@ inline void incremental_push_pop(const camada::SMTSolverRef &solver) {
   auto two = solver->mkBVFromDec(2, 8);
 
   solver->addConstraint(solver->mkEqual(x, one));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   solver->push();
   solver->addConstraint(solver->mkEqual(x, two));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   solver->pop();
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto x_res = solver->getBV(x);
   REQUIRE(x_res);
   REQUIRE(x_res.value() == 1);
@@ -427,7 +427,7 @@ inline void symbol_cache_survives_push_pop(const camada::SMTSolverRef &solver) {
   // Confirm the cached symbol still participates in solving correctly after
   // the pop discarded the in-scope assertion.
   solver->addConstraint(solver->mkEqual(x_after, solver->mkBVFromDec(7, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto v = solver->getBV(x_before);
   REQUIRE(v);
   REQUIRE(v.value() == 7);
@@ -469,19 +469,19 @@ static_assert(sizeof(camada::SMTSortRef) == (CAMADA_CHECKED_HANDLES ? 24 : 8),
 inline void quantifier_semantics(const camada::SMTSolverRef &solver) {
   auto x = solver->mkSymbol("x", solver->mkBVSort(4));
   solver->addConstraint(solver->mkForall({x}, solver->mkEqual(x, x)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   solver->reset();
   x = solver->mkSymbol("x", solver->mkBVSort(4));
   auto three = solver->mkBVFromDec(3, 4);
   solver->addConstraint(solver->mkExists({x}, solver->mkEqual(x, three)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   solver->reset();
   x = solver->mkSymbol("x", solver->mkBVSort(4));
   three = solver->mkBVFromDec(3, 4);
   solver->addConstraint(solver->mkForall({x}, solver->mkEqual(x, three)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 inline void uf_semantics(const camada::SMTSolverRef &solver) {
@@ -498,7 +498,7 @@ inline void uf_semantics(const camada::SMTSolverRef &solver) {
 
   solver->addConstraint(solver->mkEqual(x, y));
   solver->addConstraint(solver->mkNot(solver->mkEqual(fx, fy)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 inline void dump_string_semantics(const camada::SMTSolverRef &solver) {
@@ -506,7 +506,7 @@ inline void dump_string_semantics(const camada::SMTSolverRef &solver) {
   auto x = solver->mkSymbol("x", bv8);
   auto five = solver->mkBVFromDec(5, 8);
   solver->addConstraint(solver->mkEqual(x, five));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   std::string sort_dump = "seed";
   bv8->dump(sort_dump);
@@ -537,7 +537,7 @@ inline void dump_string_semantics(const camada::SMTSolverRef &solver) {
       "dmt", solver->mkTupleSort({solver->mkBVSort(8), solver->mkBoolSort()}));
   solver->addConstraint(solver->mkEqual(solver->mkTupleSelect(tup, 0),
                                         solver->mkBVFromDec(7, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   std::string tuple_model_dump = "seed";
   solver->dumpModel(tuple_model_dump);
   REQUIRE(tuple_model_dump != "seed");
@@ -555,7 +555,7 @@ inline void int_arithmetic_semantics(const camada::SMTSolverRef &solver) {
 
   solver->addConstraint(solver->mkEqual(x_plus_one, three));
   solver->addConstraint(solver->mkArithGt(x, two));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   solver->reset();
   int_sort = solver->mkIntSort();
@@ -566,7 +566,7 @@ inline void int_arithmetic_semantics(const camada::SMTSolverRef &solver) {
   x_plus_one = solver->mkArithAdd(x, one);
   solver->addConstraint(solver->mkEqual(x_plus_one, three));
   solver->addConstraint(solver->mkArithGt(x, one));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void real_arithmetic_semantics(const camada::SMTSolverRef &solver) {
@@ -581,7 +581,7 @@ inline void real_arithmetic_semantics(const camada::SMTSolverRef &solver) {
 
   solver->addConstraint(solver->mkEqual(r_plus_one, three));
   solver->addConstraint(solver->mkArithGt(r, one));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   solver->reset();
   real_sort = solver->mkRealSort();
@@ -593,7 +593,7 @@ inline void real_arithmetic_semantics(const camada::SMTSolverRef &solver) {
   (void)three;
   solver->addConstraint(solver->mkEqual(r, one));
   solver->addConstraint(solver->mkArithLt(r, one));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 inline void arith_model_queries(const camada::SMTSolverRef &solver) {
@@ -607,7 +607,7 @@ inline void arith_model_queries(const camada::SMTSolverRef &solver) {
 
   solver->addConstraint(solver->mkEqual(x, solver->mkInt(5)));
   solver->addConstraint(solver->mkEqual(r, solver->mkReal(3, 2)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto x_res = solver->getInt(x);
   auto x_plus_two_res = solver->getInt(x_plus_two);
@@ -640,15 +640,15 @@ inline void arith_model_queries(const camada::SMTSolverRef &solver) {
 inline void int_bv_conversion_semantics(const camada::SMTSolverRef &solver) {
   // int2bv wraps modulo 2^w: 300 -> 44 at 8 bits, -1 -> 0xFF.
   {
-    auto bv = solver->mkInt2BV(8, solver->mkInt(300));
+    auto bv = solver->mkInt2BV(solver->mkInt(300), 8);
     solver->addConstraint(solver->mkEqual(bv, solver->mkBVFromDec(44, 8)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
   solver->reset();
   {
-    auto bv = solver->mkInt2BV(8, solver->mkInt(-1));
+    auto bv = solver->mkInt2BV(solver->mkInt(-1), 8);
     solver->addConstraint(solver->mkEqual(bv, solver->mkBVFromDec(255, 8)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // bv2int on 0xFF: 255 unsigned, -1 signed.
@@ -659,7 +659,7 @@ inline void int_bv_conversion_semantics(const camada::SMTSolverRef &solver) {
         solver->mkEqual(solver->mkBV2Int(bv, false), solver->mkInt(255)));
     solver->addConstraint(
         solver->mkEqual(solver->mkBV2Int(bv, true), solver->mkInt(-1)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Signed round trip is the identity on every in-range integer. The
@@ -672,18 +672,18 @@ inline void int_bv_conversion_semantics(const camada::SMTSolverRef &solver) {
     auto x = solver->mkSymbol("i2b_x", solver->mkIntSort());
     solver->addConstraint(solver->mkArithGe(x, solver->mkInt(-8)));
     solver->addConstraint(solver->mkArithLe(x, solver->mkInt(7)));
-    auto rt = solver->mkBV2Int(solver->mkInt2BV(4, x), true);
+    auto rt = solver->mkBV2Int(solver->mkInt2BV(x, 4), true);
     solver->addConstraint(solver->mkNot(solver->mkEqual(rt, x)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 
   // ... and the other way: int2bv(bv2int_u(y)) == y for every bit-vector.
   solver->reset();
   {
     auto y = solver->mkSymbol("i2b_y", solver->mkBVSort(4));
-    auto rt = solver->mkInt2BV(4, solver->mkBV2Int(y, false));
+    auto rt = solver->mkInt2BV(solver->mkBV2Int(y, false), 4);
     solver->addConstraint(solver->mkNot(solver->mkEqual(rt, y)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 
   // The use case the bridge exists for: bitwise AND on integers
@@ -691,11 +691,11 @@ inline void int_bv_conversion_semantics(const camada::SMTSolverRef &solver) {
   solver->reset();
   {
     auto r = solver->mkBV2Int(
-        solver->mkBVAnd(solver->mkInt2BV(8, solver->mkInt(12)),
-                        solver->mkInt2BV(8, solver->mkInt(10))),
+        solver->mkBVAnd(solver->mkInt2BV(solver->mkInt(12), 8),
+                        solver->mkInt2BV(solver->mkInt(10), 8)),
         true);
     solver->addConstraint(solver->mkEqual(r, solver->mkInt(8)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
   }
 
   // Signed composition: ~x == -x-1 must hold for all in-range x when
@@ -705,11 +705,11 @@ inline void int_bv_conversion_semantics(const camada::SMTSolverRef &solver) {
     auto x = solver->mkSymbol("i2b_x", solver->mkIntSort());
     solver->addConstraint(solver->mkArithGe(x, solver->mkInt(-8)));
     solver->addConstraint(solver->mkArithLe(x, solver->mkInt(7)));
-    auto NotX = solver->mkBV2Int(solver->mkBVNot(solver->mkInt2BV(4, x)), true);
+    auto NotX = solver->mkBV2Int(solver->mkBVNot(solver->mkInt2BV(x, 4)), true);
     auto MinusXMinusOne =
         solver->mkArithSub(solver->mkArithNeg(x), solver->mkInt(1));
     solver->addConstraint(solver->mkNot(solver->mkEqual(NotX, MinusXMinusOne)));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
 
@@ -741,7 +741,7 @@ inline void arith_conversion_semantics(const camada::SMTSolverRef &solver) {
   solver->addConstraint(x_real_is_int);
   solver->addConstraint(solver->mkEqual(mod_expr, solver->mkInt("2")));
   solver->addConstraint(solver->mkEqual(shl_expr, solver->mkInt("40")));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void arith_symbolic_shift_semantics(const camada::SMTSolverRef &solver) {
@@ -755,7 +755,7 @@ inline void arith_symbolic_shift_semantics(const camada::SMTSolverRef &solver) {
   solver->addConstraint(solver->mkEqual(x, solver->mkInt("5")));
   solver->addConstraint(solver->mkEqual(k, solver->mkInt("3")));
   solver->addConstraint(solver->mkEqual(shl_expr, solver->mkInt("40")));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 inline void arena_stress_test(const camada::SMTSolverRef &solver) {
@@ -771,7 +771,7 @@ inline void arena_stress_test(const camada::SMTSolverRef &solver) {
   }
 
   solver->addConstraint(solver->mkEqual(acc, acc));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   solver->reset();
 
@@ -784,7 +784,7 @@ inline void arena_stress_test(const camada::SMTSolverRef &solver) {
   }
 
   solver->addConstraint(solver->mkEqual(expr, expr));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Model query over a term with a shared subterm. On the SMT-LIB backend the
@@ -796,7 +796,7 @@ inline void shared_subterm_model_value(const camada::SMTSolverRef &solver) {
   auto sum = solver->mkBVAdd(x, x);
   auto prod = solver->mkBVMul(sum, sum);
   solver->addConstraint(solver->mkEqual(x, solver->mkBVFromDec(3, bv8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   auto val = solver->getBV(prod);
   REQUIRE(val);

--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -388,10 +388,12 @@ TEST_CASE("SMTLIB feature capabilities", "[SMTLIB]") {
   REQUIRE_FALSE(solver->supports(SolverFeature::Timeouts));
   REQUIRE_FALSE(solver->supports(SolverFeature::ArrayModels));
 
-  // Camada tuple lowering flips the native-tuples bit.
+  // Camada tuple lowering does not touch the native-tuples bit: that
+  // reports the backend capability, and tupleMode() reports the request.
   auto camadaTuples = std::make_unique<camada::SMTLIBSolver>(
       Path, withTuples(camada::TupleEncoding::Camada));
-  REQUIRE_FALSE(camadaTuples->supports(SolverFeature::NativeTuples));
+  REQUIRE(camadaTuples->supports(SolverFeature::NativeTuples));
+  REQUIRE(camadaTuples->tupleMode() == camada::TupleEncoding::Camada);
 
   solver.reset();
   camadaTuples.reset();

--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -446,23 +446,23 @@ template <typename Fn> void requireAborts(Fn &&Body) {
 } // namespace
 
 TEST_CASE("SMTLIB one-shot verdict scanner contract", "[SMTLIB][oneshot]") {
-  using camada::checkResult;
+  using camada::CheckResult;
   using camada::parseOneShotVerdictLine;
 
   // Bare SMT-LIB verdicts.
-  REQUIRE(parseOneShotVerdictLine("sat") == checkResult::SAT);
-  REQUIRE(parseOneShotVerdictLine("unsat") == checkResult::UNSAT);
-  REQUIRE(parseOneShotVerdictLine("unknown") == checkResult::UNKNOWN);
+  REQUIRE(parseOneShotVerdictLine("sat") == CheckResult::SAT);
+  REQUIRE(parseOneShotVerdictLine("unsat") == CheckResult::UNSAT);
+  REQUIRE(parseOneShotVerdictLine("unknown") == CheckResult::UNKNOWN);
 
   // SAT-competition style.
-  REQUIRE(parseOneShotVerdictLine("s SATISFIABLE") == checkResult::SAT);
-  REQUIRE(parseOneShotVerdictLine("s UNSATISFIABLE") == checkResult::UNSAT);
-  REQUIRE(parseOneShotVerdictLine("s UNKNOWN") == checkResult::UNKNOWN);
+  REQUIRE(parseOneShotVerdictLine("s SATISFIABLE") == CheckResult::SAT);
+  REQUIRE(parseOneShotVerdictLine("s UNSATISFIABLE") == CheckResult::UNSAT);
+  REQUIRE(parseOneShotVerdictLine("s UNKNOWN") == CheckResult::UNKNOWN);
 
   // Surrounding whitespace tolerated.
-  REQUIRE(parseOneShotVerdictLine("  sat") == checkResult::SAT);
-  REQUIRE(parseOneShotVerdictLine("unsat\r\n") == checkResult::UNSAT);
-  REQUIRE(parseOneShotVerdictLine("\t s SATISFIABLE \n") == checkResult::SAT);
+  REQUIRE(parseOneShotVerdictLine("  sat") == CheckResult::SAT);
+  REQUIRE(parseOneShotVerdictLine("unsat\r\n") == CheckResult::UNSAT);
+  REQUIRE(parseOneShotVerdictLine("\t s SATISFIABLE \n") == CheckResult::SAT);
 
   // Everything else rejected — no substring matching.
   REQUIRE_FALSE(parseOneShotVerdictLine("").has_value());
@@ -494,7 +494,7 @@ TEST_CASE("SMTLIB one-shot sat with model solver", "[SMTLIB][oneshot]") {
 
   auto X = solver->mkSymbol("x", solver->mkBVSort(8));
   solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(5, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Pgid handed out at spawn; the formula file is complete.
   REQUIRE(SeenPgid > 0);
@@ -503,7 +503,7 @@ TEST_CASE("SMTLIB one-shot sat with model solver", "[SMTLIB][oneshot]") {
   REQUIRE(Written.find("(assert") != std::string::npos);
 
   // The parallel model solver agrees and serves the model.
-  REQUIRE(solver->oneShotModelVerdict() == camada::checkResult::SAT);
+  REQUIRE(solver->oneShotModelVerdict() == camada::CheckResult::SAT);
   REQUIRE(solver->oneShotModelSolverLive());
   auto Val = solver->getBV(X);
   REQUIRE(Val);
@@ -549,7 +549,7 @@ TEST_CASE("SMTLIB one-shot silent model solver is dropped, not hung",
 
     auto X = solver->mkSymbol("x", solver->mkBVSort(8));
     solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(5, 8)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     REQUIRE_FALSE(solver->oneShotModelVerdict().has_value());
 
     solver.reset();
@@ -574,7 +574,7 @@ TEST_CASE("SMTLIB one-shot garbled model solver is dropped, not fatal",
 
   auto X = solver->mkSymbol("x", solver->mkBVSort(8));
   solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(5, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   REQUIRE_FALSE(solver->oneShotModelVerdict().has_value());
 
   solver.reset();
@@ -591,7 +591,7 @@ TEST_CASE("SMTLIB one-shot verdict handling", "[SMTLIB][oneshot]") {
     auto solver = std::make_unique<camada::SMTLIBSolver>(
         camada::SMTLIBOneShotTag{}, Formula, Script + " %f");
     solver->addConstraint(solver->mkBool(true));
-    REQUIRE(solver->check() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::UNSAT);
     solver.reset();
     std::remove(Formula.c_str());
     std::remove(Script.c_str());
@@ -605,7 +605,7 @@ TEST_CASE("SMTLIB one-shot verdict handling", "[SMTLIB][oneshot]") {
     auto solver = std::make_unique<camada::SMTLIBSolver>(
         camada::SMTLIBOneShotTag{}, Formula, Script + " %f");
     solver->addConstraint(solver->mkBool(true));
-    REQUIRE(solver->check() == camada::checkResult::UNKNOWN);
+    REQUIRE(solver->check() == camada::CheckResult::UNKNOWN);
     const camada::OneShotDiagnostics &D = solver->oneShotDiagnostics();
     REQUIRE(D.Command.find(Formula) != std::string::npos);
     REQUIRE(D.ExitStatus == "exit code 3");
@@ -623,7 +623,7 @@ TEST_CASE("SMTLIB one-shot verdict handling", "[SMTLIB][oneshot]") {
     auto solver = std::make_unique<camada::SMTLIBSolver>(
         camada::SMTLIBOneShotTag{}, Formula, Script + " %f");
     solver->addConstraint(solver->mkBool(true));
-    REQUIRE(solver->check() == camada::checkResult::UNKNOWN);
+    REQUIRE(solver->check() == camada::CheckResult::UNKNOWN);
     REQUIRE(solver->oneShotDiagnostics().ExitStatus == "signal 9");
     solver.reset();
     std::remove(Formula.c_str());
@@ -640,7 +640,7 @@ TEST_CASE("SMTLIB one-shot %f substitution", "[SMTLIB][oneshot]") {
     auto solver = std::make_unique<camada::SMTLIBSolver>(
         camada::SMTLIBOneShotTag{}, Formula, Script + " %f %f");
     solver->addConstraint(solver->mkBool(true));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     solver.reset();
     std::remove(Formula.c_str());
     std::remove(Script.c_str());
@@ -656,7 +656,7 @@ TEST_CASE("SMTLIB one-shot %f substitution", "[SMTLIB][oneshot]") {
     auto solver = std::make_unique<camada::SMTLIBSolver>(
         camada::SMTLIBOneShotTag{}, Formula, Script);
     solver->addConstraint(solver->mkBool(true));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     solver.reset();
     std::remove(Formula.c_str());
     ::rmdir(Dir);
@@ -680,8 +680,8 @@ TEST_CASE("SMTLIB one-shot diverging and dying model solvers",
     auto A = solver->mkSymbol("a", solver->mkBoolSort());
     solver->addConstraint(A);
     solver->addConstraint(solver->mkNot(A));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
-    REQUIRE(solver->oneShotModelVerdict() == camada::checkResult::UNSAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
+    REQUIRE(solver->oneShotModelVerdict() == camada::CheckResult::UNSAT);
     REQUIRE_FALSE(solver->oneShotModelSolverLive());
     solver.reset();
     std::remove(Formula.c_str());
@@ -697,7 +697,7 @@ TEST_CASE("SMTLIB one-shot diverging and dying model solvers",
         std::vector<std::string>{"false"});
     auto X = solver->mkSymbol("x", solver->mkBVSort(8));
     solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(5, 8)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     REQUIRE_FALSE(solver->oneShotModelSolverLive());
     REQUIRE_FALSE(solver->oneShotModelVerdict().has_value());
     REQUIRE_FALSE(solver->getBV(X));
@@ -718,7 +718,7 @@ TEST_CASE("SMTLIB one-shot assumption checks and mid-negotiation death",
     auto solver = std::make_unique<camada::SMTLIBSolver>(
         camada::SMTLIBOneShotTag{}, Formula, Script + " %f");
     auto A = solver->mkSymbol("a", solver->mkBoolSort());
-    REQUIRE(solver->checkSatAssuming({A}) == camada::checkResult::SAT);
+    REQUIRE(solver->checkSatAssuming({A}) == camada::CheckResult::SAT);
     std::string Written = readFile(Formula);
     REQUIRE(Written.find("(check-sat)") != std::string::npos);
     REQUIRE(Written.find("(push 1)") != std::string::npos);
@@ -748,7 +748,7 @@ TEST_CASE("SMTLIB one-shot assumption checks and mid-negotiation death",
         std::vector<std::string>{DyingModel});
     REQUIRE_FALSE(solver->oneShotModelSolverLive());
     solver->addConstraint(solver->mkBool(true));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     solver.reset();
     std::remove(Formula.c_str());
     std::remove(Script.c_str());
@@ -788,7 +788,7 @@ TEST_CASE("SMTLIB caller-chosen logic", "[SMTLIB][logic]") {
         camada::SMTLIBOneShotTag{}, Formula, Script + " %f",
         std::vector<std::string>{}, camada::PgidCallback{}, withLogic("QF_BV"));
     solver->addConstraint(solver->mkBool(true));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     REQUIRE(readFile(Formula).find("(set-logic QF_BV)") != std::string::npos);
     solver.reset();
     std::remove(Formula.c_str());
@@ -812,7 +812,7 @@ TEST_CASE("SMTLIB caller-chosen logic", "[SMTLIB][logic]") {
         withLogic("QF_BV"));
     REQUIRE_FALSE(solver->oneShotModelSolverLive());
     solver->addConstraint(solver->mkBool(true));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     REQUIRE(readFile(Formula).find("(set-logic QF_BV)") != std::string::npos);
     solver.reset();
     std::remove(Formula.c_str());
@@ -835,11 +835,11 @@ TEST_CASE("SMTLIB caller-chosen logic against a child", "[SMTLIB][logic]") {
         camada::SMTLIBProcessTag{}, ModelArgv, Path, withLogic("QF_AUFBV"));
     auto X = solver->mkSymbol("x", solver->mkBVSort(8));
     solver->addConstraint(solver->mkEqual(X, solver->mkBVFromDec(7, 8)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     solver->reset();
     auto Y = solver->mkSymbol("y", solver->mkBVSort(8));
     solver->addConstraint(solver->mkEqual(Y, solver->mkBVFromDec(9, 8)));
-    REQUIRE(solver->check() == camada::checkResult::SAT);
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
     solver.reset();
     std::string Written = readFile(Path);
     REQUIRE(Written.find("(set-logic QF_AUFBV)") != std::string::npos);

--- a/regression/smtlib_pipeline.test.h
+++ b/regression/smtlib_pipeline.test.h
@@ -200,7 +200,7 @@ inline void runSMTLIBPublicFactory(const std::vector<std::string> &Argv) {
   auto BV8 = Solver->mkBVSort(8);
   auto X = Solver->mkSymbol("x", BV8);
   Solver->addConstraint(Solver->mkEqual(X, Solver->mkBVFromDec(1, BV8)));
-  REQUIRE(Solver->check() == camada::checkResult::SAT);
+  REQUIRE(Solver->check() == camada::CheckResult::SAT);
 }
 
 // The dual-emitter form (Argv + path) must drive the child AND tee the script
@@ -212,7 +212,7 @@ inline void runSMTLIBDualEmitter(const std::vector<std::string> &Argv) {
     auto BV8 = Solver->mkBVSort(8);
     auto X = Solver->mkSymbol("x", BV8);
     Solver->addConstraint(Solver->mkEqual(X, Solver->mkBVFromDec(3, BV8)));
-    REQUIRE(Solver->check() == camada::checkResult::SAT);
+    REQUIRE(Solver->check() == camada::CheckResult::SAT);
   }
   std::string Got = readFile(Path);
   std::remove(Path.c_str());

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -28,7 +28,7 @@ inline void tuple_semantics(const camada::SMTSolverRef &solver) {
 
   solver->addConstraint(solver->mkEqual(b, solver->mkBool(true)));
   solver->addConstraint(solver->mkEqual(bv, solver->mkBVFromDec(42, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto b_res = solver->getBool(b);
   auto bv_res = solver->getBV(bv);
   REQUIRE(b_res);
@@ -55,7 +55,7 @@ inline void tuple_semantics_with_int(const camada::SMTSolverRef &solver) {
   auto i = solver->mkTupleSelect(tupleSymbol, 2);
   REQUIRE(i->Sort == intSort);
   solver->addConstraint(solver->mkEqual(i, solver->mkInt(7)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
 // Tuple whose second field is an array. Exercises the encoded path's
@@ -89,7 +89,7 @@ inline void tuple_with_array_field(const camada::SMTSolverRef &solver) {
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(arrField, idx), fortyTwo));
 
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto bv_res = solver->getBV(bvField);
   REQUIRE(bv_res);
   REQUIRE(bv_res.value() == 7);
@@ -123,7 +123,7 @@ inline void tuple_update_semantics(const camada::SMTSolverRef &solver) {
       solver->mkTuple({solver->mkBool(true), solver->mkBVFromDec(9, 8),
                        solver->mkBVFromDec(2, 8)});
   solver->addConstraint(solver->mkNot(solver->mkEqual(u, expected)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Symbol tuple: non-updated fields stay tied to the original symbol's
   // fields, and the updated field equals the new value.
@@ -140,7 +140,7 @@ inline void tuple_update_semantics(const camada::SMTSolverRef &solver) {
   auto updated =
       solver->mkEqual(solver->mkTupleSelect(v, 2), solver->mkBVFromDec(7, 8));
   solver->addConstraint(solver->mkNot(solver->mkAnd(preserved, updated)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Chained updates of the same field — ESBMC's pointer-arithmetic hot
   // pattern — collapse to the last value with the other fields preserved.
@@ -157,7 +157,7 @@ inline void tuple_update_semantics(const camada::SMTSolverRef &solver) {
                                solver->mkEqual(solver->mkTupleSelect(twice, 2),
                                                solver->mkTupleSelect(base, 2)));
   solver->addConstraint(solver->mkNot(chainOk));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Update of an ite-shaped tuple distributes through both branches.
   solver->reset();
@@ -176,7 +176,7 @@ inline void tuple_update_semantics(const camada::SMTSolverRef &solver) {
                       solver->mkIte(cond, solver->mkTupleSelect(ta, 2),
                                     solver->mkTupleSelect(tb, 2))));
   solver->addConstraint(solver->mkNot(iteOk));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Updating the scalar field of a tuple that carries an array field
   // composes with the verbatim array storage in the Camada lowering.
@@ -195,7 +195,7 @@ inline void tuple_update_semantics(const camada::SMTSolverRef &solver) {
                                        solver->mkBVFromDec(6, 8));
   solver->addConstraint(
       solver->mkNot(solver->mkAnd(arrPreserved, scalarUpdated)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Nested tuples: updating an inner tuple through an outer update.
   solver->reset();
@@ -218,7 +218,7 @@ inline void tuple_update_semantics(const camada::SMTSolverRef &solver) {
       solver->mkEqual(solver->mkTupleSelect(newOuter, 0),
                       solver->mkTupleSelect(outer, 0)));
   solver->addConstraint(solver->mkNot(ok));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Model extraction through an update.
   solver->reset();
@@ -228,7 +228,7 @@ inline void tuple_update_semantics(const camada::SMTSolverRef &solver) {
   auto q = solver->mkTupleUpdate(p, 0, solver->mkBVFromDec(11, 8));
   solver->addConstraint(
       solver->mkEqual(solver->mkTupleSelect(p, 1), solver->mkBVFromDec(5, 8)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto f0 = solver->getBV(solver->mkTupleSelect(q, 0));
   REQUIRE(f0);
   REQUIRE(f0.value() == 11);
@@ -281,7 +281,7 @@ inline void tuple_array_semantics(const camada::SMTSolverRef &solver) {
   auto a1 = solver->mkArrayStore(a, idx(3), t);
   auto rd = solver->mkArraySelect(a1, idx(3));
   solver->addConstraint(solver->mkNot(solver->mkEqual(rd, t)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Reads at other indexes stay tied to the original array.
   solver->reset();
@@ -294,7 +294,7 @@ inline void tuple_array_semantics(const camada::SMTSolverRef &solver) {
   auto preserved = solver->mkEqual(solver->mkArraySelect(b1, idx(5)),
                                    solver->mkArraySelect(b, idx(5)));
   solver->addConstraint(solver->mkNot(preserved));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Homogeneous fields pin leaf-order identity solver-side: a leaf
   // transposition between flatten and assemble would swap 1 and 2
@@ -311,7 +311,7 @@ inline void tuple_array_semantics(const camada::SMTSolverRef &solver) {
       solver->mkAnd(solver->mkEqual(solver->mkTupleSelect(hRead, 0), idx(1)),
                     solver->mkEqual(solver->mkTupleSelect(hRead, 1), idx(2)));
   solver->addConstraint(solver->mkNot(fieldsOk));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Read-over-write at a distinct symbolic index.
   solver->reset();
@@ -327,7 +327,7 @@ inline void tuple_array_semantics(const camada::SMTSolverRef &solver) {
   auto rd2 = solver->mkArraySelect(c1, j);
   solver->addConstraint(
       solver->mkNot(solver->mkEqual(rd2, solver->mkArraySelect(c, j))));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 inline void tuple_array_equality_ite(const camada::SMTSolverRef &solver) {
@@ -343,7 +343,7 @@ inline void tuple_array_equality_ite(const camada::SMTSolverRef &solver) {
   auto fa = solver->mkTupleSelect(solver->mkArraySelect(a, idx(0)), 1);
   auto fb = solver->mkTupleSelect(solver->mkArraySelect(b, idx(0)), 1);
   solver->addConstraint(solver->mkNot(solver->mkEqual(fa, fb)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Ite distributes; selecting from the chosen branch agrees.
   solver->reset();
@@ -358,7 +358,7 @@ inline void tuple_array_equality_ite(const camada::SMTSolverRef &solver) {
   auto expected = solver->mkIte(cond, solver->mkArraySelect(c, idx(2)),
                                 solver->mkArraySelect(d, idx(2)));
   solver->addConstraint(solver->mkNot(solver->mkEqual(sel, expected)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Constant arrays of tuples: on backends without native datatypes the
@@ -378,7 +378,7 @@ inline void tuple_array_const(
   auto i = solver->mkSymbol("i", bv8);
   solver->addConstraint(
       solver->mkNot(solver->mkEqual(solver->mkArraySelect(arr, i), init)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Store over the constant array: the stored tuple at the written
   // index, the default elsewhere.
@@ -392,7 +392,7 @@ inline void tuple_array_const(
       solver->mkAnd(solver->mkEqual(solver->mkArraySelect(upd, idx(3)), stored),
                     solver->mkEqual(solver->mkArraySelect(upd, idx(5)), init));
   solver->addConstraint(solver->mkNot(ok));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // The default survives a store made inside a pushed scope: after pop,
   // reads at the previously written index see the default again.
@@ -405,11 +405,11 @@ inline void tuple_array_const(
   auto inPush = solver->mkArrayStore(arr3, idx(2), scratch);
   solver->addConstraint(
       solver->mkEqual(solver->mkArraySelect(inPush, idx(2)), scratch));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   solver->pop();
   solver->addConstraint(solver->mkNot(
       solver->mkEqual(solver->mkArraySelect(arr3, idx(2)), init)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // Homogeneous fields pin per-leaf default order semantically: a leaf
   // transposition would hand 22 to field 0 with no sort mismatch.
@@ -423,7 +423,7 @@ inline void tuple_array_const(
       solver->mkAnd(solver->mkEqual(solver->mkTupleSelect(homoRd, 0), idx(11)),
                     solver->mkEqual(solver->mkTupleSelect(homoRd, 1), idx(22)));
   solver->addConstraint(solver->mkNot(fieldsOk));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Nested constant arrays of tuples: array_of(array_of(tuple)). On the
@@ -443,9 +443,9 @@ inline void tuple_array_const_nested(const camada::SMTSolverRef &solver) {
   auto rd = solver->mkArraySelect(solver->mkArraySelect(outerConst, i), j);
   // Guard against a vacuously UNSAT context (e.g. contradictory default
   // axioms) before pinning the property itself.
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   solver->addConstraint(solver->mkNot(solver->mkEqual(rd, init)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 // Model extraction for decomposed tuple arrays: getArrayElement returns
@@ -469,7 +469,7 @@ inline void tuple_array_model_values(
   // Touch an untouched index so every backend has the array in the formula.
   solver->addConstraint(solver->mkEqual(
       solver->mkTupleSelect(solver->mkArraySelect(arr, idx(0)), 1), idx(7)));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 
   // Exact single-index recovery: getArrayElement at a written and an
   // untouched index, read each tuple field back.
@@ -545,7 +545,7 @@ inline void tuple_array_model_values(
   auto sym = solver->mkSymbol("sym_ta", solver->mkArraySort(bv8, tupSort));
   auto stored = solver->mkTuple({solver->mkBool(true), idx(33)});
   auto sym1 = solver->mkArrayStore(sym, idx(4), stored);
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
   auto e = solver->getArrayElement(sym1, idx(4));
   auto eb = solver->getBool(solver->mkTupleSelect(e, 0));
   auto en = solver->getBV(solver->mkTupleSelect(e, 1));
@@ -594,7 +594,7 @@ inline void tuple_array_deep_nesting(const camada::SMTSolverRef &solver) {
           solver->mkArraySelect(solver->mkTupleSelect(o1, 1), idx4(2)), 1),
       idx4(1));
   solver->addConstraint(solver->mkNot(solver->mkEqual(back, innerT)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 
   // An untouched path stays tied to the original.
   solver->reset();
@@ -612,7 +612,7 @@ inline void tuple_array_deep_nesting(const camada::SMTSolverRef &solver) {
   auto deepQ = solver->mkArraySelect(
       solver->mkTupleSelect(solver->mkArraySelect(q, idx4(0)), 1), idx4(3));
   solver->addConstraint(solver->mkNot(solver->mkEqual(deepP, deepQ)));
-  REQUIRE(solver->check() == camada::checkResult::UNSAT);
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
 inline void empty_tuple_semantics(const camada::SMTSolverRef &solver) {
@@ -627,5 +627,5 @@ inline void empty_tuple_semantics(const camada::SMTSolverRef &solver) {
   REQUIRE(tupleSymbol->Sort == tupleSort);
 
   solver->addConstraint(solver->mkEqual(tupleSymbol, tupleValue));
-  REQUIRE(solver->check() == camada::checkResult::SAT);
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
 }

--- a/regression/yices.test.cpp
+++ b/regression/yices.test.cpp
@@ -15,11 +15,11 @@ TEST_CASE("Config logic Yices test", "[YICES]") {
   auto yices = camada::createYicesSolver(Cfg);
   auto x = yices->mkSymbol("x", yices->mkBVSort(8));
   yices->addConstraint(yices->mkEqual(x, yices->mkBVFromDec(7, 8)));
-  REQUIRE(yices->check() == camada::checkResult::SAT);
+  REQUIRE(yices->check() == camada::CheckResult::SAT);
   yices->reset();
   auto y = yices->mkSymbol("y", yices->mkBVSort(8));
   yices->addConstraint(yices->mkEqual(y, yices->mkBVFromDec(9, 8)));
-  REQUIRE(yices->check() == camada::checkResult::SAT);
+  REQUIRE(yices->check() == camada::CheckResult::SAT);
 
   // Pin that the logic actually reached the context: a QF_BV context has
   // no array solver, so asserting an array constraint aborts — under the
@@ -88,7 +88,7 @@ TEST_CASE("Arith Yices test", "[YICES]") {
 
     yices->addConstraint(yices->mkEqual(x_plus_one, three));
     yices->addConstraint(yices->mkArithGt(x, one));
-    REQUIRE(yices->check() == camada::checkResult::SAT);
+    REQUIRE(yices->check() == camada::CheckResult::SAT);
   }
 
   {
@@ -102,7 +102,7 @@ TEST_CASE("Arith Yices test", "[YICES]") {
 
     yices->addConstraint(yices->mkEqual(r_plus_one, three));
     yices->addConstraint(yices->mkArithGt(r, one));
-    REQUIRE(yices->check() == camada::checkResult::SAT);
+    REQUIRE(yices->check() == camada::CheckResult::SAT);
   }
 
   {
@@ -166,11 +166,11 @@ TEST_CASE("Yices multi-instance lifecycle edge case", "[YICES]") {
   auto y = yices2->mkSymbol("y", yices2->mkBVSort(8));
   yices2->addConstraint(yices2->mkEqual(y, yices2->mkBVFromDec(100, 8)));
 
-  REQUIRE(yices1->check() == camada::checkResult::SAT);
-  REQUIRE(yices2->check() == camada::checkResult::SAT);
+  REQUIRE(yices1->check() == camada::CheckResult::SAT);
+  REQUIRE(yices2->check() == camada::CheckResult::SAT);
 
   yices1->reset();
-  REQUIRE(yices2->check() == camada::checkResult::SAT); // Still SAT
+  REQUIRE(yices2->check() == camada::CheckResult::SAT); // Still SAT
 }
 
 #if SOLVER_SMTLIB_ENABLED

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -68,7 +68,11 @@ TEST_CASE("Camada tuples via config Z3 test", "[Z3]") {
   camada::SolverConfig Cfg;
   Cfg.Tuples = camada::TupleEncoding::Camada;
   auto z3 = camada::createZ3Solver(Cfg);
-  REQUIRE_FALSE(z3->supports(camada::SolverFeature::NativeTuples));
+  // supports() reports the backend capability, so Z3 still claims native
+  // datatypes here; tupleMode() is what says this instance will not use
+  // them.
+  REQUIRE(z3->supports(camada::SolverFeature::NativeTuples));
+  REQUIRE(z3->tupleMode() == camada::TupleEncoding::Camada);
   tuple_semantics(z3);
   z3->reset();
   tuple_with_array_field(z3);

--- a/scripts/release-consumer/main.cpp
+++ b/scripts/release-consumer/main.cpp
@@ -23,7 +23,7 @@ int run(const camada::SMTSolverRef &solver, const std::string &name) {
   auto seven = solver->mkBVFromDec(7, 32);
   solver->addConstraint(solver->mkEqual(x, seven));
 
-  if (solver->check() != camada::checkResult::SAT) {
+  if (solver->check() != camada::CheckResult::SAT) {
     std::cerr << name << ": expected SAT\n";
     return 1;
   }

--- a/src/camada.h
+++ b/src/camada.h
@@ -1074,8 +1074,9 @@ public:
   virtual ArrayEncoding arrayMode() const = 0;
 
   /// Tuple lowering (SolverConfig::Tuples). Only reaches a decision on
-  /// backends with native datatypes; supports(NativeTuples) answers what
-  /// this solver will actually do.
+  /// backends with native datatypes -- ask supports(NativeTuples) whether
+  /// this backend has them. Ackermann arrays also force the Camada
+  /// lowering regardless of this setting.
   virtual TupleEncoding tupleMode() const = 0;
 
   /// Whether core production was requested (SolverConfig::

--- a/src/camada.h
+++ b/src/camada.h
@@ -314,7 +314,7 @@ public:
   /// that constraint lives at the current (push)/(pop) level — unlike
   /// mkIEEEFPToBV's tie, which is journalled and re-asserted after a pop
   /// because it states a definitional fact rather than an assumption.
-  virtual SMTExprRef mkInt2BV(unsigned Width, const SMTExprRef &Exp) = 0;
+  virtual SMTExprRef mkInt2BV(const SMTExprRef &Exp, unsigned Width) = 0;
 
   /// Converts a bit-vector to the integer it denotes: two's complement
   /// when IsSigned, the unsigned value in [0, 2^N) otherwise. Together
@@ -326,11 +326,13 @@ public:
   virtual SMTExprRef mkIte(const SMTExprRef &Cond, const SMTExprRef &T,
                            const SMTExprRef &F) = 0;
 
-  /// Creates a bitvector sign extension operation
-  virtual SMTExprRef mkBVSignExt(unsigned i, const SMTExprRef &Exp) = 0;
+  /// Creates a bitvector sign extension operation, widening Exp by
+  /// ExtraBits copies of its sign bit.
+  virtual SMTExprRef mkBVSignExt(const SMTExprRef &Exp, unsigned ExtraBits) = 0;
 
-  /// Creates a bitvector zero extension operation
-  virtual SMTExprRef mkBVZeroExt(unsigned i, const SMTExprRef &Exp) = 0;
+  /// Creates a bitvector zero extension operation, widening Exp by
+  /// ExtraBits leading zeroes.
+  virtual SMTExprRef mkBVZeroExt(const SMTExprRef &Exp, unsigned ExtraBits) = 0;
 
   /// Creates a bitvector extract operation
   virtual SMTExprRef mkBVExtract(unsigned High, unsigned Low,
@@ -370,7 +372,7 @@ public:
   virtual SMTExprRef mkFPIsNaN(const SMTExprRef &Exp) = 0;
 
   /// Creates a floating-point isSubnormal operation
-  virtual SMTExprRef mkFPIsDenormal(const SMTExprRef &Exp) = 0;
+  virtual SMTExprRef mkFPIsSubnormal(const SMTExprRef &Exp) = 0;
 
   /// Creates a floating-point isNormal operation
   virtual SMTExprRef mkFPIsNormal(const SMTExprRef &Exp) = 0;
@@ -422,30 +424,30 @@ public:
 
   /// Creates a floating-point conversion from floating-point to floating-point
   /// operation
-  virtual SMTExprRef mkFPtoFP(const SMTExprRef &From, const SMTSortRef &To,
+  virtual SMTExprRef mkFPToFP(const SMTExprRef &From, const SMTSortRef &To,
                               const SMTExprRef &R) = 0;
 
   /// Creates a floating-point conversion from signed bitvector to
   /// floating-point operation
-  virtual SMTExprRef mkSBVtoFP(const SMTExprRef &From, const SMTSortRef &To,
+  virtual SMTExprRef mkSBVToFP(const SMTExprRef &From, const SMTSortRef &To,
                                const SMTExprRef &R) = 0;
 
   /// Creates a floating-point conversion from unsigned bitvector to
   /// floating-point operation
-  virtual SMTExprRef mkUBVtoFP(const SMTExprRef &From, const SMTSortRef &To,
+  virtual SMTExprRef mkUBVToFP(const SMTExprRef &From, const SMTSortRef &To,
                                const SMTExprRef &R) = 0;
 
   /// Creates a floating-point conversion from floating-point to signed
   /// bitvector operation
-  virtual SMTExprRef mkFPtoSBV(const SMTExprRef &From, unsigned ToWidth) = 0;
+  virtual SMTExprRef mkFPToSBV(const SMTExprRef &From, unsigned ToWidth) = 0;
 
   /// Creates a floating-point conversion from floating-point to unsigned
   /// bitvector operation
-  virtual SMTExprRef mkFPtoUBV(const SMTExprRef &From, unsigned ToWidth) = 0;
+  virtual SMTExprRef mkFPToUBV(const SMTExprRef &From, unsigned ToWidth) = 0;
 
   /// Creates a floating-point conversion from floating-point to the closest
   /// integer, considering the rounding mode.
-  virtual SMTExprRef mkFPtoIntegral(const SMTExprRef &From,
+  virtual SMTExprRef mkFPToIntegral(const SMTExprRef &From,
                                     const SMTExprRef &R) = 0;
 
   // --- Fixed-point arithmetic (TR 18037-shaped, Camada-encoded over BV) ---
@@ -1018,11 +1020,11 @@ public:
   virtual SMTExprRef mkIEEEFPToBV(const SMTExprRef &Exp) = 0;
 
   /// Check if the constraints are satisfiable
-  virtual checkResult check() = 0;
+  virtual CheckResult check() = 0;
 
   /// Set a wall-clock time limit, in milliseconds, applied to each
   /// subsequent check() or checkSatAssuming() individually; 0 removes the
-  /// limit. A check that hits the limit returns checkResult::UNKNOWN and
+  /// limit. A check that hits the limit returns CheckResult::UNKNOWN and
   /// leaves the solver usable. The limit persists across reset(). Returns
   /// false when the backend cannot enforce time limits — the limit is
   /// then ignored. Equivalently queryable up front as
@@ -1034,7 +1036,7 @@ public:
   /// have no effect on the satisfiability of later checks. (Backends whose
   /// native API only accepts literals lower compound assumptions through
   /// fresh activation literals, which is observable in dump() output.)
-  virtual checkResult
+  virtual CheckResult
   checkSatAssuming(const std::vector<SMTExprRef> &Assumptions) = 0;
 
   /// Returns the subset of the assumptions the solver used to derive
@@ -1062,6 +1064,7 @@ public:
   /// was configured. A backend that makes unsat-assumption tracking opt-in
   /// still reports SolverFeature::UnsatAssumptions; ask
   /// produceUnsatAssumptions() whether this solver has it enabled.
+
   virtual bool supports(SolverFeature Feature) const = 0;
 
   // --- Creation-time options, as this solver was constructed with ---

--- a/src/camada.h
+++ b/src/camada.h
@@ -49,11 +49,14 @@ std::string getCamadaVersion();
 ///     must be serialized by the caller; a single solver is intended for use
 ///     from one thread at a time. Concurrent solving should be done with one
 ///     solver per thread.
-///   * SMTExprRef and SMTSortRef handles are nullable, copyable, and safe to
-///     read concurrently from any thread as long as the owning solver
-///     outlives the read. The handle's liveness check is race-free against
-///     reset()/destruction on another thread: a stale handle deterministically
-///     aborts via fatalError() rather than reading freed memory.
+///   * SMTExprRef and SMTSortRef handles are nullable and copyable, and may
+///     be read concurrently from any thread as long as no thread calls
+///     reset() or destroys the solver meanwhile. The liveness check catches
+///     a handle left stale by an *earlier* reset() -- it aborts via
+///     fatalError() instead of reading freed memory -- but it does not
+///     synchronize against a reset() running concurrently: the check can
+///     pass and the arena be cleared before the dereference. Serialize
+///     reset() and destruction against handle reads.
 class SMTSolver {
 public:
   SMTSolver() = default;

--- a/src/camadaexpr.h
+++ b/src/camadaexpr.h
@@ -103,7 +103,7 @@ enum class SMTExprKind : std::uint8_t {
   FPNeg,
   FPIsInfinite,
   FPIsNaN,
-  FPIsDenormal,
+  FPIsSubnormal,
   FPIsNormal,
   FPIsZero,
   FPMul,

--- a/src/camadatypes.h
+++ b/src/camadatypes.h
@@ -175,7 +175,7 @@ enum class RM : std::uint8_t {
   ROUND_TO_ZERO = 4,
 };
 
-enum class checkResult : std::uint8_t { SAT, UNSAT, UNKNOWN };
+enum class CheckResult : std::uint8_t { SAT, UNSAT, UNKNOWN };
 
 /// Capabilities a backend may or may not implement, queryable through
 /// SMTSolver::supports() instead of discovering them through aborts or

--- a/src/camadatypes.h
+++ b/src/camadatypes.h
@@ -197,7 +197,12 @@ enum class SolverFeature : std::uint8_t {
   /// every backend regardless.
   NativeFloatingPoint,
   /// Backend-native tuple/datatype sorts; other backends route tuples
-  /// through the Camada per-field lowering.
+  /// through the Camada per-field lowering. Like every bit here this is a
+  /// property of the backend, not of this instance: it stays true on a
+  /// solver configured for TupleEncoding::Camada, or for Ackermann arrays
+  /// (which force the lowering because a datatype cannot hold an array
+  /// member with no backend term). To ask what this solver will actually
+  /// do, compose with tupleMode() and arrayMode().
   NativeTuples,
   /// Backend-native `((as const ...) v)` constant arrays; other backends
   /// lower them lazily (see ConstArrayLowering).
@@ -274,8 +279,9 @@ struct SolverConfig {
   /// context creation -- so it is opt-in.
   ///
   /// False (the default) gives fast contexts: checkSatAssuming() works
-  /// unchanged, getUnsatAssumptions() reports UnsupportedOperation and
-  /// supports(SolverFeature::UnsatAssumptions) answers false. True makes
+  /// unchanged and getUnsatAssumptions() reports UnsupportedOperation.
+  /// supports(SolverFeature::UnsatAssumptions) still answers true: it
+  /// reports the backend's capability, not this setting. True makes
   /// the backend track assumptions so getUnsatAssumptions() returns real
   /// cores after an UNSAT checkSatAssuming().
   ///

--- a/src/core/camadaimpl.cpp
+++ b/src/core/camadaimpl.cpp
@@ -87,15 +87,16 @@ namespace camada {
 #define CAMADA_DEFINE_UNSUPPORTED_IMPL(ReturnType, Name, Feature, ...)         \
   ReturnType SMTSolverImpl::Name(__VA_ARGS__) { unsupportedFeature(Feature); }
 // Width-extension wrapper: same guard and postcondition for sign- and
-// zero-extension. The guard is what stops i + width wrapping unsigned, so it
+// zero-extension. The guard is what stops ExtraBits + width wrapping, so it
 // belongs with the operation rather than being retyped per extension.
 #define CAMADA_DEFINE_BV_EXTEND_WRAPPER(Name, ImplName, What)                  \
-  SMTExprRef SMTSolverImpl::Name(unsigned i, const SMTExprRef &Exp) {          \
+  SMTExprRef SMTSolverImpl::Name(const SMTExprRef &Exp, unsigned ExtraBits) {  \
     requireBVSort(Exp, "Expected bit-vector expression");                      \
-    fatalErrorIf(i > std::numeric_limits<unsigned>::max() - Exp->getWidth(),   \
+    fatalErrorIf(ExtraBits >                                                   \
+                     std::numeric_limits<unsigned>::max() - Exp->getWidth(),   \
                  "Bit-vector " What " extension width overflow");              \
-    SMTExprRef theExp = ImplName(i, Exp);                                      \
-    assert(theExp->getWidth() == Exp->getWidth() + i);                         \
+    SMTExprRef theExp = ImplName(Exp, ExtraBits);                              \
+    assert(theExp->getWidth() == Exp->getWidth() + ExtraBits);                 \
     return theExp;                                                             \
   }
 // FP arithmetic taking a rounding mode: same encoding dispatch as the unary
@@ -1070,10 +1071,10 @@ CAMADA_DEFINE_SIMPLE_UNARY_WRAPPER(
     requireArithSort(Exp, "Expected arithmetic expression"), mkIsIntImpl(Exp),
     assert(theExp->isBoolSort()))
 
-SMTExprRef SMTSolverImpl::mkInt2BV(unsigned Width, const SMTExprRef &Exp) {
+SMTExprRef SMTSolverImpl::mkInt2BV(const SMTExprRef &Exp, unsigned Width) {
   fatalErrorIf(Width == 0, "Bit-vector width must be non-zero");
   requireIntSort(Exp, "Expected integer expression");
-  SMTExprRef theExp = mkInt2BVImpl(Width, Exp);
+  SMTExprRef theExp = mkInt2BVImpl(Exp, Width);
   assert(theExp->isBVSort());
   assert(theExp->getWidth() == Width);
   return theExp;
@@ -1182,7 +1183,7 @@ CAMADA_DEFINE_FP_UNARY_WRAPPER(
     assert(theExp->isBoolSort()))
 
 CAMADA_DEFINE_FP_UNARY_WRAPPER(
-    mkFPIsDenormal, mkFPIsDenormalImpl,
+    mkFPIsSubnormal, mkFPIsSubnormalImpl,
     requireFPSort(Exp, "Expected floating-point expression"),
     assert(theExp->isBoolSort()))
 
@@ -1235,7 +1236,7 @@ SMTExprRef SMTSolverImpl::mkFPFMA(const SMTExprRef &X, const SMTExprRef &Y,
   return theExp;
 }
 
-SMTExprRef SMTSolverImpl::mkFPtoFP(const SMTExprRef &From, const SMTSortRef &To,
+SMTExprRef SMTSolverImpl::mkFPToFP(const SMTExprRef &From, const SMTSortRef &To,
                                    const SMTExprRef &R) {
   requireFPSort(From, "Expected floating-point expression");
   requireFPSort(To, "Expected floating-point target sort");
@@ -1246,13 +1247,13 @@ SMTExprRef SMTSolverImpl::mkFPtoFP(const SMTExprRef &From, const SMTSortRef &To,
       usesBVFPEncoding(To) != usesBVRMEncoding(R),
       "Floating-point target and rounding mode use different encodings");
   SMTExprRef theExp = usesBVFPEncoding(To)
-                          ? SMTSolverImpl::mkFPtoFPImpl(From, To, R)
-                          : mkFPtoFPImpl(From, To, R);
+                          ? SMTSolverImpl::mkFPToFPImpl(From, To, R)
+                          : mkFPToFPImpl(From, To, R);
   assert(theExp->Sort == To);
   return theExp;
 }
 
-SMTExprRef SMTSolverImpl::mkSBVtoFP(const SMTExprRef &From,
+SMTExprRef SMTSolverImpl::mkSBVToFP(const SMTExprRef &From,
                                     const SMTSortRef &To, const SMTExprRef &R) {
   requireBVSort(From, "Expected bit-vector expression");
   requireFPSort(To, "Expected floating-point target sort");
@@ -1261,13 +1262,13 @@ SMTExprRef SMTSolverImpl::mkSBVtoFP(const SMTExprRef &From,
       usesBVFPEncoding(To) != usesBVRMEncoding(R),
       "Floating-point target and rounding mode use different encodings");
   SMTExprRef theExp = usesBVFPEncoding(To)
-                          ? SMTSolverImpl::mkSBVtoFPImpl(From, To, R)
-                          : mkSBVtoFPImpl(From, To, R);
+                          ? SMTSolverImpl::mkSBVToFPImpl(From, To, R)
+                          : mkSBVToFPImpl(From, To, R);
   assert(theExp->Sort == To);
   return theExp;
 }
 
-SMTExprRef SMTSolverImpl::mkUBVtoFP(const SMTExprRef &From,
+SMTExprRef SMTSolverImpl::mkUBVToFP(const SMTExprRef &From,
                                     const SMTSortRef &To, const SMTExprRef &R) {
   requireBVSort(From, "Expected bit-vector expression");
   requireFPSort(To, "Expected floating-point target sort");
@@ -1276,23 +1277,23 @@ SMTExprRef SMTSolverImpl::mkUBVtoFP(const SMTExprRef &From,
       usesBVFPEncoding(To) != usesBVRMEncoding(R),
       "Floating-point target and rounding mode use different encodings");
   SMTExprRef theExp = usesBVFPEncoding(To)
-                          ? SMTSolverImpl::mkUBVtoFPImpl(From, To, R)
-                          : mkUBVtoFPImpl(From, To, R);
+                          ? SMTSolverImpl::mkUBVToFPImpl(From, To, R)
+                          : mkUBVToFPImpl(From, To, R);
   assert(theExp->Sort == To);
   return theExp;
 }
 
-CAMADA_DEFINE_FP_TO_BV_WRAPPER(mkFPtoSBV, mkFPtoSBVImpl)
+CAMADA_DEFINE_FP_TO_BV_WRAPPER(mkFPToSBV, mkFPToSBVImpl)
 
-CAMADA_DEFINE_FP_TO_BV_WRAPPER(mkFPtoUBV, mkFPtoUBVImpl)
+CAMADA_DEFINE_FP_TO_BV_WRAPPER(mkFPToUBV, mkFPToUBVImpl)
 
-SMTExprRef SMTSolverImpl::mkFPtoIntegral(const SMTExprRef &From,
+SMTExprRef SMTSolverImpl::mkFPToIntegral(const SMTExprRef &From,
                                          const SMTExprRef &R) {
   requireFPSort(From, "Expected floating-point expression");
   requireMatchingFPAndRMEncoding(From, R);
   SMTExprRef theExp = usesBVFPEncoding(From)
-                          ? SMTSolverImpl::mkFPtoIntegralImpl(From, R)
-                          : mkFPtoIntegralImpl(From, R);
+                          ? SMTSolverImpl::mkFPToIntegralImpl(From, R)
+                          : mkFPToIntegralImpl(From, R);
   assert(theExp->isFPSort());
   return theExp;
 }
@@ -2180,12 +2181,12 @@ SMTExprRef SMTSolverImpl::mkIEEEFPToBV(const SMTExprRef &Exp) {
   return theExp;
 }
 
-checkResult SMTSolverImpl::check() {
+CheckResult SMTSolverImpl::check() {
   invalidateUnsatAssumptions();
   return checkImpl();
 }
 
-checkResult
+CheckResult
 SMTSolverImpl::checkSatAssuming(const std::vector<SMTExprRef> &Assumptions) {
   for (const SMTExprRef &Assumption : Assumptions)
     requireBoolSort(Assumption, "Expected boolean assumption");
@@ -2193,20 +2194,20 @@ SMTSolverImpl::checkSatAssuming(const std::vector<SMTExprRef> &Assumptions) {
   // addConstraint/push/pop (the default fallback and the activation-literal
   // lowerings do), all of which invalidate the unsat-assumption state, so
   // record it only after the check completes.
-  const checkResult Result =
+  const CheckResult Result =
       Assumptions.empty() ? checkImpl() : checkSatAssumingImpl(Assumptions);
-  UnsatAssumptionsValid = Result == checkResult::UNSAT;
+  UnsatAssumptionsValid = Result == CheckResult::UNSAT;
   LastAssumptions =
       UnsatAssumptionsValid ? Assumptions : std::vector<SMTExprRef>{};
   return Result;
 }
 
-checkResult SMTSolverImpl::checkSatAssumingImpl(
+CheckResult SMTSolverImpl::checkSatAssumingImpl(
     const std::vector<SMTExprRef> &Assumptions) {
   push();
   for (const SMTExprRef &Assumption : Assumptions)
     addConstraint(Assumption);
-  const checkResult Result = checkImpl();
+  const CheckResult Result = checkImpl();
   pop();
   return Result;
 }
@@ -2368,7 +2369,7 @@ SMTExprRef SMTSolverImpl::mkBVAddOverflowImpl(const SMTExprRef &LHS,
     theExp = mkAnd(mkEqual(LSign, RSign), mkNot(mkEqual(LSign, SumSign)));
   } else {
     // Unsigned addition overflows iff the (Width+1)-bit sum carries out.
-    SMTExprRef Sum = mkBVAdd(mkBVZeroExt(1, LHS), mkBVZeroExt(1, RHS));
+    SMTExprRef Sum = mkBVAdd(mkBVZeroExt(LHS, 1), mkBVZeroExt(RHS, 1));
     theExp = mkEqual(mkBVExtract(Width, Width, Sum), getBVOne1Expr());
   }
   return rewrapExprImpl(*theExp, theExp->Sort, SMTExprKind::BVAddOverflow);
@@ -2403,14 +2404,14 @@ SMTExprRef SMTSolverImpl::mkBVMulOverflowImpl(const SMTExprRef &LHS,
   if (IsSigned) {
     // Multiply at double width; the product is representable iff its top
     // Width+1 bits all equal the result's sign bit.
-    SMTExprRef Prod = mkBVMul(mkBVSignExt(Width, LHS), mkBVSignExt(Width, RHS));
+    SMTExprRef Prod = mkBVMul(mkBVSignExt(LHS, Width), mkBVSignExt(RHS, Width));
     SMTExprRef Top = mkBVExtract(2 * Width - 1, Width - 1, Prod);
     SMTExprRef Zeros = mkBVFromDec(0, Width + 1);
     SMTExprRef Ones = mkBVNot(Zeros);
     theExp = mkNot(mkOr(mkEqual(Top, Zeros), mkEqual(Top, Ones)));
   } else {
     // Unsigned: any set bit in the product's top half is an overflow.
-    SMTExprRef Prod = mkBVMul(mkBVZeroExt(Width, LHS), mkBVZeroExt(Width, RHS));
+    SMTExprRef Prod = mkBVMul(mkBVZeroExt(LHS, Width), mkBVZeroExt(RHS, Width));
     SMTExprRef Top = mkBVExtract(2 * Width - 1, Width, Prod);
     theExp = mkNot(mkEqual(Top, mkBVFromDec(0, Width)));
   }
@@ -2512,7 +2513,7 @@ SMTExprRef SMTSolverImpl::mkBV2IntImpl(const SMTExprRef &Exp, bool IsSigned) {
   return rewrapExprImpl(*Sum, Sum->Sort, SMTExprKind::BV2Int);
 }
 
-SMTExprRef SMTSolverImpl::mkInt2BVImpl(unsigned Width, const SMTExprRef &Exp) {
+SMTExprRef SMTSolverImpl::mkInt2BVImpl(const SMTExprRef &Exp, unsigned Width) {
   // No native conversion and no portable operator to compose one from: a
   // bit-vector value tied to an integer can only be introduced through a
   // fresh symbol constrained via the inverse direction (the mkIEEEFPToBV

--- a/src/core/camadaimpl.cpp
+++ b/src/core/camadaimpl.cpp
@@ -2260,7 +2260,7 @@ bool SMTSolverImpl::supports(SolverFeature Feature) const {
   case SolverFeature::NativeFloatingPoint:
     return nativeFloatingPointSupport();
   case SolverFeature::NativeTuples:
-    return nativeTupleSupport();
+    return nativeDatatypeSupport();
   case SolverFeature::NativeConstantArrays:
     return nativeConstArraySupport();
   case SolverFeature::UnsatAssumptions:

--- a/src/core/camadaimpl.h
+++ b/src/core/camadaimpl.h
@@ -839,7 +839,9 @@ protected:
   /// caller asked for Native, the backend has datatypes, and Ackermann
   /// arrays are not in play, since a datatype cannot hold an array member
   /// with no backend term -- so it lives here instead of being repeated
-  /// identically in every backend that has datatypes.
+  /// identically in every backend that has datatypes. This is the internal
+  /// routing predicate; supports(NativeTuples) reports the backend
+  /// capability and ignores the configuration.
   virtual bool nativeTupleSupport() const final {
     return tupleMode() == TupleEncoding::Native &&
            arrayMode() != ArrayEncoding::Ackermann && nativeDatatypeSupport();

--- a/src/core/camadaimpl.h
+++ b/src/core/camadaimpl.h
@@ -544,12 +544,14 @@ public:
   SMTExprRef mkInt2Real(const SMTExprRef &Exp) override final;
   SMTExprRef mkReal2Int(const SMTExprRef &Exp) override final;
   SMTExprRef mkIsInt(const SMTExprRef &Exp) override final;
-  SMTExprRef mkInt2BV(unsigned Width, const SMTExprRef &Exp) override final;
+  SMTExprRef mkInt2BV(const SMTExprRef &Exp, unsigned Width) override final;
   SMTExprRef mkBV2Int(const SMTExprRef &Exp, bool IsSigned) override final;
   SMTExprRef mkIte(const SMTExprRef &Cond, const SMTExprRef &T,
                    const SMTExprRef &F) override final;
-  SMTExprRef mkBVSignExt(unsigned i, const SMTExprRef &Exp) override final;
-  SMTExprRef mkBVZeroExt(unsigned i, const SMTExprRef &Exp) override final;
+  SMTExprRef mkBVSignExt(const SMTExprRef &Exp,
+                         unsigned ExtraBits) override final;
+  SMTExprRef mkBVZeroExt(const SMTExprRef &Exp,
+                         unsigned ExtraBits) override final;
   SMTExprRef mkBVExtract(unsigned High, unsigned Low,
                          const SMTExprRef &Exp) override final;
   SMTExprRef mkBVConcat(const SMTExprRef &LHS,
@@ -563,7 +565,7 @@ public:
   SMTExprRef mkFPIsInfinite(const SMTExprRef &Exp) override final;
   SMTExprRef mkFPIsNaN(const SMTExprRef &Exp) override final;
 
-  SMTExprRef mkFPIsDenormal(const SMTExprRef &Exp) override final;
+  SMTExprRef mkFPIsSubnormal(const SMTExprRef &Exp) override final;
   SMTExprRef mkFPIsNormal(const SMTExprRef &Exp) override final;
   SMTExprRef mkFPIsZero(const SMTExprRef &Exp) override final;
   SMTExprRef mkFPMul(const SMTExprRef &LHS, const SMTExprRef &RHS,
@@ -590,15 +592,15 @@ public:
                     const SMTExprRef &RHS) override final;
   SMTExprRef mkFPEqual(const SMTExprRef &LHS,
                        const SMTExprRef &RHS) override final;
-  SMTExprRef mkFPtoFP(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkFPToFP(const SMTExprRef &From, const SMTSortRef &To,
                       const SMTExprRef &R) override final;
-  SMTExprRef mkSBVtoFP(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkSBVToFP(const SMTExprRef &From, const SMTSortRef &To,
                        const SMTExprRef &R) override final;
-  SMTExprRef mkUBVtoFP(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkUBVToFP(const SMTExprRef &From, const SMTSortRef &To,
                        const SMTExprRef &R) override final;
-  SMTExprRef mkFPtoSBV(const SMTExprRef &From, unsigned ToWidth) override final;
-  SMTExprRef mkFPtoUBV(const SMTExprRef &From, unsigned ToWidth) override final;
-  SMTExprRef mkFPtoIntegral(const SMTExprRef &From,
+  SMTExprRef mkFPToSBV(const SMTExprRef &From, unsigned ToWidth) override final;
+  SMTExprRef mkFPToUBV(const SMTExprRef &From, unsigned ToWidth) override final;
+  SMTExprRef mkFPToIntegral(const SMTExprRef &From,
                             const SMTExprRef &R) override final;
   // Fixed-point operations (all implemented once, in camadafxp.cpp, on top
   // of the public BV surface — no backend hooks).
@@ -753,10 +755,10 @@ public:
   SMTExprRef mkBVToIEEEFP(const SMTExprRef &Exp,
                           const SMTSortRef &To) override final;
   SMTExprRef mkIEEEFPToBV(const SMTExprRef &Exp) override final;
-  checkResult check() override final;
+  CheckResult check() override final;
   bool setTimeout(uint64_t Milliseconds) override final;
 
-  checkResult
+  CheckResult
   checkSatAssuming(const std::vector<SMTExprRef> &Assumptions) override final;
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptions() override final;
 
@@ -1024,7 +1026,7 @@ protected:
   /// Int -> BV conversion. The default lowers through a fresh BV symbol
   /// constrained via mkBV2IntImpl (no portable SMT-LIB operator exists);
   /// backends with a native conversion (Z3, cvc5, MathSAT) override.
-  virtual SMTExprRef mkInt2BVImpl(unsigned Width, const SMTExprRef &Exp);
+  virtual SMTExprRef mkInt2BVImpl(const SMTExprRef &Exp, unsigned Width);
 
   /// BV -> Int conversion. The default composes the value as a sum of
   /// bit-tests, which works on any backend with both theories.
@@ -1036,9 +1038,11 @@ protected:
   virtual SMTExprRef mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                                const SMTExprRef &F) = 0;
 
-  virtual SMTExprRef mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) = 0;
+  virtual SMTExprRef mkBVSignExtImpl(const SMTExprRef &Exp,
+                                     unsigned ExtraBits) = 0;
 
-  virtual SMTExprRef mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) = 0;
+  virtual SMTExprRef mkBVZeroExtImpl(const SMTExprRef &Exp,
+                                     unsigned ExtraBits) = 0;
 
   virtual SMTExprRef mkBVExtractImpl(unsigned High, unsigned Low,
                                      const SMTExprRef &Exp) = 0;
@@ -1058,7 +1062,7 @@ protected:
 
   virtual SMTExprRef mkFPIsNaNImpl(const SMTExprRef &Exp);
 
-  virtual SMTExprRef mkFPIsDenormalImpl(const SMTExprRef &Exp);
+  virtual SMTExprRef mkFPIsSubnormalImpl(const SMTExprRef &Exp);
 
   virtual SMTExprRef mkFPIsNormalImpl(const SMTExprRef &Exp);
 
@@ -1094,20 +1098,20 @@ protected:
   virtual SMTExprRef mkFPEqualImpl(const SMTExprRef &LHS,
                                    const SMTExprRef &RHS);
 
-  virtual SMTExprRef mkFPtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  virtual SMTExprRef mkFPToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                   const SMTExprRef &R);
 
-  virtual SMTExprRef mkSBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  virtual SMTExprRef mkSBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                    const SMTExprRef &R);
 
-  virtual SMTExprRef mkUBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  virtual SMTExprRef mkUBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                    const SMTExprRef &R);
 
-  virtual SMTExprRef mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth);
+  virtual SMTExprRef mkFPToSBVImpl(const SMTExprRef &From, unsigned ToWidth);
 
-  virtual SMTExprRef mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth);
+  virtual SMTExprRef mkFPToUBVImpl(const SMTExprRef &From, unsigned ToWidth);
 
-  virtual SMTExprRef mkFPtoIntegralImpl(const SMTExprRef &From,
+  virtual SMTExprRef mkFPToIntegralImpl(const SMTExprRef &From,
                                         const SMTExprRef &R);
 
   virtual SMTExprRef mkArraySelectImpl(const SMTExprRef &Array,
@@ -1217,7 +1221,7 @@ protected:
                            SMTExprRef &Sig, SMTExprRef &Exp, unsigned EWidth,
                            unsigned SWidth);
 
-  virtual checkResult checkImpl() = 0;
+  virtual CheckResult checkImpl() = 0;
 
   /// Apply a per-check wall-clock limit (milliseconds; 0 disables) to the
   /// backend. Returns false when the backend cannot enforce it — the
@@ -1230,7 +1234,7 @@ protected:
   /// push a scope, assert each assumption, check, pop. Goes through the
   /// public push/pop/addConstraint so the lazy constant-array journal
   /// stays consistent.
-  virtual checkResult
+  virtual CheckResult
   checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions);
 
   /// Only dispatched right after checkSatAssumingImpl returned UNSAT for a

--- a/src/solvers/bitwuzlasolver.cpp
+++ b/src/solvers/bitwuzlasolver.cpp
@@ -292,9 +292,9 @@ SMTExprRef BitwuzlaSolver::mkFPIsNaNImpl(const SMTExprRef &Exp) {
       mkTerm1(TermManager, BITWUZLA_KIND_FP_IS_NAN, Exp));
 }
 
-SMTExprRef BitwuzlaSolver::mkFPIsDenormalImpl(const SMTExprRef &Exp) {
+SMTExprRef BitwuzlaSolver::mkFPIsSubnormalImpl(const SMTExprRef &Exp) {
   return makeExprRef<BitwExpr>(
-      SMTExprKind::FPIsDenormal, Context, mkBoolSort(),
+      SMTExprKind::FPIsSubnormal, Context, mkBoolSort(),
       mkTerm1(TermManager, BITWUZLA_KIND_FP_IS_SUBNORMAL, Exp));
 }
 
@@ -616,18 +616,20 @@ SMTExprRef BitwuzlaSolver::mkIteImpl(const SMTExprRef &Cond,
       mkTerm3(TermManager, BITWUZLA_KIND_ITE, Cond, T, F));
 }
 
-SMTExprRef BitwuzlaSolver::mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef BitwuzlaSolver::mkBVSignExtImpl(const SMTExprRef &Exp,
+                                           unsigned ExtraBits) {
   return makeExprRef<BitwExpr>(
-      SMTExprKind::BVSignExt, Context, mkBVSort(i + Exp->getWidth()),
+      SMTExprKind::BVSignExt, Context, mkBVSort(ExtraBits + Exp->getWidth()),
       bitwuzla_mk_term1_indexed1(TermManager, BITWUZLA_KIND_BV_SIGN_EXTEND,
-                                 toSolverExpr<BitwExpr>(*Exp).Expr, i));
+                                 toSolverExpr<BitwExpr>(*Exp).Expr, ExtraBits));
 }
 
-SMTExprRef BitwuzlaSolver::mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef BitwuzlaSolver::mkBVZeroExtImpl(const SMTExprRef &Exp,
+                                           unsigned ExtraBits) {
   return makeExprRef<BitwExpr>(
-      SMTExprKind::BVZeroExt, Context, mkBVSort(i + Exp->getWidth()),
+      SMTExprKind::BVZeroExt, Context, mkBVSort(ExtraBits + Exp->getWidth()),
       bitwuzla_mk_term1_indexed1(TermManager, BITWUZLA_KIND_BV_ZERO_EXTEND,
-                                 toSolverExpr<BitwExpr>(*Exp).Expr, i));
+                                 toSolverExpr<BitwExpr>(*Exp).Expr, ExtraBits));
 }
 
 SMTExprRef BitwuzlaSolver::mkBVExtractImpl(unsigned High, unsigned Low,
@@ -685,7 +687,7 @@ SMTExprRef BitwuzlaSolver::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
       mkTerm4(TermManager, BITWUZLA_KIND_FP_FMA, R, X, Y, Z));
 }
 
-SMTExprRef BitwuzlaSolver::mkFPtoFPImpl(const SMTExprRef &From,
+SMTExprRef BitwuzlaSolver::mkFPToFPImpl(const SMTExprRef &From,
                                         const SMTSortRef &To,
                                         const SMTExprRef &R) {
   return makeExprRef<BitwExpr>(
@@ -696,7 +698,7 @@ SMTExprRef BitwuzlaSolver::mkFPtoFPImpl(const SMTExprRef &From,
           To->getFPExponentWidth(), To->getFPSignificandWidth() + 1));
 }
 
-SMTExprRef BitwuzlaSolver::mkSBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef BitwuzlaSolver::mkSBVToFPImpl(const SMTExprRef &From,
                                          const SMTSortRef &To,
                                          const SMTExprRef &R) {
   return makeExprRef<BitwExpr>(
@@ -707,7 +709,7 @@ SMTExprRef BitwuzlaSolver::mkSBVtoFPImpl(const SMTExprRef &From,
           To->getFPExponentWidth(), To->getFPSignificandWidth() + 1));
 }
 
-SMTExprRef BitwuzlaSolver::mkUBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef BitwuzlaSolver::mkUBVToFPImpl(const SMTExprRef &From,
                                          const SMTSortRef &To,
                                          const SMTExprRef &R) {
   return makeExprRef<BitwExpr>(
@@ -718,7 +720,7 @@ SMTExprRef BitwuzlaSolver::mkUBVtoFPImpl(const SMTExprRef &From,
           To->getFPExponentWidth(), To->getFPSignificandWidth() + 1));
 }
 
-SMTExprRef BitwuzlaSolver::mkFPtoSBVImpl(const SMTExprRef &From,
+SMTExprRef BitwuzlaSolver::mkFPToSBVImpl(const SMTExprRef &From,
                                          unsigned ToWidth) {
   const SMTExprRef &roundingMode = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
   return makeExprRef<BitwExpr>(
@@ -728,7 +730,7 @@ SMTExprRef BitwuzlaSolver::mkFPtoSBVImpl(const SMTExprRef &From,
                                  toSolverExpr<BitwExpr>(*From).Expr, ToWidth));
 }
 
-SMTExprRef BitwuzlaSolver::mkFPtoUBVImpl(const SMTExprRef &From,
+SMTExprRef BitwuzlaSolver::mkFPToUBVImpl(const SMTExprRef &From,
                                          unsigned ToWidth) {
   const SMTExprRef &roundingMode = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
   return makeExprRef<BitwExpr>(
@@ -738,7 +740,7 @@ SMTExprRef BitwuzlaSolver::mkFPtoUBVImpl(const SMTExprRef &From,
                                  toSolverExpr<BitwExpr>(*From).Expr, ToWidth));
 }
 
-SMTExprRef BitwuzlaSolver::mkFPtoIntegralImpl(const SMTExprRef &From,
+SMTExprRef BitwuzlaSolver::mkFPToIntegralImpl(const SMTExprRef &From,
                                               const SMTExprRef &R) {
   return makeExprRef<BitwExpr>(
       SMTExprKind::FPtoIntegral, Context, From->Sort,
@@ -1016,21 +1018,21 @@ void BitwuzlaSolver::armCheckDeadline() {
                                        std::chrono::milliseconds(TimeoutMs);
 }
 
-checkResult BitwuzlaSolver::checkImpl() {
+CheckResult BitwuzlaSolver::checkImpl() {
   armCheckDeadline();
   BitwuzlaResult res = bitwuzla_check_sat(Context);
   if (res == BITWUZLA_SAT)
-    return checkResult::SAT;
+    return CheckResult::SAT;
   if (res == BITWUZLA_UNSAT)
-    return checkResult::UNSAT;
-  return checkResult::UNKNOWN;
+    return CheckResult::UNSAT;
+  return CheckResult::UNKNOWN;
 }
 
 // The termination callback is always registered; arming the deadline per
 // check (above) is all that is needed.
 bool BitwuzlaSolver::setTimeoutImpl(uint64_t) { return true; }
 
-checkResult BitwuzlaSolver::checkSatAssumingImpl(
+CheckResult BitwuzlaSolver::checkSatAssumingImpl(
     const std::vector<SMTExprRef> &Assumptions) {
   std::vector<BitwuzlaTerm> assumptions;
   assumptions.reserve(Assumptions.size());
@@ -1041,10 +1043,10 @@ checkResult BitwuzlaSolver::checkSatAssumingImpl(
   BitwuzlaResult res = bitwuzla_check_sat_assuming(
       Context, static_cast<uint32_t>(assumptions.size()), assumptions.data());
   if (res == BITWUZLA_SAT)
-    return checkResult::SAT;
+    return CheckResult::SAT;
   if (res == BITWUZLA_UNSAT)
-    return checkResult::UNSAT;
-  return checkResult::UNKNOWN;
+    return CheckResult::UNSAT;
+  return CheckResult::UNKNOWN;
 }
 
 SMTResult<std::vector<SMTExprRef>> BitwuzlaSolver::getUnsatAssumptionsImpl() {

--- a/src/solvers/bitwuzlasolver.h
+++ b/src/solvers/bitwuzlasolver.h
@@ -159,8 +159,10 @@ protected:
   SMTExprRef mkEqualImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
   SMTExprRef mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                        const SMTExprRef &F) override;
-  SMTExprRef mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) override;
-  SMTExprRef mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVSignExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
+  SMTExprRef mkBVZeroExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
   SMTExprRef mkBVExtractImpl(unsigned High, unsigned Low,
                              const SMTExprRef &Exp) override;
   SMTExprRef mkBVConcatImpl(const SMTExprRef &LHS,
@@ -171,7 +173,7 @@ protected:
   SMTExprRef mkFPNegImpl(const SMTExprRef &Exp, FPNegBehavior) override;
   SMTExprRef mkFPIsInfiniteImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkFPIsNaNImpl(const SMTExprRef &Exp) override;
-  SMTExprRef mkFPIsDenormalImpl(const SMTExprRef &Exp) override;
+  SMTExprRef mkFPIsSubnormalImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkFPIsNormalImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkFPIsZeroImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkFPMulImpl(const SMTExprRef &LHS, const SMTExprRef &RHS,
@@ -192,15 +194,15 @@ protected:
   SMTExprRef mkFPGeImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
   SMTExprRef mkFPEqualImpl(const SMTExprRef &LHS,
                            const SMTExprRef &RHS) override;
-  SMTExprRef mkFPtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkFPToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                           const SMTExprRef &R) override;
-  SMTExprRef mkSBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkSBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
-  SMTExprRef mkUBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkUBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
-  SMTExprRef mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
-  SMTExprRef mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
-  SMTExprRef mkFPtoIntegralImpl(const SMTExprRef &From,
+  SMTExprRef mkFPToSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToIntegralImpl(const SMTExprRef &From,
                                 const SMTExprRef &R) override;
   SMTExprRef mkArraySelectImpl(const SMTExprRef &Array,
                                const SMTExprRef &Index) override;
@@ -249,10 +251,10 @@ protected:
                               const SMTSortRef &To) override;
   SMTExprRef mkIEEEFPToBVImpl(const SMTExprRef &Exp) override;
 
-  checkResult checkImpl() override;
+  CheckResult checkImpl() override;
   bool setTimeoutImpl(uint64_t Milliseconds) override;
 
-  checkResult
+  CheckResult
   checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
 

--- a/src/solvers/cvc5solver.cpp
+++ b/src/solvers/cvc5solver.cpp
@@ -270,7 +270,7 @@ SMTExprRef CVC5Solver::mkIsIntImpl(const SMTExprRef &Exp) {
                    {toSolverExpr<CVC5Expr>(*Exp).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkInt2BVImpl(unsigned Width, const SMTExprRef &Exp) {
+SMTExprRef CVC5Solver::mkInt2BVImpl(const SMTExprRef &Exp, unsigned Width) {
   return makeExprRef<CVC5Expr>(
       SMTExprKind::Int2BV, &Context, mkBVSort(Width),
       Terms.mkTerm(Terms.mkOp(cvc5::Kind::INT_TO_BITVECTOR, {Width}),
@@ -680,17 +680,19 @@ SMTExprRef CVC5Solver::mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                                      toSolverExpr<CVC5Expr>(*F).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef CVC5Solver::mkBVSignExtImpl(const SMTExprRef &Exp,
+                                       unsigned ExtraBits) {
   return makeExprRef<CVC5Expr>(
-      SMTExprKind::BVSignExt, &Context, mkBVSort(i + Exp->getWidth()),
-      Terms.mkTerm(Terms.mkOp(cvc5::Kind::BITVECTOR_SIGN_EXTEND, {i}),
+      SMTExprKind::BVSignExt, &Context, mkBVSort(ExtraBits + Exp->getWidth()),
+      Terms.mkTerm(Terms.mkOp(cvc5::Kind::BITVECTOR_SIGN_EXTEND, {ExtraBits}),
                    {toSolverExpr<CVC5Expr>(*Exp).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef CVC5Solver::mkBVZeroExtImpl(const SMTExprRef &Exp,
+                                       unsigned ExtraBits) {
   return makeExprRef<CVC5Expr>(
-      SMTExprKind::BVZeroExt, &Context, mkBVSort(i + Exp->getWidth()),
-      Terms.mkTerm(Terms.mkOp(cvc5::Kind::BITVECTOR_ZERO_EXTEND, {i}),
+      SMTExprKind::BVZeroExt, &Context, mkBVSort(ExtraBits + Exp->getWidth()),
+      Terms.mkTerm(Terms.mkOp(cvc5::Kind::BITVECTOR_ZERO_EXTEND, {ExtraBits}),
                    {toSolverExpr<CVC5Expr>(*Exp).Expr}));
 }
 
@@ -795,9 +797,9 @@ SMTExprRef CVC5Solver::mkFPIsNaNImpl(const SMTExprRef &Exp) {
                    {toSolverExpr<CVC5Expr>(*Exp).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkFPIsDenormalImpl(const SMTExprRef &Exp) {
+SMTExprRef CVC5Solver::mkFPIsSubnormalImpl(const SMTExprRef &Exp) {
   return makeExprRef<CVC5Expr>(
-      SMTExprKind::FPIsDenormal, &Context, mkBoolSort(),
+      SMTExprKind::FPIsSubnormal, &Context, mkBoolSort(),
       Terms.mkTerm(cvc5::Kind::FLOATINGPOINT_IS_SUBNORMAL,
                    {toSolverExpr<CVC5Expr>(*Exp).Expr}));
 }
@@ -929,7 +931,7 @@ SMTExprRef CVC5Solver::mkFPEqualImpl(const SMTExprRef &LHS,
                     toSolverExpr<CVC5Expr>(*RHS).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkFPtoFPImpl(const SMTExprRef &From,
+SMTExprRef CVC5Solver::mkFPToFPImpl(const SMTExprRef &From,
                                     const SMTSortRef &To, const SMTExprRef &R) {
   return makeExprRef<CVC5Expr>(
       SMTExprKind::FPtoFP, &Context, To,
@@ -940,7 +942,7 @@ SMTExprRef CVC5Solver::mkFPtoFPImpl(const SMTExprRef &From,
                     toSolverExpr<CVC5Expr>(*From).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkSBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef CVC5Solver::mkSBVToFPImpl(const SMTExprRef &From,
                                      const SMTSortRef &To,
                                      const SMTExprRef &R) {
   return makeExprRef<CVC5Expr>(
@@ -952,7 +954,7 @@ SMTExprRef CVC5Solver::mkSBVtoFPImpl(const SMTExprRef &From,
                     toSolverExpr<CVC5Expr>(*From).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkUBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef CVC5Solver::mkUBVToFPImpl(const SMTExprRef &From,
                                      const SMTSortRef &To,
                                      const SMTExprRef &R) {
   return makeExprRef<CVC5Expr>(
@@ -964,7 +966,7 @@ SMTExprRef CVC5Solver::mkUBVtoFPImpl(const SMTExprRef &From,
                     toSolverExpr<CVC5Expr>(*From).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) {
+SMTExprRef CVC5Solver::mkFPToSBVImpl(const SMTExprRef &From, unsigned ToWidth) {
   // Conversion from float to integers always truncate, so we assume
   // the round mode to be toward zero
   const SMTExprRef &roundingMode = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
@@ -975,7 +977,7 @@ SMTExprRef CVC5Solver::mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) {
                     toSolverExpr<CVC5Expr>(*From).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) {
+SMTExprRef CVC5Solver::mkFPToUBVImpl(const SMTExprRef &From, unsigned ToWidth) {
   // Conversion from float to integers always truncate, so we assume
   // the round mode to be toward zero
   const SMTExprRef &roundingMode = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
@@ -986,7 +988,7 @@ SMTExprRef CVC5Solver::mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) {
                     toSolverExpr<CVC5Expr>(*From).Expr}));
 }
 
-SMTExprRef CVC5Solver::mkFPtoIntegralImpl(const SMTExprRef &From,
+SMTExprRef CVC5Solver::mkFPToIntegralImpl(const SMTExprRef &From,
                                           const SMTExprRef &R) {
   return makeExprRef<CVC5Expr>(
       SMTExprKind::FPtoIntegral, &Context, From->Sort,
@@ -1239,15 +1241,15 @@ SMTExprRef CVC5Solver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
       Terms.mkTerm(cvc5::Kind::EXISTS, {bound_list, substituted_body}));
 }
 
-checkResult CVC5Solver::checkImpl() {
+CheckResult CVC5Solver::checkImpl() {
   cvc5::Result res = Context.checkSat();
   if (res.isSat())
-    return checkResult::SAT;
+    return CheckResult::SAT;
 
   if (res.isUnknown())
-    return checkResult::UNKNOWN;
+    return CheckResult::UNKNOWN;
 
-  return checkResult::UNSAT;
+  return CheckResult::UNSAT;
 }
 
 bool CVC5Solver::setTimeoutImpl(uint64_t Milliseconds) {
@@ -1257,7 +1259,7 @@ bool CVC5Solver::setTimeoutImpl(uint64_t Milliseconds) {
   return true;
 }
 
-checkResult
+CheckResult
 CVC5Solver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
   std::vector<cvc5::Term> assumptions;
   assumptions.reserve(Assumptions.size());
@@ -1266,12 +1268,12 @@ CVC5Solver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
 
   cvc5::Result res = Context.checkSatAssuming(assumptions);
   if (res.isSat())
-    return checkResult::SAT;
+    return CheckResult::SAT;
 
   if (res.isUnknown())
-    return checkResult::UNKNOWN;
+    return CheckResult::UNKNOWN;
 
-  return checkResult::UNSAT;
+  return CheckResult::UNSAT;
 }
 
 SMTResult<std::vector<SMTExprRef>> CVC5Solver::getUnsatAssumptionsImpl() {

--- a/src/solvers/cvc5solver.h
+++ b/src/solvers/cvc5solver.h
@@ -221,7 +221,7 @@ protected:
   SMTExprRef mkInt2RealImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkReal2IntImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkIsIntImpl(const SMTExprRef &Exp) override;
-  SMTExprRef mkInt2BVImpl(unsigned Width, const SMTExprRef &Exp) override;
+  SMTExprRef mkInt2BVImpl(const SMTExprRef &Exp, unsigned Width) override;
   SMTExprRef mkBV2IntImpl(const SMTExprRef &Exp, bool IsSigned) override;
 
   SMTExprRef mkEqualImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
@@ -229,9 +229,11 @@ protected:
   SMTExprRef mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                        const SMTExprRef &F) override;
 
-  SMTExprRef mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVSignExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
-  SMTExprRef mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVZeroExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
   SMTExprRef mkBVExtractImpl(unsigned High, unsigned Low,
                              const SMTExprRef &Exp) override;
@@ -262,7 +264,7 @@ protected:
 
   SMTExprRef mkFPIsNaNImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef mkFPIsDenormalImpl(const SMTExprRef &Exp) override;
+  SMTExprRef mkFPIsSubnormalImpl(const SMTExprRef &Exp) override;
 
   SMTExprRef mkFPIsNormalImpl(const SMTExprRef &Exp) override;
 
@@ -298,20 +300,20 @@ protected:
   SMTExprRef mkFPEqualImpl(const SMTExprRef &LHS,
                            const SMTExprRef &RHS) override;
 
-  SMTExprRef mkFPtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkFPToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                           const SMTExprRef &R) override;
 
-  SMTExprRef mkSBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkSBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
 
-  SMTExprRef mkUBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkUBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
 
-  SMTExprRef mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
 
-  SMTExprRef mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
 
-  SMTExprRef mkFPtoIntegralImpl(const SMTExprRef &From,
+  SMTExprRef mkFPToIntegralImpl(const SMTExprRef &From,
                                 const SMTExprRef &R) override;
 
   SMTResult<bool> getBoolImpl(const SMTExprRef &Exp) override;
@@ -364,11 +366,11 @@ protected:
   SMTExprRef mkArrayConstImpl(const SMTSortRef &IndexSort,
                               const SMTExprRef &InitValue) override;
 
-  checkResult checkImpl() override;
+  CheckResult checkImpl() override;
 
   bool setTimeoutImpl(uint64_t Milliseconds) override;
 
-  checkResult
+  CheckResult
   checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
 
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;

--- a/src/solvers/mathsatsolver.cpp
+++ b/src/solvers/mathsatsolver.cpp
@@ -544,7 +544,7 @@ SMTExprRef MathSATSolver::mkIsIntImpl(const SMTExprRef &Exp) {
   return rewrapExprImpl(*theExp, theExp->Sort, SMTExprKind::IsInt);
 }
 
-SMTExprRef MathSATSolver::mkInt2BVImpl(unsigned Width, const SMTExprRef &Exp) {
+SMTExprRef MathSATSolver::mkInt2BVImpl(const SMTExprRef &Exp, unsigned Width) {
   return makeExprRef<MathSATExpr>(
       SMTExprKind::Int2BV, &Context, mkBVSort(Width),
       msat_make_int_to_bv(Context, Width, toMathSATTerm(Exp)));
@@ -575,16 +575,18 @@ SMTExprRef MathSATSolver::mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                          toMathSATTerm(F)));
 }
 
-SMTExprRef MathSATSolver::mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef MathSATSolver::mkBVSignExtImpl(const SMTExprRef &Exp,
+                                          unsigned ExtraBits) {
   return makeExprRef<MathSATExpr>(
-      SMTExprKind::BVSignExt, &Context, mkBVSort(i + Exp->getWidth()),
-      msat_make_bv_sext(Context, i, toMathSATTerm(Exp)));
+      SMTExprKind::BVSignExt, &Context, mkBVSort(ExtraBits + Exp->getWidth()),
+      msat_make_bv_sext(Context, ExtraBits, toMathSATTerm(Exp)));
 }
 
-SMTExprRef MathSATSolver::mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef MathSATSolver::mkBVZeroExtImpl(const SMTExprRef &Exp,
+                                          unsigned ExtraBits) {
   return makeExprRef<MathSATExpr>(
-      SMTExprKind::BVZeroExt, &Context, mkBVSort(i + Exp->getWidth()),
-      msat_make_bv_zext(Context, i, toMathSATTerm(Exp)));
+      SMTExprKind::BVZeroExt, &Context, mkBVSort(ExtraBits + Exp->getWidth()),
+      msat_make_bv_zext(Context, ExtraBits, toMathSATTerm(Exp)));
 }
 
 SMTExprRef MathSATSolver::mkBVExtractImpl(unsigned High, unsigned Low,
@@ -670,9 +672,9 @@ SMTExprRef MathSATSolver::mkFPIsNaNImpl(const SMTExprRef &Exp) {
       msat_make_fp_isnan(Context, toMathSATTerm(Exp)));
 }
 
-SMTExprRef MathSATSolver::mkFPIsDenormalImpl(const SMTExprRef &Exp) {
+SMTExprRef MathSATSolver::mkFPIsSubnormalImpl(const SMTExprRef &Exp) {
   return makeExprRef<MathSATExpr>(
-      SMTExprKind::FPIsDenormal, &Context, mkBoolSort(),
+      SMTExprKind::FPIsSubnormal, &Context, mkBoolSort(),
       msat_make_fp_issubnormal(Context, toMathSATTerm(Exp)));
 }
 
@@ -798,7 +800,7 @@ SMTExprRef MathSATSolver::mkFPEqualImpl(const SMTExprRef &LHS,
       msat_make_fp_equal(Context, toMathSATTerm(LHS), toMathSATTerm(RHS)));
 }
 
-SMTExprRef MathSATSolver::mkFPtoFPImpl(const SMTExprRef &From,
+SMTExprRef MathSATSolver::mkFPToFPImpl(const SMTExprRef &From,
                                        const SMTSortRef &To,
                                        const SMTExprRef &R) {
   return makeExprRef<MathSATExpr>(
@@ -808,7 +810,7 @@ SMTExprRef MathSATSolver::mkFPtoFPImpl(const SMTExprRef &From,
                         toMathSATTerm(From)));
 }
 
-SMTExprRef MathSATSolver::mkSBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef MathSATSolver::mkSBVToFPImpl(const SMTExprRef &From,
                                         const SMTSortRef &To,
                                         const SMTExprRef &R) {
   return makeExprRef<MathSATExpr>(
@@ -818,7 +820,7 @@ SMTExprRef MathSATSolver::mkSBVtoFPImpl(const SMTExprRef &From,
                             toMathSATTerm(From)));
 }
 
-SMTExprRef MathSATSolver::mkUBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef MathSATSolver::mkUBVToFPImpl(const SMTExprRef &From,
                                         const SMTSortRef &To,
                                         const SMTExprRef &R) {
   return makeExprRef<MathSATExpr>(
@@ -828,7 +830,7 @@ SMTExprRef MathSATSolver::mkUBVtoFPImpl(const SMTExprRef &From,
                             toMathSATTerm(From)));
 }
 
-SMTExprRef MathSATSolver::mkFPtoSBVImpl(const SMTExprRef &From,
+SMTExprRef MathSATSolver::mkFPToSBVImpl(const SMTExprRef &From,
                                         unsigned ToWidth) {
   // Conversion from float to integers always truncate, so we assume
   // the round mode to be toward zero
@@ -839,7 +841,7 @@ SMTExprRef MathSATSolver::mkFPtoSBVImpl(const SMTExprRef &From,
                          toMathSATTerm(From)));
 }
 
-SMTExprRef MathSATSolver::mkFPtoUBVImpl(const SMTExprRef &From,
+SMTExprRef MathSATSolver::mkFPToUBVImpl(const SMTExprRef &From,
                                         unsigned ToWidth) {
   // Conversion from float to integers always truncate, so we assume
   // the round mode to be toward zero
@@ -850,7 +852,7 @@ SMTExprRef MathSATSolver::mkFPtoUBVImpl(const SMTExprRef &From,
                           toMathSATTerm(From)));
 }
 
-SMTExprRef MathSATSolver::mkFPtoIntegralImpl(const SMTExprRef &From,
+SMTExprRef MathSATSolver::mkFPToIntegralImpl(const SMTExprRef &From,
                                              const SMTExprRef &R) {
   return makeExprRef<MathSATExpr>(
       SMTExprKind::FPtoIntegral, &Context, From->Sort,
@@ -1175,23 +1177,23 @@ void MathSATSolver::armCheckDeadline() {
                                        std::chrono::milliseconds(TimeoutMs);
 }
 
-checkResult MathSATSolver::checkImpl() {
+CheckResult MathSATSolver::checkImpl() {
   armCheckDeadline();
   msat_result res = msat_solve(Context);
   if (res == MSAT_SAT)
-    return checkResult::SAT;
+    return CheckResult::SAT;
 
   if (res == MSAT_UNSAT)
-    return checkResult::UNSAT;
+    return CheckResult::UNSAT;
 
-  return checkResult::UNKNOWN;
+  return CheckResult::UNKNOWN;
 }
 
 // The termination test is always registered; arming the deadline per
 // check (above) is all that is needed.
 bool MathSATSolver::setTimeoutImpl(uint64_t) { return true; }
 
-checkResult MathSATSolver::checkSatAssumingImpl(
+CheckResult MathSATSolver::checkSatAssumingImpl(
     const std::vector<SMTExprRef> &Assumptions) {
   // msat_solve_with_assumptions rejects anything but (negated) Boolean
   // constants, so activate each assumption through a fresh literal:
@@ -1215,12 +1217,12 @@ checkResult MathSATSolver::checkSatAssumingImpl(
   msat_result res =
       msat_solve_with_assumptions(Context, lits.data(), lits.size());
   if (res == MSAT_SAT)
-    return checkResult::SAT;
+    return CheckResult::SAT;
 
   if (res == MSAT_UNSAT)
-    return checkResult::UNSAT;
+    return CheckResult::UNSAT;
 
-  return checkResult::UNKNOWN;
+  return CheckResult::UNKNOWN;
 }
 
 SMTResult<std::vector<SMTExprRef>> MathSATSolver::getUnsatAssumptionsImpl() {

--- a/src/solvers/mathsatsolver.h
+++ b/src/solvers/mathsatsolver.h
@@ -205,7 +205,7 @@ protected:
   SMTExprRef mkInt2RealImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkReal2IntImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkIsIntImpl(const SMTExprRef &Exp) override;
-  SMTExprRef mkInt2BVImpl(unsigned Width, const SMTExprRef &Exp) override;
+  SMTExprRef mkInt2BVImpl(const SMTExprRef &Exp, unsigned Width) override;
   SMTExprRef mkBV2IntImpl(const SMTExprRef &Exp, bool IsSigned) override;
 
   SMTExprRef mkEqualImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
@@ -213,9 +213,11 @@ protected:
   SMTExprRef mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                        const SMTExprRef &F) override;
 
-  SMTExprRef mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVSignExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
-  SMTExprRef mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVZeroExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
   SMTExprRef mkBVExtractImpl(unsigned High, unsigned Low,
                              const SMTExprRef &Exp) override;
@@ -239,7 +241,7 @@ protected:
 
   SMTExprRef mkFPIsNaNImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef mkFPIsDenormalImpl(const SMTExprRef &Exp) override;
+  SMTExprRef mkFPIsSubnormalImpl(const SMTExprRef &Exp) override;
 
   SMTExprRef mkFPIsNormalImpl(const SMTExprRef &Exp) override;
 
@@ -271,20 +273,20 @@ protected:
   SMTExprRef mkFPEqualImpl(const SMTExprRef &LHS,
                            const SMTExprRef &RHS) override;
 
-  SMTExprRef mkFPtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkFPToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                           const SMTExprRef &R) override;
 
-  SMTExprRef mkSBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkSBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
 
-  SMTExprRef mkUBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkUBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
 
-  SMTExprRef mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
 
-  SMTExprRef mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
 
-  SMTExprRef mkFPtoIntegralImpl(const SMTExprRef &From,
+  SMTExprRef mkFPToIntegralImpl(const SMTExprRef &From,
                                 const SMTExprRef &R) override;
 
   SMTResult<bool> getBoolImpl(const SMTExprRef &Exp) override;
@@ -343,11 +345,11 @@ protected:
   SMTExprRef mkArrayConstImpl(const SMTSortRef &IndexSort,
                               const SMTExprRef &InitValue) override;
 
-  checkResult checkImpl() override;
+  CheckResult checkImpl() override;
 
   bool setTimeoutImpl(uint64_t Milliseconds) override;
 
-  checkResult
+  CheckResult
   checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
 
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;

--- a/src/solvers/smtlibsolver.cpp
+++ b/src/solvers/smtlibsolver.cpp
@@ -736,7 +736,7 @@ SMTLIBSolver::SMTLIBSolver(SMTLIBOneShotTag, const std::string &FormulaPath,
   initializeCommonSingletons();
 }
 
-std::optional<checkResult> parseOneShotVerdictLine(const std::string &Raw) {
+std::optional<CheckResult> parseOneShotVerdictLine(const std::string &Raw) {
   const std::size_t Start = Raw.find_first_not_of(" \t\r\n");
   if (Start == std::string::npos)
     return std::nullopt;
@@ -744,11 +744,11 @@ std::optional<checkResult> parseOneShotVerdictLine(const std::string &Raw) {
   const std::string Line = Raw.substr(Start, End - Start + 1);
 
   if (Line == "sat" || Line == "s SATISFIABLE")
-    return checkResult::SAT;
+    return CheckResult::SAT;
   if (Line == "unsat" || Line == "s UNSATISFIABLE")
-    return checkResult::UNSAT;
+    return CheckResult::UNSAT;
   if (Line == "unknown" || Line == "s UNKNOWN")
-    return checkResult::UNKNOWN;
+    return CheckResult::UNKNOWN;
   return std::nullopt;
 }
 
@@ -775,7 +775,7 @@ std::string shellQuotePath(const std::string &Path) {
 
 } // namespace
 
-checkResult SMTLIBSolver::runOneShotCommand() {
+CheckResult SMTLIBSolver::runOneShotCommand() {
   // Substitute the formula file for every %f, or append it, quoting the
   // path for the shell the command runs under.
   const std::string Quoted = shellQuotePath(OneShotFormulaPath);
@@ -823,7 +823,7 @@ checkResult SMTLIBSolver::runOneShotCommand() {
 
   // Scan the output for verdict lines; the LAST one wins. Keep a tail of
   // the output for the caller's diagnostics.
-  std::optional<checkResult> Verdict;
+  std::optional<CheckResult> Verdict;
   std::deque<std::string> Tail;
   char Buf[4096];
   while (std::fgets(Buf, sizeof(Buf), ChildOut)) {
@@ -835,7 +835,7 @@ checkResult SMTLIBSolver::runOneShotCommand() {
     if (Start != std::string::npos)
       Line.erase(0, Start);
 
-    if (std::optional<checkResult> V = parseOneShotVerdictLine(Line))
+    if (std::optional<CheckResult> V = parseOneShotVerdictLine(Line))
       Verdict = V;
 
     Tail.push_back(std::move(Line));
@@ -857,13 +857,13 @@ checkResult SMTLIBSolver::runOneShotCommand() {
   // not become a verification verdict. Non-zero *exit codes* stay
   // accepted — SAT-competition-style solvers exit 10/20.
   if (Verdict && WIFSIGNALED(Status))
-    return checkResult::UNKNOWN;
+    return CheckResult::UNKNOWN;
   if (!Verdict)
-    return checkResult::UNKNOWN;
+    return CheckResult::UNKNOWN;
   return *Verdict;
 }
 
-checkResult SMTLIBSolver::oneShotCheck() {
+CheckResult SMTLIBSolver::oneShotCheck() {
   fatalErrorIf(OneShotCheckDone,
                "SMTLIBSolver: one-shot mode supports a single (check-sat) "
                "query per run; incremental strategies are not supported");
@@ -881,21 +881,21 @@ checkResult SMTLIBSolver::oneShotCheck() {
     Proc->flush();
   }
 
-  const checkResult Verdict = runOneShotCommand();
+  const CheckResult Verdict = runOneShotCommand();
 
-  if (Verdict == checkResult::SAT && Proc) {
+  if (Verdict == CheckResult::SAT && Proc) {
     const std::string Resp = Proc->readResponse();
     if (Resp.empty()) {
       // The model solver died mid-solve; continue without counterexample
       // support. The caller sees oneShotModelSolverLive() == false.
       Proc.reset();
     } else {
-      OneShotModelVerdictValue = Resp == "sat"     ? checkResult::SAT
-                                 : Resp == "unsat" ? checkResult::UNSAT
-                                                   : checkResult::UNKNOWN;
+      OneShotModelVerdictValue = Resp == "sat"     ? CheckResult::SAT
+                                 : Resp == "unsat" ? CheckResult::UNSAT
+                                                   : CheckResult::UNKNOWN;
       // A disagreeing model solver has no model to serve; the caller
       // compares the two verdicts and decides how to report it.
-      if (*OneShotModelVerdictValue != checkResult::SAT)
+      if (*OneShotModelVerdictValue != CheckResult::SAT)
         Proc.reset();
     }
   } else if (Proc) {
@@ -1279,16 +1279,18 @@ SMTExprRef SMTLIBSolver::mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
   return makeSMTLIBExpr(SMTExprKind::Ite, T->Sort, "ite", {Cond, T, F});
 }
 
-SMTExprRef SMTLIBSolver::mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) {
-  unsigned NewWidth = Exp->getWidth() + i;
+SMTExprRef SMTLIBSolver::mkBVSignExtImpl(const SMTExprRef &Exp,
+                                         unsigned ExtraBits) {
+  unsigned NewWidth = Exp->getWidth() + ExtraBits;
   return makeSMTLIBExpr(SMTExprKind::BVSignExt, mkBVSort(NewWidth),
-                        "(_ sign_extend " + utoa(i) + ")", {Exp});
+                        "(_ sign_extend " + utoa(ExtraBits) + ")", {Exp});
 }
 
-SMTExprRef SMTLIBSolver::mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) {
-  unsigned NewWidth = Exp->getWidth() + i;
+SMTExprRef SMTLIBSolver::mkBVZeroExtImpl(const SMTExprRef &Exp,
+                                         unsigned ExtraBits) {
+  unsigned NewWidth = Exp->getWidth() + ExtraBits;
   return makeSMTLIBExpr(SMTExprKind::BVZeroExt, mkBVSort(NewWidth),
-                        "(_ zero_extend " + utoa(i) + ")", {Exp});
+                        "(_ zero_extend " + utoa(ExtraBits) + ")", {Exp});
 }
 
 SMTExprRef SMTLIBSolver::mkBVExtractImpl(unsigned High, unsigned Low,
@@ -1488,7 +1490,7 @@ SMTExprRef SMTLIBSolver::mkFPNegImpl(const SMTExprRef &Exp,
 CAMADA_SMTLIB_UNARY(mkFPIsInfiniteImpl, "fp.isInfinite", FPIsInfinite,
                     mkBoolSort())
 CAMADA_SMTLIB_UNARY(mkFPIsNaNImpl, "fp.isNaN", FPIsNaN, mkBoolSort())
-CAMADA_SMTLIB_UNARY(mkFPIsDenormalImpl, "fp.isSubnormal", FPIsDenormal,
+CAMADA_SMTLIB_UNARY(mkFPIsSubnormalImpl, "fp.isSubnormal", FPIsSubnormal,
                     mkBoolSort())
 CAMADA_SMTLIB_UNARY(mkFPIsNormalImpl, "fp.isNormal", FPIsNormal, mkBoolSort())
 CAMADA_SMTLIB_UNARY(mkFPIsZeroImpl, "fp.isZero", FPIsZero, mkBoolSort())
@@ -1520,7 +1522,7 @@ CAMADA_SMTLIB_BINARY(mkFPEqualImpl, "fp.eq", FPEqual, mkBoolSort())
 #undef CAMADA_SMTLIB_BINARY
 #undef CAMADA_SMTLIB_RM_BINARY
 
-SMTExprRef SMTLIBSolver::mkFPtoFPImpl(const SMTExprRef &From,
+SMTExprRef SMTLIBSolver::mkFPToFPImpl(const SMTExprRef &From,
                                       const SMTSortRef &To,
                                       const SMTExprRef &R) {
   std::string Head = "(_ to_fp " + utoa(To->getFPExponentWidth()) + " " +
@@ -1528,7 +1530,7 @@ SMTExprRef SMTLIBSolver::mkFPtoFPImpl(const SMTExprRef &From,
   return makeSMTLIBExpr(SMTExprKind::FPtoFP, To, std::move(Head), {R, From});
 }
 
-SMTExprRef SMTLIBSolver::mkSBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef SMTLIBSolver::mkSBVToFPImpl(const SMTExprRef &From,
                                        const SMTSortRef &To,
                                        const SMTExprRef &R) {
   // Same opcode as fp→fp; SMT-LIB disambiguates by argument sort.
@@ -1537,7 +1539,7 @@ SMTExprRef SMTLIBSolver::mkSBVtoFPImpl(const SMTExprRef &From,
   return makeSMTLIBExpr(SMTExprKind::SBVtoFP, To, std::move(Head), {R, From});
 }
 
-SMTExprRef SMTLIBSolver::mkUBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef SMTLIBSolver::mkUBVToFPImpl(const SMTExprRef &From,
                                        const SMTSortRef &To,
                                        const SMTExprRef &R) {
   std::string Head = "(_ to_fp_unsigned " + utoa(To->getFPExponentWidth()) +
@@ -1545,21 +1547,21 @@ SMTExprRef SMTLIBSolver::mkUBVtoFPImpl(const SMTExprRef &From,
   return makeSMTLIBExpr(SMTExprKind::UBVtoFP, To, std::move(Head), {R, From});
 }
 
-SMTExprRef SMTLIBSolver::mkFPtoSBVImpl(const SMTExprRef &From,
+SMTExprRef SMTLIBSolver::mkFPToSBVImpl(const SMTExprRef &From,
                                        unsigned ToWidth) {
   const SMTExprRef &R = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
   return makeSMTLIBExpr(SMTExprKind::FPtoSBV, mkBVSort(ToWidth),
                         "(_ fp.to_sbv " + utoa(ToWidth) + ")", {R, From});
 }
 
-SMTExprRef SMTLIBSolver::mkFPtoUBVImpl(const SMTExprRef &From,
+SMTExprRef SMTLIBSolver::mkFPToUBVImpl(const SMTExprRef &From,
                                        unsigned ToWidth) {
   const SMTExprRef &R = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
   return makeSMTLIBExpr(SMTExprKind::FPtoUBV, mkBVSort(ToWidth),
                         "(_ fp.to_ubv " + utoa(ToWidth) + ")", {R, From});
 }
 
-SMTExprRef SMTLIBSolver::mkFPtoIntegralImpl(const SMTExprRef &From,
+SMTExprRef SMTLIBSolver::mkFPToIntegralImpl(const SMTExprRef &From,
                                             const SMTExprRef &R) {
   return makeSMTLIBExpr(SMTExprKind::FPtoIntegral, From->Sort,
                         "fp.roundToIntegral", {R, From});
@@ -2491,7 +2493,7 @@ SMTExprRef SMTLIBSolver::getArrayElementImpl(const SMTExprRef &Array,
   return mkArraySelect(Array, Index);
 }
 
-checkResult SMTLIBSolver::emitCheckCommand(const std::string &Cmd) {
+CheckResult SMTLIBSolver::emitCheckCommand(const std::string &Cmd) {
   // Check commands are queries — they do NOT produce a `success` ack even
   // when :print-success is true. Bypass emitLine's resync logic; write the
   // command directly and read the sat/unsat/unknown line ourselves. In
@@ -2502,22 +2504,22 @@ checkResult SMTLIBSolver::emitCheckCommand(const std::string &Cmd) {
     Proc->emitRaw(Cmd);
     Proc->flush();
     const std::string Resp = Proc->readResponse();
-    return Resp == "sat"     ? checkResult::SAT
-           : Resp == "unsat" ? checkResult::UNSAT
-                             : checkResult::UNKNOWN;
+    return Resp == "sat"     ? CheckResult::SAT
+           : Resp == "unsat" ? CheckResult::UNSAT
+                             : CheckResult::UNKNOWN;
   }
   if (File)
     File->flush();
-  return checkResult::UNKNOWN;
+  return CheckResult::UNKNOWN;
 }
 
-checkResult SMTLIBSolver::checkImpl() {
+CheckResult SMTLIBSolver::checkImpl() {
   if (OneShotMode)
     return oneShotCheck();
   return emitCheckCommand("(check-sat)\n");
 }
 
-checkResult
+CheckResult
 SMTLIBSolver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
   // A child that rejected :produce-unsat-assumptions may not implement
   // (check-sat-assuming ...) at all (stp answers `unsupported`), and without

--- a/src/solvers/smtlibsolver.h
+++ b/src/solvers/smtlibsolver.h
@@ -189,10 +189,10 @@ using PgidCallback = std::function<void(long Pgid)>;
 /// Accepts exactly the bare SMT-LIB verdicts (`sat`, `unsat`, `unknown`)
 /// and the SAT-competition forms (`s SATISFIABLE`, `s UNSATISFIABLE`,
 /// `s UNKNOWN`), with surrounding whitespace tolerated; `unknown` maps to
-/// checkResult::UNKNOWN. Everything else is rejected — deliberately no
+/// CheckResult::UNKNOWN. Everything else is rejected — deliberately no
 /// substring matching, or a log line mentioning "unsat core" would become
 /// a verification verdict.
-std::optional<checkResult> parseOneShotVerdictLine(const std::string &Line);
+std::optional<CheckResult> parseOneShotVerdictLine(const std::string &Line);
 
 /// Facts about the last one-shot run, for the caller's diagnostics: the
 /// command after %f substitution, a decoded exit status ("exit code N" /
@@ -287,7 +287,7 @@ public:
   /// One-shot mode: the model solver's own answer to the shared query,
   /// read only after a sat verdict from the one-shot run. Unset when no
   /// model solver was configured, it died, or the verdict was not sat.
-  std::optional<checkResult> oneShotModelVerdict() const {
+  std::optional<CheckResult> oneShotModelVerdict() const {
     return OneShotModelVerdictValue;
   }
 
@@ -362,8 +362,10 @@ protected:
   SMTExprRef mkOrImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
   SMTExprRef mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                        const SMTExprRef &F) override;
-  SMTExprRef mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) override;
-  SMTExprRef mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVSignExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
+  SMTExprRef mkBVZeroExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
   SMTExprRef mkBVExtractImpl(unsigned High, unsigned Low,
                              const SMTExprRef &Exp) override;
   SMTExprRef mkBVConcatImpl(const SMTExprRef &LHS,
@@ -394,7 +396,7 @@ protected:
                          FPNegBehavior Behavior) override;
   SMTExprRef mkFPIsInfiniteImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkFPIsNaNImpl(const SMTExprRef &Exp) override;
-  SMTExprRef mkFPIsDenormalImpl(const SMTExprRef &Exp) override;
+  SMTExprRef mkFPIsSubnormalImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkFPIsNormalImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkFPIsZeroImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkFPMulImpl(const SMTExprRef &LHS, const SMTExprRef &RHS,
@@ -415,15 +417,15 @@ protected:
   SMTExprRef mkFPGeImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
   SMTExprRef mkFPEqualImpl(const SMTExprRef &LHS,
                            const SMTExprRef &RHS) override;
-  SMTExprRef mkFPtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkFPToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                           const SMTExprRef &R) override;
-  SMTExprRef mkSBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkSBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
-  SMTExprRef mkUBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkUBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
-  SMTExprRef mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
-  SMTExprRef mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
-  SMTExprRef mkFPtoIntegralImpl(const SMTExprRef &From,
+  SMTExprRef mkFPToSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToIntegralImpl(const SMTExprRef &From,
                                 const SMTExprRef &R) override;
   SMTExprRef mkBVToIEEEFPImpl(const SMTExprRef &Exp,
                               const SMTSortRef &To) override;
@@ -482,8 +484,8 @@ protected:
                                  const SMTExprRef &Index) override;
 
   // --- check / push / pop / reset ---
-  checkResult checkImpl() override;
-  checkResult
+  CheckResult checkImpl() override;
+  CheckResult
   checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;
 
@@ -541,7 +543,7 @@ private:
 
   // Emit a check command (a query: no `success` ack) and read the
   // sat/unsat/unknown verdict; UNKNOWN in write-only mode.
-  checkResult emitCheckCommand(const std::string &Cmd);
+  CheckResult emitCheckCommand(const std::string &Cmd);
 
   // Send (get-value (Exp)) to the child solver and extract the value text
   // from its response. Fails in write-only mode (no child process). Resp
@@ -552,15 +554,15 @@ private:
   void emitPreamble();
 
   // One-shot mode plumbing (see the SMTLIBOneShotTag constructor).
-  checkResult oneShotCheck();
-  checkResult runOneShotCommand();
+  CheckResult oneShotCheck();
+  CheckResult runOneShotCommand();
 
   bool OneShotMode = false;
   bool OneShotCheckDone = false;
   std::string OneShotFormulaPath;
   std::string OneShotShellCmd;
   PgidCallback OneShotOnSpawn;
-  std::optional<checkResult> OneShotModelVerdictValue;
+  std::optional<CheckResult> OneShotModelVerdictValue;
   OneShotDiagnostics Diags;
 
   std::unique_ptr<FileEmitter> File;

--- a/src/solvers/stpsolver.cpp
+++ b/src/solvers/stpsolver.cpp
@@ -446,19 +446,21 @@ SMTExprRef STPSolver::mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                                               toSolverExpr<STPExpr>(*F).Expr));
 }
 
-SMTExprRef STPSolver::mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef STPSolver::mkBVSignExtImpl(const SMTExprRef &Exp,
+                                      unsigned ExtraBits) {
   return makeExprRef<STPExpr>(
-      SMTExprKind::BVSignExt, &Context, mkBVSort(i + Exp->getWidth()),
+      SMTExprKind::BVSignExt, &Context, mkBVSort(ExtraBits + Exp->getWidth()),
       STP::vc_bvSignExtend(Context, toSolverExpr<STPExpr>(*Exp).Expr,
-                           i + Exp->getWidth()));
+                           ExtraBits + Exp->getWidth()));
 }
 
-SMTExprRef STPSolver::mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef STPSolver::mkBVZeroExtImpl(const SMTExprRef &Exp,
+                                      unsigned ExtraBits) {
   // Extending by nothing is the identity; the concat below would ask for
   // a zero-width constant, which is not a valid sort.
-  if (i == 0)
+  if (ExtraBits == 0)
     return Exp;
-  const SMTExprRef &z = SMTSolverImpl::mkBVFromDec(0, i);
+  const SMTExprRef &z = SMTSolverImpl::mkBVFromDec(0, ExtraBits);
   return mkBVConcat(z, Exp);
 }
 
@@ -615,7 +617,7 @@ SMTExprRef STPSolver::mkArrayConstImpl(const SMTSortRef &, const SMTExprRef &) {
   fatalError("STP constant arrays are lowered lazily by the common layer");
 }
 
-checkResult STPSolver::checkImpl() {
+CheckResult STPSolver::checkImpl() {
   STP::Expr query = STP::vc_falseExpr(Context);
   // -1 disables the budget. The time budget is whole seconds for the
   // entire query, so the millisecond deadline rounds up; the CryptoMiniSat
@@ -631,13 +633,13 @@ checkResult STPSolver::checkImpl() {
                                  /*timeout_max_conflicts=*/-1, MaxTimeSecs);
   STP::vc_DeleteExpr(query);
   if (!res)
-    return checkResult::SAT;
+    return CheckResult::SAT;
 
   if (res == 1)
-    return checkResult::UNSAT;
+    return CheckResult::UNSAT;
 
   // 2 is an error, 3 a timeout.
-  return checkResult::UNKNOWN;
+  return CheckResult::UNKNOWN;
 }
 
 bool STPSolver::setTimeoutImpl(uint64_t) {

--- a/src/solvers/stpsolver.h
+++ b/src/solvers/stpsolver.h
@@ -178,9 +178,11 @@ protected:
   SMTExprRef mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                        const SMTExprRef &F) override;
 
-  SMTExprRef mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVSignExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
-  SMTExprRef mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVZeroExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
   SMTExprRef mkBVExtractImpl(unsigned High, unsigned Low,
                              const SMTExprRef &Exp) override;
@@ -223,7 +225,7 @@ protected:
   // array-sorted operands.
   bool nativeArrayExtensionality() const override { return false; }
 
-  checkResult checkImpl() override;
+  CheckResult checkImpl() override;
 
   // Per-check wall-clock limit enforced through vc_query_with_timeout's
   // whole-second time budget (STP >= 2.4.0 gives it one meaning across

--- a/src/solvers/yicessolver.cpp
+++ b/src/solvers/yicessolver.cpp
@@ -675,16 +675,18 @@ SMTExprRef YicesSolver::mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                                           toSolverExpr<YicesExpr>(*F).Expr));
 }
 
-SMTExprRef YicesSolver::mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef YicesSolver::mkBVSignExtImpl(const SMTExprRef &Exp,
+                                        unsigned ExtraBits) {
   return makeExprRef<YicesExpr>(
-      SMTExprKind::BVSignExt, Context, mkBVSort(i + Exp->getWidth()),
-      yices_sign_extend(toSolverExpr<YicesExpr>(*Exp).Expr, i));
+      SMTExprKind::BVSignExt, Context, mkBVSort(ExtraBits + Exp->getWidth()),
+      yices_sign_extend(toSolverExpr<YicesExpr>(*Exp).Expr, ExtraBits));
 }
 
-SMTExprRef YicesSolver::mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef YicesSolver::mkBVZeroExtImpl(const SMTExprRef &Exp,
+                                        unsigned ExtraBits) {
   return makeExprRef<YicesExpr>(
-      SMTExprKind::BVZeroExt, Context, mkBVSort(i + Exp->getWidth()),
-      yices_zero_extend(toSolverExpr<YicesExpr>(*Exp).Expr, i));
+      SMTExprKind::BVZeroExt, Context, mkBVSort(ExtraBits + Exp->getWidth()),
+      yices_zero_extend(toSolverExpr<YicesExpr>(*Exp).Expr, ExtraBits));
 }
 
 SMTExprRef YicesSolver::mkBVExtractImpl(unsigned High, unsigned Low,
@@ -1036,20 +1038,20 @@ bool YicesSolver::timeoutSupport() const {
 #endif
 }
 
-checkResult YicesSolver::checkImpl() {
+CheckResult YicesSolver::checkImpl() {
   armTimeout();
   smt_status_t res = yices_check_context(Context, nullptr);
   disarmTimeout();
   if (res == YICES_STATUS_SAT)
-    return checkResult::SAT;
+    return CheckResult::SAT;
 
   if (res == YICES_STATUS_UNSAT)
-    return checkResult::UNSAT;
+    return CheckResult::UNSAT;
 
-  return checkResult::UNKNOWN;
+  return CheckResult::UNKNOWN;
 }
 
-checkResult
+CheckResult
 YicesSolver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
   std::vector<term_t> assumptions;
   assumptions.reserve(Assumptions.size());
@@ -1062,12 +1064,12 @@ YicesSolver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
       assumptions.data());
   disarmTimeout();
   if (res == YICES_STATUS_SAT)
-    return checkResult::SAT;
+    return CheckResult::SAT;
 
   if (res == YICES_STATUS_UNSAT)
-    return checkResult::UNSAT;
+    return CheckResult::UNSAT;
 
-  return checkResult::UNKNOWN;
+  return CheckResult::UNKNOWN;
 }
 
 SMTResult<std::vector<SMTExprRef>> YicesSolver::getUnsatAssumptionsImpl() {

--- a/src/solvers/yicessolver.h
+++ b/src/solvers/yicessolver.h
@@ -210,9 +210,11 @@ protected:
   SMTExprRef mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                        const SMTExprRef &F) override;
 
-  SMTExprRef mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVSignExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
-  SMTExprRef mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVZeroExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
   SMTExprRef mkBVExtractImpl(unsigned High, unsigned Low,
                              const SMTExprRef &Exp) override;
@@ -272,11 +274,11 @@ protected:
 
   bool nativeConstArraySupport() const override { return false; }
 
-  checkResult checkImpl() override;
+  CheckResult checkImpl() override;
 
   bool setTimeoutImpl(uint64_t Milliseconds) override;
 
-  checkResult
+  CheckResult
   checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
 
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;

--- a/src/solvers/z3solver.cpp
+++ b/src/solvers/z3solver.cpp
@@ -273,7 +273,7 @@ SMTExprRef Z3Solver::mkIsIntImpl(const SMTExprRef &Exp) {
                              z3::is_int(toZ3Expr(Exp)));
 }
 
-SMTExprRef Z3Solver::mkInt2BVImpl(unsigned Width, const SMTExprRef &Exp) {
+SMTExprRef Z3Solver::mkInt2BVImpl(const SMTExprRef &Exp, unsigned Width) {
   return makeExprRef<Z3Expr>(SMTExprKind::Int2BV, &Context, mkBVSort(Width),
                              z3::int2bv(Width, toZ3Expr(Exp)));
 }
@@ -303,8 +303,8 @@ SMTExprRef Z3Solver::mkFPIsNaNImpl(const SMTExprRef &Exp) {
                              toZ3Expr(Exp).mk_is_nan());
 }
 
-SMTExprRef Z3Solver::mkFPIsDenormalImpl(const SMTExprRef &Exp) {
-  return makeExprRef<Z3Expr>(SMTExprKind::FPIsDenormal, &Context, mkBoolSort(),
+SMTExprRef Z3Solver::mkFPIsSubnormalImpl(const SMTExprRef &Exp) {
+  return makeExprRef<Z3Expr>(SMTExprKind::FPIsSubnormal, &Context, mkBoolSort(),
                              toZ3Expr(Exp).mk_is_subnormal());
 }
 
@@ -635,16 +635,18 @@ SMTExprRef Z3Solver::mkReal2IntImpl(const SMTExprRef &Exp) {
       z3::to_expr(Context, Z3_mk_real2int(Context, toZ3Expr(Exp))));
 }
 
-SMTExprRef Z3Solver::mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef Z3Solver::mkBVSignExtImpl(const SMTExprRef &Exp,
+                                     unsigned ExtraBits) {
   return makeExprRef<Z3Expr>(SMTExprKind::BVSignExt, &Context,
-                             mkBVSort(i + Exp->getWidth()),
-                             z3::sext(toZ3Expr(Exp), i));
+                             mkBVSort(ExtraBits + Exp->getWidth()),
+                             z3::sext(toZ3Expr(Exp), ExtraBits));
 }
 
-SMTExprRef Z3Solver::mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) {
+SMTExprRef Z3Solver::mkBVZeroExtImpl(const SMTExprRef &Exp,
+                                     unsigned ExtraBits) {
   return makeExprRef<Z3Expr>(SMTExprKind::BVZeroExt, &Context,
-                             mkBVSort(i + Exp->getWidth()),
-                             z3::zext(toZ3Expr(Exp), i));
+                             mkBVSort(ExtraBits + Exp->getWidth()),
+                             z3::zext(toZ3Expr(Exp), ExtraBits));
 }
 
 SMTExprRef Z3Solver::mkBVExtractImpl(unsigned High, unsigned Low,
@@ -754,7 +756,7 @@ SMTExprRef Z3Solver::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
       z3::fma(toZ3Expr(X), toZ3Expr(Y), toZ3Expr(Z), toZ3Expr(R)));
 }
 
-SMTExprRef Z3Solver::mkFPtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+SMTExprRef Z3Solver::mkFPToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                   const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
       SMTExprKind::FPtoFP, &Context, To,
@@ -763,7 +765,7 @@ SMTExprRef Z3Solver::mkFPtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                         toSolverSort<Z3Sort>(*To).Sort)));
 }
 
-SMTExprRef Z3Solver::mkSBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+SMTExprRef Z3Solver::mkSBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                    const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
       SMTExprKind::SBVtoFP, &Context, To,
@@ -772,7 +774,7 @@ SMTExprRef Z3Solver::mkSBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                          toSolverSort<Z3Sort>(*To).Sort)));
 }
 
-SMTExprRef Z3Solver::mkUBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+SMTExprRef Z3Solver::mkUBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                    const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
       SMTExprKind::UBVtoFP, &Context, To,
@@ -781,7 +783,7 @@ SMTExprRef Z3Solver::mkUBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                                            toSolverSort<Z3Sort>(*To).Sort)));
 }
 
-SMTExprRef Z3Solver::mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) {
+SMTExprRef Z3Solver::mkFPToSBVImpl(const SMTExprRef &From, unsigned ToWidth) {
   const SMTExprRef &roundingMode = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
   return makeExprRef<Z3Expr>(
       SMTExprKind::FPtoSBV, &Context, mkBVSort(ToWidth),
@@ -789,7 +791,7 @@ SMTExprRef Z3Solver::mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) {
                                             toZ3Expr(From), ToWidth)));
 }
 
-SMTExprRef Z3Solver::mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) {
+SMTExprRef Z3Solver::mkFPToUBVImpl(const SMTExprRef &From, unsigned ToWidth) {
   const SMTExprRef &roundingMode = mkRM(RM::ROUND_TO_ZERO, FPEncoding::Native);
   return makeExprRef<Z3Expr>(
       SMTExprKind::FPtoUBV, &Context, mkBVSort(ToWidth),
@@ -797,7 +799,7 @@ SMTExprRef Z3Solver::mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) {
                                             toZ3Expr(From), ToWidth)));
 }
 
-SMTExprRef Z3Solver::mkFPtoIntegralImpl(const SMTExprRef &From,
+SMTExprRef Z3Solver::mkFPToIntegralImpl(const SMTExprRef &From,
                                         const SMTExprRef &R) {
   return makeExprRef<Z3Expr>(
       SMTExprKind::FPtoIntegral, &Context, From->Sort,
@@ -1107,15 +1109,15 @@ SMTExprRef Z3Solver::mkExistsImpl(const std::vector<SMTExprRef> &Vars,
                              z3::exists(bound_vars, toZ3Expr(Body)));
 }
 
-checkResult Z3Solver::checkImpl() {
+CheckResult Z3Solver::checkImpl() {
   z3::check_result res = Solver.check();
   if (res == z3::check_result::sat)
-    return checkResult::SAT;
+    return CheckResult::SAT;
 
   if (res == z3::check_result::unsat)
-    return checkResult::UNSAT;
+    return CheckResult::UNSAT;
 
-  return checkResult::UNKNOWN;
+  return CheckResult::UNKNOWN;
 }
 
 bool Z3Solver::setTimeoutImpl(uint64_t Milliseconds) {
@@ -1131,7 +1133,7 @@ bool Z3Solver::setTimeoutImpl(uint64_t Milliseconds) {
   return true;
 }
 
-checkResult
+CheckResult
 Z3Solver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
   // Tactic-built solvers (see setSolver) do not track assumption cores
   // unless asked: they answer UNSAT with an empty unsat_core(). The plain
@@ -1148,12 +1150,12 @@ Z3Solver::checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) {
 
   z3::check_result res = Solver.check(assumptions);
   if (res == z3::check_result::sat)
-    return checkResult::SAT;
+    return CheckResult::SAT;
 
   if (res == z3::check_result::unsat)
-    return checkResult::UNSAT;
+    return CheckResult::UNSAT;
 
-  return checkResult::UNKNOWN;
+  return CheckResult::UNKNOWN;
 }
 
 SMTResult<std::vector<SMTExprRef>> Z3Solver::getUnsatAssumptionsImpl() {

--- a/src/solvers/z3solver.h
+++ b/src/solvers/z3solver.h
@@ -231,7 +231,7 @@ protected:
   SMTExprRef mkInt2RealImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkReal2IntImpl(const SMTExprRef &Exp) override;
   SMTExprRef mkIsIntImpl(const SMTExprRef &Exp) override;
-  SMTExprRef mkInt2BVImpl(unsigned Width, const SMTExprRef &Exp) override;
+  SMTExprRef mkInt2BVImpl(const SMTExprRef &Exp, unsigned Width) override;
   SMTExprRef mkBV2IntImpl(const SMTExprRef &Exp, bool IsSigned) override;
 
   SMTExprRef mkEqualImpl(const SMTExprRef &LHS, const SMTExprRef &RHS) override;
@@ -239,9 +239,11 @@ protected:
   SMTExprRef mkIteImpl(const SMTExprRef &Cond, const SMTExprRef &T,
                        const SMTExprRef &F) override;
 
-  SMTExprRef mkBVSignExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVSignExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
-  SMTExprRef mkBVZeroExtImpl(unsigned i, const SMTExprRef &Exp) override;
+  SMTExprRef mkBVZeroExtImpl(const SMTExprRef &Exp,
+                             unsigned ExtraBits) override;
 
   SMTExprRef mkBVExtractImpl(unsigned High, unsigned Low,
                              const SMTExprRef &Exp) override;
@@ -276,7 +278,7 @@ protected:
 
   SMTExprRef mkFPIsNaNImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef mkFPIsDenormalImpl(const SMTExprRef &Exp) override;
+  SMTExprRef mkFPIsSubnormalImpl(const SMTExprRef &Exp) override;
 
   SMTExprRef mkFPIsNormalImpl(const SMTExprRef &Exp) override;
 
@@ -312,20 +314,20 @@ protected:
   SMTExprRef mkFPEqualImpl(const SMTExprRef &LHS,
                            const SMTExprRef &RHS) override;
 
-  SMTExprRef mkFPtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkFPToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                           const SMTExprRef &R) override;
 
-  SMTExprRef mkSBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkSBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
 
-  SMTExprRef mkUBVtoFPImpl(const SMTExprRef &From, const SMTSortRef &To,
+  SMTExprRef mkUBVToFPImpl(const SMTExprRef &From, const SMTSortRef &To,
                            const SMTExprRef &R) override;
 
-  SMTExprRef mkFPtoSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToSBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
 
-  SMTExprRef mkFPtoUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
+  SMTExprRef mkFPToUBVImpl(const SMTExprRef &From, unsigned ToWidth) override;
 
-  SMTExprRef mkFPtoIntegralImpl(const SMTExprRef &From,
+  SMTExprRef mkFPToIntegralImpl(const SMTExprRef &From,
                                 const SMTExprRef &R) override;
 
   SMTResult<bool> getBoolImpl(const SMTExprRef &Exp) override;
@@ -378,11 +380,11 @@ protected:
   SMTExprRef mkArrayConstImpl(const SMTSortRef &IndexSort,
                               const SMTExprRef &InitValue) override;
 
-  checkResult checkImpl() override;
+  CheckResult checkImpl() override;
 
   bool setTimeoutImpl(uint64_t Milliseconds) override;
 
-  checkResult
+  CheckResult
   checkSatAssumingImpl(const std::vector<SMTExprRef> &Assumptions) override;
 
   SMTResult<std::vector<SMTExprRef>> getUnsatAssumptionsImpl() override;

--- a/src/theories/camadafp.cpp
+++ b/src/theories/camadafp.cpp
@@ -423,7 +423,7 @@ static inline void unpack(SMTSolver &S, const SMTExprRef &Src, SMTExprRef &Sgn,
   SMTExprRef normal_sig = S.mkBVConcat(mkBVOne1(S), Sig);
   SMTExprRef normal_exp = mkUnbias(S, Exp);
 
-  SMTExprRef denormal_sig = S.mkBVZeroExt(1, Sig);
+  SMTExprRef denormal_sig = S.mkBVZeroExt(Sig, 1);
   SMTExprRef denormal_exp = mkMinExp(S, EWidth);
   if (Normalize) {
     SMTExprRef zero_s = S.mkBVFromDec(0, SWidth);
@@ -437,7 +437,7 @@ static inline void unpack(SMTSolver &S, const SMTExprRef &Src, SMTExprRef &Sgn,
     assert(shift->getWidth() == EWidth);
 
     if (EWidth <= SWidth) {
-      SMTExprRef q = S.mkBVZeroExt(SWidth - EWidth, shift);
+      SMTExprRef q = S.mkBVZeroExt(shift, SWidth - EWidth);
       denormal_sig = S.mkBVShl(denormal_sig, q);
     } else {
       // the maximum shift is `SWidth', because after that the mantissa
@@ -533,7 +533,7 @@ SMTExprRef SMTSolverImpl::mkFPIsNaNImpl(const SMTExprRef &Exp) {
   return rewrapExprImpl(*result, result->Sort, SMTExprKind::FPIsNaN);
 }
 
-SMTExprRef SMTSolverImpl::mkFPIsDenormalImpl(const SMTExprRef &Exp) {
+SMTExprRef SMTSolverImpl::mkFPIsSubnormalImpl(const SMTExprRef &Exp) {
   // Extract the exponent
   SMTExprRef exp = extractExp(*this, Exp);
 
@@ -542,14 +542,14 @@ SMTExprRef SMTSolverImpl::mkFPIsDenormalImpl(const SMTExprRef &Exp) {
   SMTExprRef isZero = mkFPIsZero(Exp);
   SMTExprRef nIsZero = mkNot(isZero);
   SMTExprRef result = mkAnd(nIsZero, zExp);
-  return rewrapExprImpl(*result, result->Sort, SMTExprKind::FPIsDenormal);
+  return rewrapExprImpl(*result, result->Sort, SMTExprKind::FPIsSubnormal);
 }
 
 SMTExprRef SMTSolverImpl::mkFPIsNormalImpl(const SMTExprRef &Exp) {
   // Extract the exponent
   SMTExprRef exp = extractExp(*this, Exp);
 
-  SMTExprRef isDenormal = mkFPIsDenormal(Exp);
+  SMTExprRef isSubnormal = mkFPIsSubnormal(Exp);
   SMTExprRef isZero = mkFPIsZero(Exp);
 
   unsigned eWidth = exp->getWidth();
@@ -557,7 +557,7 @@ SMTExprRef SMTSolverImpl::mkFPIsNormalImpl(const SMTExprRef &Exp) {
 
   SMTExprRef isSpecial = mkEqual(exp, p);
 
-  SMTExprRef orEx = mkOr(isSpecial, isDenormal);
+  SMTExprRef orEx = mkOr(isSpecial, isSubnormal);
   orEx = mkOr(isZero, orEx);
   SMTExprRef result = mkNot(orEx);
   return rewrapExprImpl(*result, result->Sort, SMTExprKind::FPIsNormal);
@@ -640,14 +640,14 @@ SMTExprRef SMTSolverImpl::mkFPMulImpl(const SMTExprRef &LHS,
   unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, true);
   unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, true);
 
-  SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
-  SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
+  SMTExprRef a_lz_ext = mkBVZeroExt(a_lz, 2);
+  SMTExprRef b_lz_ext = mkBVZeroExt(b_lz, 2);
 
-  SMTExprRef a_sig_ext = mkBVZeroExt(sbits, a_sig);
-  SMTExprRef b_sig_ext = mkBVZeroExt(sbits, b_sig);
+  SMTExprRef a_sig_ext = mkBVZeroExt(a_sig, sbits);
+  SMTExprRef b_sig_ext = mkBVZeroExt(b_sig, sbits);
 
-  SMTExprRef a_exp_ext = mkBVSignExt(2, a_exp);
-  SMTExprRef b_exp_ext = mkBVSignExt(2, b_exp);
+  SMTExprRef a_exp_ext = mkBVSignExt(a_exp, 2);
+  SMTExprRef b_exp_ext = mkBVSignExt(b_exp, 2);
 
   SMTExprRef res_sgn, res_sig, res_exp;
   res_sgn = mkBVXor(a_sgn, b_sgn);
@@ -753,15 +753,15 @@ SMTExprRef SMTSolverImpl::mkFPDivImpl(const SMTExprRef &LHS,
 
   unsigned extra_bits = sbits + 2;
   SMTExprRef a_sig_ext = mkBVConcat(a_sig, mkBVFromDec(0, sbits + extra_bits));
-  SMTExprRef b_sig_ext = mkBVZeroExt(sbits + extra_bits, b_sig);
+  SMTExprRef b_sig_ext = mkBVZeroExt(b_sig, sbits + extra_bits);
 
-  SMTExprRef a_exp_ext = mkBVSignExt(2, a_exp);
-  SMTExprRef b_exp_ext = mkBVSignExt(2, b_exp);
+  SMTExprRef a_exp_ext = mkBVSignExt(a_exp, 2);
+  SMTExprRef b_exp_ext = mkBVSignExt(b_exp, 2);
 
   SMTExprRef res_sgn = mkBVXor(a_sgn, b_sgn);
 
-  SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
-  SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
+  SMTExprRef a_lz_ext = mkBVZeroExt(a_lz, 2);
+  SMTExprRef b_lz_ext = mkBVZeroExt(b_lz, 2);
 
   SMTExprRef res_exp =
       mkBVSub(mkBVSub(a_exp_ext, a_lz_ext), mkBVSub(b_exp_ext, b_lz_ext));
@@ -865,10 +865,10 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
   unpack(*this, LHS, a_sgn, a_sig, a_exp, a_lz, true);
   unpack(*this, RHS, b_sgn, b_sig, b_exp, b_lz, true);
 
-  SMTExprRef a_exp_ext = mkBVSignExt(2, a_exp);
-  SMTExprRef b_exp_ext = mkBVSignExt(2, b_exp);
-  SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
-  SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
+  SMTExprRef a_exp_ext = mkBVSignExt(a_exp, 2);
+  SMTExprRef b_exp_ext = mkBVSignExt(b_exp, 2);
+  SMTExprRef a_lz_ext = mkBVZeroExt(a_lz, 2);
+  SMTExprRef b_lz_ext = mkBVZeroExt(b_lz, 2);
 
   // ebits+2 bits hold the maximal normalized difference
   // (2^ebits - 3) + (sbits - 1) only while sbits <= 2^ebits + 3; every IEEE
@@ -899,11 +899,11 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
   // width. This path's value is discarded by the ite when d > 0.
   const unsigned wn = sbits + 4;
   const unsigned wshift = std::max(wn, ebits + 2);
-  SMTExprRef a8 = mkBVZeroExt(1, mkBVConcat(a_sig, mkBVZero3(*this)));
-  SMTExprRef b8 = mkBVZeroExt(1, mkBVConcat(b_sig, mkBVZero3(*this)));
+  SMTExprRef a8 = mkBVZeroExt(mkBVConcat(a_sig, mkBVZero3(*this)), 1);
+  SMTExprRef b8 = mkBVZeroExt(mkBVConcat(b_sig, mkBVZero3(*this)), 1);
   SMTExprRef shifted_neg = mkBVLshr(
-      wshift > wn ? mkBVZeroExt(wshift - wn, a8) : a8,
-      wshift > ebits + 2 ? mkBVZeroExt(wshift - (ebits + 2), neg_exp_diff)
+      wshift > wn ? mkBVZeroExt(a8, wshift - wn) : a8,
+      wshift > ebits + 2 ? mkBVZeroExt(neg_exp_diff, wshift - (ebits + 2))
                          : neg_exp_diff);
   if (wshift > wn)
     shifted_neg = mkBVExtract(wn - 1, 0, shifted_neg);
@@ -917,7 +917,7 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
   const unsigned W = 2 * sbits + 3;
   SMTExprRef one_W = mkBVFromDec(1, W);
   SMTExprRef m2_W =
-      mkBVZeroExt(W - (sbits + 1), mkBVConcat(b_sig, mkBVZero1(*this)));
+      mkBVZeroExt(mkBVConcat(b_sig, mkBVZero1(*this)), W - (sbits + 1));
   // Processing MSB-first, after consuming the top `lead` bits the
   // accumulator is 2^(d >> (ebits+1-lead)), which stays within [1, 2M] (and
   // congruent mod 2M) as long as 2^lead - 1 <= sbits. Those first rounds
@@ -929,12 +929,12 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
   SMTExprRef acc;
   if (lead > 0) {
     SMTExprRef top_bits = mkBVExtract(ebits, ebits + 1 - lead, exp_diff);
-    acc = mkBVShl(mkBVFromDec(1, w2), mkBVZeroExt(w2 - lead, top_bits));
+    acc = mkBVShl(mkBVFromDec(1, w2), mkBVZeroExt(top_bits, w2 - lead));
   } else {
     acc = mkBVFromDec(1, w2);
   }
   for (int i = static_cast<int>(ebits) - static_cast<int>(lead); i >= 0; --i) {
-    SMTExprRef sq = mkBVMul(mkBVZeroExt(W - w2, acc), mkBVZeroExt(W - w2, acc));
+    SMTExprRef sq = mkBVMul(mkBVZeroExt(acc, W - w2), mkBVZeroExt(acc, W - w2));
     SMTExprRef bit_set =
         mkEqual(mkBVExtract(static_cast<unsigned>(i), static_cast<unsigned>(i),
                             exp_diff),
@@ -943,9 +943,9 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
     acc = mkBVExtract(w2 - 1, 0, mkBVURem(dbl, m2_W));
   }
   SMTExprRef prod =
-      mkBVMul(mkBVZeroExt(W - sbits, a_sig), mkBVZeroExt(W - w2, acc));
+      mkBVMul(mkBVZeroExt(a_sig, W - sbits), mkBVZeroExt(acc, W - w2));
   SMTExprRef r2 = mkBVExtract(w2 - 1, 0, mkBVURem(prod, m2_W));
-  SMTExprRef m_w2 = mkBVZeroExt(2, b_sig);
+  SMTExprRef m_w2 = mkBVZeroExt(b_sig, 2);
   SMTExprRef q_odd_pos = mkBVUge(r2, m_w2);
   SMTExprRef r_pos = mkIte(q_odd_pos, mkBVSub(r2, m_w2), r2);
   SMTExprRef rem_pos =
@@ -964,7 +964,7 @@ SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
   SMTExprRef rndd_exp_eq_y_exp = mkEqual(rndd_sig_lz, one_ebits_p2);
   SMTExprRef rndd_exp_eq_y_exp_m1 = mkEqual(rndd_sig_lz, two_ebits_p2);
 
-  SMTExprRef y_sig_ext = mkBVConcat(mkBVZeroExt(2, b_sig), mkBVZero2(*this));
+  SMTExprRef y_sig_ext = mkBVConcat(mkBVZeroExt(b_sig, 2), mkBVZero2(*this));
   SMTExprRef y_sig_le_rndd_sig = mkBVSle(y_sig_ext, rndd_sig);
   SMTExprRef y_sig_eq_rndd_sig = mkEqual(y_sig_ext, rndd_sig);
 
@@ -1011,8 +1011,8 @@ static inline void addCore(SMTSolver &S, unsigned int SWidth,
   if (log2(SWidth + 2) < EWidth + 2) {
     // cap the delta
     SMTExprRef cap = S.mkBVFromDec(SWidth + 2, EWidth + 2);
-    SMTExprRef cap_le_delta = S.mkBVUle(cap, S.mkBVZeroExt(2, exp_delta));
-    SMTExprRef exp_delta_ext = S.mkBVZeroExt(2, exp_delta);
+    SMTExprRef cap_le_delta = S.mkBVUle(cap, S.mkBVZeroExt(exp_delta, 2));
+    SMTExprRef exp_delta_ext = S.mkBVZeroExt(exp_delta, 2);
     exp_delta = S.mkIte(cap_le_delta, cap, exp_delta_ext);
     exp_delta = S.mkBVExtract(EWidth - 1, 0, exp_delta);
   }
@@ -1041,8 +1041,8 @@ static inline void addCore(SMTSolver &S, unsigned int SWidth,
   SMTExprRef eq_sgn = S.mkEqual(CSgn, DSgn);
 
   // two extra bits for catching the overflow.
-  new_CSig = S.mkBVZeroExt(2, new_CSig);
-  shifted_d_sig = S.mkBVZeroExt(2, shifted_d_sig);
+  new_CSig = S.mkBVZeroExt(new_CSig, 2);
+  shifted_d_sig = S.mkBVZeroExt(shifted_d_sig, 2);
 
   assert(new_CSig->getWidth() == SWidth + 5);
   assert(shifted_d_sig->getWidth() == SWidth + 5);
@@ -1067,7 +1067,7 @@ static inline void addCore(SMTSolver &S, unsigned int SWidth,
   SMTExprRef sig_abs = S.mkIte(res_sig_eq, n_sum, sum);
 
   ResSig = S.mkBVExtract(SWidth + 3, 0, sig_abs);
-  ResExp = S.mkBVSignExt(2, CExp); // rounder requires 2 extra bits!
+  ResExp = S.mkBVSignExt(CExp, 2); // rounder requires 2 extra bits!
 }
 
 SMTExprRef SMTSolverImpl::mkFPAddImpl(const SMTExprRef &LHS,
@@ -1208,8 +1208,8 @@ SMTExprRef SMTSolverImpl::mkFPSqrtImpl(const SMTExprRef &Exp,
 
   const SMTExprRef res_sgn = zero1;
 
-  SMTExprRef real_exp = mkBVSub(mkBVSignExt(1, a_exp), mkBVZeroExt(1, a_lz));
-  SMTExprRef res_exp = mkBVSignExt(2, mkBVExtract(ebits, 1, real_exp));
+  SMTExprRef real_exp = mkBVSub(mkBVSignExt(a_exp, 1), mkBVZeroExt(a_lz, 1));
+  SMTExprRef res_exp = mkBVSignExt(mkBVExtract(ebits, 1, real_exp), 2);
 
   SMTExprRef e_is_odd = mkEqual(mkBVExtract(0, 0, real_exp), one1);
 
@@ -1252,8 +1252,8 @@ SMTExprRef SMTSolverImpl::mkFPSqrtImpl(const SMTExprRef &Exp,
 
   SMTExprRef last = mkBVExtract(0, 0, Q);
   SMTExprRef rest = mkBVExtract(sbits + 3, 1, Q);
-  SMTExprRef rest_ext = mkBVZeroExt(1, rest);
-  SMTExprRef last_ext = mkBVZeroExt(sbits + 3, last);
+  SMTExprRef rest_ext = mkBVZeroExt(rest, 1);
+  SMTExprRef last_ext = mkBVZeroExt(last, sbits + 3);
   SMTExprRef one_sbits4 = mkBVFromDec(1, sbits + 4);
   SMTExprRef sticky = mkIte(is_exact, last_ext, one_sbits4);
   SMTExprRef res_sig = mkBVOr(rest_ext, sticky);
@@ -1363,16 +1363,16 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   unpack(*this, Y, b_sgn, b_sig, b_exp, b_lz, true);
   unpack(*this, Z, c_sgn, c_sig, c_exp, c_lz, true);
 
-  SMTExprRef a_lz_ext = mkBVZeroExt(2, a_lz);
-  SMTExprRef b_lz_ext = mkBVZeroExt(2, b_lz);
-  SMTExprRef c_lz_ext = mkBVZeroExt(2, c_lz);
+  SMTExprRef a_lz_ext = mkBVZeroExt(a_lz, 2);
+  SMTExprRef b_lz_ext = mkBVZeroExt(b_lz, 2);
+  SMTExprRef c_lz_ext = mkBVZeroExt(c_lz, 2);
 
-  SMTExprRef a_sig_ext = mkBVZeroExt(sbits, a_sig);
-  SMTExprRef b_sig_ext = mkBVZeroExt(sbits, b_sig);
+  SMTExprRef a_sig_ext = mkBVZeroExt(a_sig, sbits);
+  SMTExprRef b_sig_ext = mkBVZeroExt(b_sig, sbits);
 
-  SMTExprRef a_exp_ext = mkBVSignExt(2, a_exp);
-  SMTExprRef b_exp_ext = mkBVSignExt(2, b_exp);
-  SMTExprRef c_exp_ext = mkBVSignExt(2, c_exp);
+  SMTExprRef a_exp_ext = mkBVSignExt(a_exp, 2);
+  SMTExprRef b_exp_ext = mkBVSignExt(b_exp, 2);
+  SMTExprRef c_exp_ext = mkBVSignExt(c_exp, 2);
 
   SMTExprRef mul_sgn = mkBVXor(a_sgn, b_sgn);
 
@@ -1388,7 +1388,7 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
 
   // Extend c
   SMTExprRef c_sig_ext =
-      mkBVZeroExt(1, mkBVConcat(c_sig, mkBVFromDec(0, sbits + 2)));
+      mkBVZeroExt(mkBVConcat(c_sig, mkBVFromDec(0, sbits + 2)), 1);
   c_exp_ext = mkBVSub(c_exp_ext, c_lz_ext);
   mul_sig = mkBVConcat(mul_sig, mkBVZero3(*this));
 
@@ -1421,7 +1421,7 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   // Alignment shift with sticky bit computation.
   SMTExprRef shifted_big =
       mkBVLshr(mkBVConcat(f_sig, mkBVFromDec(0, sbits)),
-               mkBVZeroExt((3 * sbits + 3) - (ebits + 2), exp_delta));
+               mkBVZeroExt(exp_delta, (3 * sbits + 3) - (ebits + 2)));
   SMTExprRef shifted_f_sig = mkBVExtract(3 * sbits + 2, sbits, shifted_big);
   SMTExprRef alignment_sticky_raw = mkBVExtract(sbits - 1, 0, shifted_big);
   SMTExprRef alignment_sticky = mkBVRedOr(alignment_sticky_raw);
@@ -1429,8 +1429,8 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
 
   // Significant addition.
   // Two extra bits for the sign and for catching overflows.
-  e_sig = mkBVZeroExt(2, e_sig);
-  shifted_f_sig = mkBVZeroExt(2, shifted_f_sig);
+  e_sig = mkBVZeroExt(e_sig, 2);
+  shifted_f_sig = mkBVZeroExt(shifted_f_sig, 2);
 
   SMTExprRef eq_sgn = mkEqual(e_sgn, f_sgn);
 
@@ -1443,7 +1443,7 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
    * and this is exactly equivalent to the conditional post-add/sub on an
    * even result -- without chaining a second full-width adder onto the
    * first. Same shape as addCore. */
-  SMTExprRef sticky_wide = mkBVZeroExt(2 * sbits + 4, alignment_sticky);
+  SMTExprRef sticky_wide = mkBVZeroExt(alignment_sticky, 2 * sbits + 4);
   shifted_f_sig = mkBVOr(shifted_f_sig, sticky_wide);
   SMTExprRef e_plus_f = mkBVAdd(e_sig, shifted_f_sig);
   SMTExprRef e_minus_f = mkBVSub(e_sig, shifted_f_sig);
@@ -1477,7 +1477,7 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   // Renormalize
   SMTExprRef zero_e2 = mkBVFromDec(0, ebits + 2);
   SMTExprRef min_exp = mkMinExp(*this, ebits);
-  min_exp = mkBVSignExt(2, min_exp);
+  min_exp = mkBVSignExt(min_exp, 2);
   SMTExprRef sig_lz = mkLeadingZeros(*this, sig_abs, ebits + 2);
   sig_lz = mkBVSub(sig_lz, mkBVFromDec(2, ebits + 2));
   SMTExprRef max_exp_delta = mkBVSub(res_exp, min_exp);
@@ -1486,7 +1486,7 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   SMTExprRef renorm_delta =
       mkIte(mkBVSle(zero_e2, sig_lz_capped), sig_lz_capped, zero_e2);
   res_exp = mkBVSub(res_exp, renorm_delta);
-  sig_abs = mkBVShl(sig_abs, mkBVZeroExt(2 * sbits + 3 - ebits, renorm_delta));
+  sig_abs = mkBVShl(sig_abs, mkBVZeroExt(renorm_delta, 2 * sbits + 3 - ebits));
 
   unsigned too_short = 0;
   if (sbits < 5) {
@@ -1497,7 +1497,7 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   SMTExprRef sticky_h1 = mkBVExtract(sbits + too_short - 2, 0, sig_abs);
   SMTExprRef sig_abs_h1 =
       mkBVExtract(2 * sbits + too_short + 4, sbits - 1 + too_short, sig_abs);
-  SMTExprRef sticky_h1_red = mkBVZeroExt(sbits + 5, mkBVRedOr(sticky_h1));
+  SMTExprRef sticky_h1_red = mkBVZeroExt(mkBVRedOr(sticky_h1), sbits + 5);
   SMTExprRef sig_abs_h1_f = mkBVOr(sig_abs_h1, sticky_h1_red);
   SMTExprRef res_sig_1 = mkBVExtract(sbits + 3, 0, sig_abs_h1_f);
   assert(sticky_h1->getWidth() == sbits + too_short - 1);
@@ -1513,8 +1513,8 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   // rounder then sees an exact tie where the value is actually above the
   // halfway point and rounds to even instead of up.
   SMTExprRef sticky_h2 = mkBVExtract(sbits + too_short - 1, 0, sig_abs);
-  SMTExprRef sticky_h2_red = mkBVZeroExt(sbits + 4, mkBVRedOr(sticky_h2));
-  SMTExprRef sig_abs_h2_f = mkBVZeroExt(1, mkBVOr(sig_abs_h2, sticky_h2_red));
+  SMTExprRef sticky_h2_red = mkBVZeroExt(mkBVRedOr(sticky_h2), sbits + 4);
+  SMTExprRef sig_abs_h2_f = mkBVZeroExt(mkBVOr(sig_abs_h2, sticky_h2_red), 1);
   SMTExprRef res_sig_2 = mkBVExtract(sbits + 3, 0, sig_abs_h2_f);
   assert(sig_abs_h2->getWidth() == sbits + 5);
   assert(sticky_h2_red->getWidth() == sbits + 5);
@@ -1617,7 +1617,7 @@ SMTExprRef SMTSolverImpl::mkFPEqualImpl(const SMTExprRef &LHS,
   return rewrapExprImpl(*result, result->Sort, SMTExprKind::FPEqual);
 }
 
-SMTExprRef SMTSolverImpl::mkFPtoFPImpl(const SMTExprRef &From,
+SMTExprRef SMTSolverImpl::mkFPToFPImpl(const SMTExprRef &From,
                                        const SMTSortRef &To,
                                        const SMTExprRef &R) {
   unsigned from_sbits = From->Sort->getFPSignificandWidth();
@@ -1687,23 +1687,23 @@ SMTExprRef SMTSolverImpl::mkFPtoFPImpl(const SMTExprRef &From,
     res_sig = sig;
 
   // extra zero in the front for the rounder.
-  res_sig = mkBVZeroExt(1, res_sig);
+  res_sig = mkBVZeroExt(res_sig, 1);
   assert(res_sig->getWidth() == to_sbits + 4);
 
   SMTExprRef exponent_overflow = mkBool(false);
 
   SMTExprRef res_exp;
   if (from_ebits < (to_ebits + 2)) {
-    res_exp = mkBVSignExt(to_ebits - from_ebits + 2, exp);
+    res_exp = mkBVSignExt(exp, to_ebits - from_ebits + 2);
 
     // subtract lz for subnormal numbers.
-    SMTExprRef lz_ext = mkBVZeroExt(to_ebits - from_ebits + 2, lz);
+    SMTExprRef lz_ext = mkBVZeroExt(lz, to_ebits - from_ebits + 2);
     res_exp = mkBVSub(res_exp, lz_ext);
   } else if (from_ebits > (to_ebits + 2)) {
     unsigned ebits_diff = from_ebits - (to_ebits + 2);
 
     // subtract lz for subnormal numbers.
-    SMTExprRef exp_sub_lz = mkBVSub(mkBVSignExt(2, exp), mkBVSignExt(2, lz));
+    SMTExprRef exp_sub_lz = mkBVSub(mkBVSignExt(exp, 2), mkBVSignExt(lz, 2));
 
     // check whether exponent is within roundable (to_ebits+2) range.
     SMTExprRef max_exp = mkBVConcat(
@@ -1750,7 +1750,7 @@ SMTExprRef SMTSolverImpl::mkFPtoFPImpl(const SMTExprRef &From,
   return rewrapExprImpl(*result, result->Sort, SMTExprKind::FPtoFP);
 }
 
-SMTExprRef SMTSolverImpl::mkSBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef SMTSolverImpl::mkSBVToFPImpl(const SMTExprRef &From,
                                         const SMTSortRef &To,
                                         const SMTExprRef &R) {
   // This is a conversion from unsigned bitvector to float:
@@ -1832,7 +1832,7 @@ SMTExprRef SMTSolverImpl::mkSBVtoFPImpl(const SMTExprRef &From,
     // Take the maximum legal exponent; this
     // allows us to keep the most precision.
     SMTExprRef max_exp = mkMaxExp(*this, exp_sz);
-    SMTExprRef max_exp_bvsz = mkBVZeroExt(bv_sz - exp_sz, max_exp);
+    SMTExprRef max_exp_bvsz = mkBVZeroExt(max_exp, bv_sz - exp_sz);
 
     SMTExprRef exp_too_large =
         mkBVSle(mkBVAdd(max_exp_bvsz, mkBVFromDec(1, bv_sz)), s_exp);
@@ -1854,7 +1854,7 @@ SMTExprRef SMTSolverImpl::mkSBVtoFPImpl(const SMTExprRef &From,
   return rewrapExprImpl(*result, result->Sort, SMTExprKind::SBVtoFP);
 }
 
-SMTExprRef SMTSolverImpl::mkUBVtoFPImpl(const SMTExprRef &From,
+SMTExprRef SMTSolverImpl::mkUBVToFPImpl(const SMTExprRef &From,
                                         const SMTSortRef &To,
                                         const SMTExprRef &R) {
   // This is a conversion from unsigned bitvector to float:
@@ -1931,7 +1931,7 @@ SMTExprRef SMTSolverImpl::mkUBVtoFPImpl(const SMTExprRef &From,
     // Take the maximum legal exponent; this
     // allows us to keep the most precision.
     SMTExprRef max_exp = mkMaxExp(*this, exp_sz);
-    SMTExprRef max_exp_bvsz = mkBVZeroExt(bv_sz - exp_sz, max_exp);
+    SMTExprRef max_exp_bvsz = mkBVZeroExt(max_exp, bv_sz - exp_sz);
 
     SMTExprRef exp_too_large =
         mkBVSle(mkBVAdd(max_exp_bvsz, mkBVFromDec(1, bv_sz)), s_exp);
@@ -1997,17 +1997,17 @@ SMTExprRef SMTSolverImpl::mkToBV(const SMTExprRef &Exp, bool isSigned,
   assert(sig_sz >= (bv_sz + 3));
 
   // x is of the form +- [1].[sig][r][g][s] ... and at least bv_sz + 3 long
-  SMTExprRef exp_m_lz = mkBVSub(mkBVSignExt(2, exp), mkBVZeroExt(2, lz));
+  SMTExprRef exp_m_lz = mkBVSub(mkBVSignExt(exp, 2), mkBVZeroExt(lz, 2));
 
   // big_sig is +- [... bv_sz+2 bits ...][1].[r][ ... sbits-1  ... ]
-  SMTExprRef big_sig = mkBVConcat(mkBVZeroExt(bv_sz + 2, sig), bv0);
+  SMTExprRef big_sig = mkBVConcat(mkBVZeroExt(sig, bv_sz + 2), bv0);
   unsigned big_sig_sz = sig_sz + 1 + bv_sz + 2;
   assert(big_sig->getWidth() == big_sig_sz);
 
   SMTExprRef is_neg_shift = mkBVSle(exp_m_lz, mkBVFromDec(0, ebits + 2));
   SMTExprRef shift = mkIte(is_neg_shift, mkBVNeg(exp_m_lz), exp_m_lz);
   if (ebits + 2 < big_sig_sz)
-    shift = mkBVZeroExt(big_sig_sz - ebits - 2, shift);
+    shift = mkBVZeroExt(shift, big_sig_sz - ebits - 2);
   else if (ebits + 2 > big_sig_sz) {
     SMTExprRef upper = mkBVExtract(big_sig_sz, ebits + 2, shift);
     shift = mkBVExtract(ebits + 1, 0, shift);
@@ -2036,7 +2036,7 @@ SMTExprRef SMTSolverImpl::mkToBV(const SMTExprRef &Exp, bool isSigned,
       mkRoundingDecision(*this, rm, sgn, last, round, sticky);
   assert(rounding_decision->getWidth() == 1);
 
-  SMTExprRef inc = mkBVZeroExt(bv_sz + 2, rounding_decision);
+  SMTExprRef inc = mkBVZeroExt(rounding_decision, bv_sz + 2);
   SMTExprRef pre_rounded = mkBVAdd(int_part, inc);
 
   SMTExprRef incd = mkEqual(rounding_decision, bv1);
@@ -2045,7 +2045,7 @@ SMTExprRef SMTSolverImpl::mkToBV(const SMTExprRef &Exp, bool isSigned,
 
   SMTExprRef ul, in_range;
   if (!isSigned) {
-    ul = mkBVZeroExt(3, mkBVNeg(mkBVFromDec(1, bv_sz)));
+    ul = mkBVZeroExt(mkBVNeg(mkBVFromDec(1, bv_sz)), 3);
     in_range =
         mkAnd(mkAnd(mkOr(mkNot(x_is_neg),
                          mkEqual(pre_rounded, mkBVFromDec(0, bv_sz + 3))),
@@ -2074,19 +2074,19 @@ SMTExprRef SMTSolverImpl::mkToBV(const SMTExprRef &Exp, bool isSigned,
   return mkIte(c1, v1, result);
 }
 
-SMTExprRef SMTSolverImpl::mkFPtoSBVImpl(const SMTExprRef &From,
+SMTExprRef SMTSolverImpl::mkFPToSBVImpl(const SMTExprRef &From,
                                         unsigned ToWidth) {
   SMTExprRef result = mkToBV(From, true, ToWidth);
   return rewrapExprImpl(*result, result->Sort, SMTExprKind::FPtoSBV);
 }
 
-SMTExprRef SMTSolverImpl::mkFPtoUBVImpl(const SMTExprRef &From,
+SMTExprRef SMTSolverImpl::mkFPToUBVImpl(const SMTExprRef &From,
                                         unsigned ToWidth) {
   SMTExprRef result = mkToBV(From, false, ToWidth);
   return rewrapExprImpl(*result, result->Sort, SMTExprKind::FPtoUBV);
 }
 
-SMTExprRef SMTSolverImpl::mkFPtoIntegralImpl(const SMTExprRef &From,
+SMTExprRef SMTSolverImpl::mkFPToIntegralImpl(const SMTExprRef &From,
                                              const SMTExprRef &R) {
   unsigned ebits = From->Sort->getFPExponentWidth();
   unsigned sbits = From->Sort->getFPSignificandWidth();
@@ -2122,7 +2122,7 @@ SMTExprRef SMTSolverImpl::mkFPtoIntegralImpl(const SMTExprRef &From,
   SMTExprRef xzero = mkIte(sgn_eq_1, nzero, pzero);
 
   // exponent < 0 -> 0/1
-  SMTExprRef x_is_denormal = mkFPIsDenormal(From);
+  SMTExprRef x_is_denormal = mkFPIsSubnormal(From);
   SMTExprRef exp_h = mkBVExtract(ebits - 1, ebits - 1, a_exp);
   SMTExprRef exp_lt_zero = mkEqual(exp_h, one_1);
   SMTExprRef c4 = mkOr(exp_lt_zero, x_is_denormal);
@@ -2181,7 +2181,7 @@ SMTExprRef SMTSolverImpl::mkFPtoIntegralImpl(const SMTExprRef &From,
   SMTExprRef zero_s = mkBVFromDec(0, sbits);
 
   SMTExprRef shift =
-      mkBVSub(mkBVFromDec(sbits - 1, sbits), mkBVZeroExt(sbits - ebits, a_exp));
+      mkBVSub(mkBVFromDec(sbits - 1, sbits), mkBVZeroExt(a_exp, sbits - ebits));
   SMTExprRef shifted_sig =
       mkBVLshr(mkBVConcat(a_sig, zero_s), mkBVConcat(zero_s, shift));
   SMTExprRef div = mkBVExtract(2 * sbits - 1, sbits, shifted_sig);
@@ -2228,9 +2228,9 @@ SMTExprRef SMTSolverImpl::mkFPtoIntegralImpl(const SMTExprRef &From,
 
   SMTExprRef e_shift = (ebits + 2 <= sbits + 1)
                            ? mkBVExtract(ebits + 1, 0, shift)
-                           : mkBVSignExt((ebits + 2) - (sbits), shift);
+                           : mkBVSignExt(shift, (ebits + 2) - (sbits));
   assert(e_shift->getWidth() == ebits + 2);
-  res_exp = mkBVAdd(mkBVZeroExt(2, res_exp), e_shift);
+  res_exp = mkBVAdd(mkBVZeroExt(res_exp, 2), e_shift);
 
   assert(res_sgn->getWidth() == 1);
   assert(res_sig->getWidth() == sbits);
@@ -2239,7 +2239,7 @@ SMTExprRef SMTSolverImpl::mkFPtoIntegralImpl(const SMTExprRef &From,
   // Renormalize
   SMTExprRef zero_e2 = mkBVFromDec(0, ebits + 2);
   SMTExprRef min_exp = mkMinExp(*this, ebits);
-  min_exp = mkBVSignExt(2, min_exp);
+  min_exp = mkBVSignExt(min_exp, 2);
   SMTExprRef sig_lz = mkLeadingZeros(*this, res_sig, ebits + 2);
   SMTExprRef max_exp_delta = mkBVSub(res_exp, min_exp);
   SMTExprRef sig_lz_capped =
@@ -2248,7 +2248,7 @@ SMTExprRef SMTSolverImpl::mkFPtoIntegralImpl(const SMTExprRef &From,
       mkIte(mkBVSle(zero_e2, sig_lz_capped), sig_lz_capped, zero_e2);
   assert(renorm_delta->getWidth() == ebits + 2);
   res_exp = mkBVSub(res_exp, renorm_delta);
-  res_sig = mkBVShl(res_sig, mkBVZeroExt(sbits - ebits - 2, renorm_delta));
+  res_sig = mkBVShl(res_sig, mkBVZeroExt(renorm_delta, sbits - ebits - 2));
 
   res_exp = mkBVExtract(ebits - 1, 0, res_exp);
   res_exp = mkBias(*this, res_exp);
@@ -2367,7 +2367,7 @@ SMTExprRef SMTSolverImpl::round(const SMTExprRef &R, const SMTExprRef &Sgn,
   SMTExprRef ne3 = mkNot(e3);
   SMTExprRef e_top_three = mkAnd(ne3, e21);
 
-  SMTExprRef ext_emax = mkBVZeroExt(2, e_max);
+  SMTExprRef ext_emax = mkBVZeroExt(e_max, 2);
   SMTExprRef t_sig = mkBVExtract(SWidth + 3, SWidth + 3, Sig);
   SMTExprRef e_eq_emax = mkEqual(ext_emax, Exp);
   SMTExprRef sigm1 = mkEqual(t_sig, one_1);
@@ -2379,12 +2379,12 @@ SMTExprRef SMTSolverImpl::round(const SMTExprRef &R, const SMTExprRef &Sgn,
 
   SMTExprRef t = mkBVAdd(Exp, mkBVFromDec(1, EWidth + 2));
   t = mkBVSub(t, lz);
-  t = mkBVSub(t, mkBVSignExt(2, e_min));
+  t = mkBVSub(t, mkBVSignExt(e_min, 2));
   SMTExprRef TINY = mkBVSle(t, mkBVFromDec(-1, EWidth + 2));
 
   SMTExprRef beta = mkBVAdd(mkBVSub(Exp, lz), mkBVFromDec(1, EWidth + 2));
 
-  SMTExprRef sigma_add = mkBVSub(Exp, mkBVSignExt(2, e_min));
+  SMTExprRef sigma_add = mkBVSub(Exp, mkBVSignExt(e_min, 2));
   sigma_add = mkBVAdd(sigma_add, mkBVFromDec(1, EWidth + 2));
   SMTExprRef sigma = mkIte(TINY, sigma_add, lz);
 
@@ -2402,9 +2402,9 @@ SMTExprRef SMTSolverImpl::round(const SMTExprRef &R, const SMTExprRef &Sgn,
 
   SMTExprRef sig_ext = mkBVConcat(Sig, mkBVFromDec(0, sig_size));
   SMTExprRef rs_sig = mkBVLshr(
-      sig_ext, mkBVZeroExt(2 * sig_size - sigma_size, sigma_neg_capped));
+      sig_ext, mkBVZeroExt(sigma_neg_capped, 2 * sig_size - sigma_size));
   SMTExprRef ls_sig =
-      mkBVShl(sig_ext, mkBVZeroExt(2 * sig_size - sigma_size, sigma));
+      mkBVShl(sig_ext, mkBVZeroExt(sigma, 2 * sig_size - sigma_size));
   SMTExprRef big_sh_sig = mkIte(sigma_lt_zero, rs_sig, ls_sig);
   assert(big_sh_sig->getWidth() == 2 * sig_size);
 
@@ -2416,11 +2416,11 @@ SMTExprRef SMTSolverImpl::round(const SMTExprRef &R, const SMTExprRef &Sgn,
       mkBVRedOr(mkBVExtract(sig_extract_low_bit - 1, 0, big_sh_sig));
 
   // put the sticky bit into the significand.
-  SMTExprRef ext_sticky = mkBVZeroExt(SWidth + 1, sticky);
+  SMTExprRef ext_sticky = mkBVZeroExt(sticky, SWidth + 1);
   Sig = mkBVOr(Sig, ext_sticky);
   assert(Sig->getWidth() == SWidth + 2);
 
-  SMTExprRef ext_emin = mkBVZeroExt(2, e_min);
+  SMTExprRef ext_emin = mkBVZeroExt(e_min, 2);
   Exp = mkIte(TINY, ext_emin, beta);
 
   // Significand rounding
@@ -2439,7 +2439,7 @@ SMTExprRef SMTSolverImpl::round(const SMTExprRef &R, const SMTExprRef &Sgn,
                                       rm_even, Sgn, last, round, sticky);
   assert(inc->getWidth() == 1);
 
-  Sig = mkBVAdd(mkBVZeroExt(1, Sig), mkBVZeroExt(SWidth, inc));
+  Sig = mkBVAdd(mkBVZeroExt(Sig, 1), mkBVZeroExt(inc, SWidth));
 
   // Post normalization
   assert(Sig->getWidth() == SWidth + 1);

--- a/src/theories/camadafxp.cpp
+++ b/src/theories/camadafxp.cpp
@@ -138,7 +138,7 @@ SMTExprRef extendRaw(SMTSolverImpl &S, const SMTExprRef &Raw, bool IsSigned,
                      unsigned Extra) {
   if (Extra == 0)
     return Raw;
-  return IsSigned ? S.mkBVSignExt(Extra, Raw) : S.mkBVZeroExt(Extra, Raw);
+  return IsSigned ? S.mkBVSignExt(Raw, Extra) : S.mkBVZeroExt(Raw, Extra);
 }
 
 // Aligns a fixed-point operand into format C as a plain-BV raw view,
@@ -246,8 +246,8 @@ SMTExprRef roundQuotient(SMTSolverImpl &S, const SMTExprRef &Quot,
   }
   // Nearest: compare twice the remainder against the divisor. Both are
   // taken as magnitudes, and the doubling needs one extra bit.
-  SMTExprRef AR = S.mkBVZeroExt(1, absOf(Rem));
-  SMTExprRef AD = S.mkBVZeroExt(1, absOf(R));
+  SMTExprRef AR = S.mkBVZeroExt(absOf(Rem), 1);
+  SMTExprRef AD = S.mkBVZeroExt(absOf(R), 1);
   SMTExprRef Twice = S.mkBVShl(AR, S.mkBVFromDec(1, W + 1));
   SMTExprRef Above = S.mkBVUgt(Twice, AD);
   SMTExprRef Tie = S.mkEqual(Twice, AD);
@@ -279,7 +279,7 @@ SMTExprRef roundQuotient(SMTSolverImpl &S, const SMTExprRef &Quot,
 SMTExprRef roundFPToIntegral(SMTSolverImpl &S, const SMTExprRef &V,
                              FXPRM Mode) {
   FPEncoding E = V->Sort->isBVFPSort() ? FPEncoding::BV : FPEncoding::Native;
-  auto integral = [&](RM R) { return S.mkFPtoIntegral(V, S.mkRM(R, E)); };
+  auto integral = [&](RM R) { return S.mkFPToIntegral(V, S.mkRM(R, E)); };
   switch (Mode) {
   case FXPRM::TowardZero:
     return integral(RM::ROUND_TO_ZERO);
@@ -1043,7 +1043,7 @@ SMTExprRef SMTSolverImpl::mkFXPRound(const SMTExprRef &Exp, unsigned Digits,
   case FXPRM::NearestTiesToEven:
     // half - 1 + (lowest kept bit): a tie lands on the even neighbour.
     Bias = mkBVAdd(mkBVSub(Bias, One),
-                   mkBVZeroExt(W - 1, mkBVExtract(Shift, Shift, Raw)));
+                   mkBVZeroExt(mkBVExtract(Shift, Shift, Raw), W - 1));
     break;
   case FXPRM::TowardNegative:
     // Masking alone floors, for both signednesses.
@@ -1121,7 +1121,7 @@ SMTExprRef SMTSolverImpl::mkFXPCountls(const SMTExprRef &Exp,
   unsigned P = 1;
   while (P < Counted)
     P *= 2;
-  SMTExprRef Rest = mkBVZeroExt(P - Counted, Payload);
+  SMTExprRef Rest = mkBVZeroExt(Payload, P - Counted);
   if (P != Counted) {
     Rest = mkBVShl(Rest, mkBVFromDec(P - Counted, P));
     Rest = mkBVOr(Rest, mkBVFromBin(std::string(Counted, '0') +
@@ -1273,11 +1273,11 @@ SMTExprRef SMTSolverImpl::mkFXPExp(const SMTExprRef &Exp) {
   // them before the shift brings it back: the multiply is done at twice
   // the width and narrowed only once the low bits have been discarded.
   const unsigned W2 = 2 * W;
-  SMTExprRef RWide = mkBVZeroExt(W, R);
+  SMTExprRef RWide = mkBVZeroExt(R, W);
   for (unsigned I = NTerms; I >= 1; --I) {
     // acc = 1 + (r * acc >> P) / I
     SMTExprRef Prod =
-        mkBVLshr(mkBVMul(RWide, mkBVZeroExt(W, Acc)), mkBVFromDec(P, W2));
+        mkBVLshr(mkBVMul(RWide, mkBVZeroExt(Acc, W)), mkBVFromDec(P, W2));
     if (I > 1)
       Prod = mkBVUDiv(Prod, mkBVFromDec(I, W2));
     Acc = mkBVAdd(One, mkBVExtract(W - 1, 0, Prod));
@@ -1336,7 +1336,7 @@ SMTExprRef SMTSolverImpl::mkFXPSqrt(const SMTExprRef &Exp, FXPRM Mode) {
   SMTExprRef Raw = mkFXPToRawBV(Exp);
   // A negative operand has no real square root; zero-extending
   // gives its bits a defined reading rather than a trapping one.
-  SMTExprRef Rad = mkBVZeroExt(RadWidth - F.Width, Raw);
+  SMTExprRef Rad = mkBVZeroExt(Raw, RadWidth - F.Width);
   if (F.FracBits != 0)
     Rad = mkBVShl(Rad, mkBVFromDec(F.FracBits, RadWidth));
   // Restoring square root, most significant digit first. Root and
@@ -1351,7 +1351,7 @@ SMTExprRef SMTSolverImpl::mkFXPSqrt(const SMTExprRef &Exp, FXPRM Mode) {
   SMTExprRef One = mkBVFromDec(1, RadWidth);
   for (unsigned I = Digits; I-- > 0;) {
     SMTExprRef Pair =
-        mkBVZeroExt(RadWidth - 2, mkBVExtract(2 * I + 1, 2 * I, Rad));
+        mkBVZeroExt(mkBVExtract(2 * I + 1, 2 * I, Rad), RadWidth - 2);
     Rem = mkBVOr(mkBVShl(Rem, Two), Pair);
     SMTExprRef Trial = mkBVOr(mkBVShl(Root, Two), One);
     SMTExprRef Fits = mkBVUge(Rem, Trial);
@@ -1512,7 +1512,7 @@ FPFXPParts fpToFXPParts(SMTSolverImpl &S, const SMTExprRef &Exp,
   unsigned WE = Wide->getFPExponentWidth();
   unsigned WS = Wide->getWidth() - 1 - WE;
   SMTExprRef RNE = S.mkRM(RM::ROUND_TO_EVEN, Enc);
-  SMTExprRef Scaled = S.mkFPtoFP(Val, Wide, RNE); // exact: Wide covers Src
+  SMTExprRef Scaled = S.mkFPToFP(Val, Wide, RNE); // exact: Wide covers Src
   if (To.FracBits != 0)
     Scaled = S.mkFPMul(
         Scaled,
@@ -1556,7 +1556,7 @@ SMTExprRef SMTSolverImpl::mkFXPToFP(const SMTExprRef &Exp, const SMTSortRef &To,
   uint64_t MaxExp = uint64_t(std::max(From.Width, From.FracBits)) + 2;
   // The raw integer converts exactly (wide significand covers the raw
   // width), the 2^-FracBits scale is an exact power-of-two multiply
-  // inside the wide range, and the final mkFPtoFP performs the
+  // inside the wide range, and the final mkFPToFP performs the
   // conversion's only rounding, per R. When the target is native but no
   // universal native format holds the intermediate, the whole conversion
   // runs in the BV encoder — including the final rounding, into a
@@ -1578,7 +1578,7 @@ SMTExprRef SMTSolverImpl::mkFXPToFP(const SMTExprRef &Exp, const SMTSortRef &To,
   SMTExprRef Rm = mkRM(R, Enc);
   SMTExprRef Raw = mkFXPToRawBV(Exp);
   SMTExprRef Val =
-      From.IsSigned ? mkSBVtoFP(Raw, Wide, Rm) : mkUBVtoFP(Raw, Wide, Rm);
+      From.IsSigned ? mkSBVToFP(Raw, Wide, Rm) : mkUBVToFP(Raw, Wide, Rm);
   if (From.FracBits != 0) {
     unsigned WE = Wide->getFPExponentWidth();
     unsigned WS = Wide->getWidth() - 1 - WE;
@@ -1588,7 +1588,7 @@ SMTExprRef SMTSolverImpl::mkFXPToFP(const SMTExprRef &Exp, const SMTSortRef &To,
                     Enc),
         Rm);
   }
-  SMTExprRef Res = mkFPtoFP(Val, RoundTo, Rm);
+  SMTExprRef Res = mkFPToFP(Val, RoundTo, Rm);
   if (RoundTo != To)
     Res = mkBVToIEEEFP(mkIEEEFPToBV(Res), To);
   return rewrapExprImpl(*Res, To, SMTExprKind::FXPToFP);
@@ -1607,8 +1607,8 @@ SMTExprRef SMTSolverImpl::mkFPToFXP(const SMTExprRef &Exp, const SMTSortRef &To,
   // result is solver-chosen, matching C's UB; gate with
   // mkFPToFXPOverflow.
   FPFXPParts P = fpToFXPParts(*this, Exp, Target, Mode);
-  SMTExprRef Raw = Target.IsSigned ? mkFPtoSBV(P.Scaled, Target.Width)
-                                   : mkFPtoUBV(P.Scaled, Target.Width);
+  SMTExprRef Raw = Target.IsSigned ? mkFPToSBV(P.Scaled, Target.Width)
+                                   : mkFPToUBV(P.Scaled, Target.Width);
   return rewrapExprImpl(*Raw, To, SMTExprKind::FPToFXP);
 }
 
@@ -1630,8 +1630,8 @@ SMTExprRef SMTSolverImpl::mkFPToFXPSat(const SMTExprRef &Exp,
   FXPFormat Target = formatOf(To);
   FPFXPParts P = fpToFXPParts(*this, Exp, Target, Mode);
   // P.Scaled is already rounded per Mode, so the conversion is exact.
-  SMTExprRef Raw = Target.IsSigned ? mkFPtoSBV(P.Scaled, Target.Width)
-                                   : mkFPtoUBV(P.Scaled, Target.Width);
+  SMTExprRef Raw = Target.IsSigned ? mkFPToSBV(P.Scaled, Target.Width)
+                                   : mkFPToUBV(P.Scaled, Target.Width);
   // NaN -> 0 (Clang's _Sat choice; the TR leaves it undefined), rails for
   // out-of-range and +-infinity, rounded per Mode otherwise. NaN first:
   // it fails both comparisons, so TooHi and TooLo both hold for it.


### PR DESCRIPTION
Three pre-1.0 fixes that all touch `camada.h` declarations, so they share a branch rather than conflicting as separate PRs. One commit each.

### Correct the handle-liveness threading guarantee (#162)

The contract claimed the liveness check was race-free against a concurrent `reset()` or destruction. It is not — the generation check can pass and the arena be cleared before the reader dereferences the raw pointer. The check only catches handles left stale by an *earlier* reset. Documents what it actually provides and requires callers to serialize `reset()` and destruction against handle reads.

Retracting rather than fixing: real reader lifetime protection (hazard pointers or epoch reclamation) would land in the hottest path in the library, and the surrounding contract already says one solver per thread.

### Make supports(NativeTuples) report the backend capability (#158)

`supports()` answers what a backend can do, not how the instance was configured, but `NativeTuples` folded in `TupleEncoding` and `ArrayEncoding`: a Z3 solver configured for the Camada lowering claimed no native tuples even though Z3 has datatypes. Asking whether a backend supports *Camada* tuples is meaningless — every backend does, since Camada encodes them itself — so the only useful question is whether the driver has datatypes.

- `supports(NativeTuples)` now answers `nativeDatatypeSupport()`.
- `nativeTupleSupport()` keeps the configuration-dependent rule as the internal routing predicate.
- Ackermann arrays stay out of the capability answer for the same reason: that is a Camada encoding choice, not a driver property.
- Callers wanting the effective behaviour compose `supports(NativeTuples)` with `tupleMode()`; the three affected tests now assert both, to document the pattern.
- Also drops the stale `SolverConfig` claim that `supports(UnsatAssumptions)` answers false when core production is off.

### Normalize public API names before the freeze (#161)

Now-or-never renames:

- `checkResult` → `CheckResult` (the only lower-case public type).
- `mkFPtoFP`, `mkFPtoSBV`, `mkFPtoUBV`, `mkFPtoIntegral`, `mkSBVtoFP`, `mkUBVtoFP` → `mkFPTo*`, `mkSBVToFP`, `mkUBVToFP`, matching the eleven conversions that already used `To`. The last two were not in the issue; the sweep found them.
- `mkFPIsDenormal` → `mkFPIsSubnormal`, which is what the documentation and the emitted SMT-LIB already said. `SMTExprKind::FPIsDenormal` follows, since it is public via `camadaexpr.h`.
- Width argument of `mkInt2BV`, `mkBVSignExt` and `mkBVZeroExt` moves after the expression, so every operation taking a source and a target reads `(source, target)`. This corrects the direction given in the issue: the conversions were already consistent, and these three BV ops were the outliers. 130 call sites, reviewed by diff rather than trusting the rewrite.
- The extension parameter is `ExtraBits` instead of `i`.

### Verification

`ctest -j16`: 237/237 pass. Clean build, no warnings. clang-format applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp6BKyd2TaLMghESwZNaKQ