### PR TITLE
Stop STP from aliasing symbols that differ only in punctuation

### DIFF
--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -4,6 +4,7 @@
 #include <bitset>
 #include <catch2/catch_test_macros.hpp>
 #include <string>
+#include <vector>
 
 inline void equal_ten(const camada::SMTSolverRef &solver) {
   // A free variable
@@ -567,6 +568,36 @@ inline void int_arithmetic_semantics(const camada::SMTSolverRef &solver) {
   solver->addConstraint(solver->mkEqual(x_plus_one, three));
   solver->addConstraint(solver->mkArithGt(x, one));
   REQUIRE(solver->check() == camada::CheckResult::SAT);
+}
+
+inline void
+symbol_name_punctuation_distinct(const camada::SMTSolverRef &solver) {
+  // Names differing only in punctuation are different symbols. A backend
+  // that rewrites those characters to a common replacement aliases them,
+  // which silently changes satisfiability: the conjunction below is
+  // trivially satisfiable for distinct symbols and unsatisfiable if any
+  // pair collapses into one variable. ESBMC generates all of these
+  // (`main::1::x`, `x!0`, `&y`, `#tmp`).
+  const char *Names[] = {"n@x", "n!x", "n&x", "n#x", "n$x", "n:x", "n_x"};
+  auto sort = solver->mkBVSort(4);
+  std::vector<camada::SMTExprRef> syms;
+  for (const char *N : Names)
+    syms.push_back(solver->mkSymbol(N, sort));
+
+  // Pin each symbol to a distinct value. Seven names, sixteen values, so
+  // this is satisfiable exactly when all seven are independent.
+  for (std::size_t I = 0; I < syms.size(); ++I)
+    solver->addConstraint(solver->mkEqual(
+        syms[I], solver->mkBVFromDec(static_cast<int64_t>(I), 4)));
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
+
+  // And each really holds the value it was pinned to, so the names did not
+  // merely survive but map to the right terms.
+  for (std::size_t I = 0; I < syms.size(); ++I) {
+    auto v = solver->getBV(syms[I]);
+    REQUIRE(v);
+    REQUIRE(v.value() == static_cast<int64_t>(I));
+  }
 }
 
 inline void arith_division_semantics(const camada::SMTSolverRef &solver) {

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -72,6 +72,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   constexpr auto BVFP = camada::FPEncoding::BV;
 
   RESETANDTEST(equal_ten);
+  RESETANDTEST(symbol_name_punctuation_distinct);
   RESETANDTEST(implies_semantics);
   RESETANDTEST(implies_true_implies_false);
   RESETANDTEST(bv_lshr_semantics);

--- a/src/solvers/stpsolver.cpp
+++ b/src/solvers/stpsolver.cpp
@@ -601,15 +601,13 @@ SMTExprRef STPSolver::mkBVFromBinImpl(const std::string &Int,
 
 SMTExprRef STPSolver::mkSymbolImpl(const std::string &Name,
                                    const SMTSortRef &Sort) {
-
-  std::string new_name = Name;
-  for (char &c : new_name)
-    if (c == '@' || c == '!' || c == '&' || c == '#' || c == '$' || c == ':')
-      c = '_';
-
+  // Pass the name through unchanged, like every other backend. This used to
+  // rewrite each of `@!&#$:` to `_`, which made `a@b`, `a!b` and `a_b` the
+  // same STP variable and silently changed satisfiability. STP accepts and
+  // prints those characters verbatim, so there was nothing to sanitize.
   return makeExprRef<STPExpr>(
       SMTExprKind::Symbol, &Context, Sort,
-      STP::vc_varExpr(Context, new_name.c_str(),
+      STP::vc_varExpr(Context, Name.c_str(),
                       toSolverSort<STPSort>(*Sort).Sort));
 }
 


### PR DESCRIPTION
`STPSolver::mkSymbolImpl` rewrote each of `@ ! & # $ :` to `_`, so `a@b`, `a!b` and `a_b` all became the same STP variable. Distinct symbols silently merged into one, which changes satisfiability — and ESBMC generates every one of those spellings (`main::1::x`, `x!0`, `&y`, `#tmp`).

### Why removing it is the fix

I checked what STP actually requires before choosing an escape scheme, and it requires nothing:

- `vc_varExpr` accepts every punctuation character tested, including all six that were being rewritten.
- STP keeps `a@b` and `a_b` as independent variables — `x != y` is satisfiable — so the aliasing was entirely Camada's, before STP ever saw the names.
- Model values are read back by expression handle, not by name, so nothing parses printed names.
- STP's printer emits all 33 tested punctuation characters verbatim, so `dump()` round-trips them too.

So the sanitizer protected against nothing and lost information. I first wrote an injective `_xx` hex escape, which worked but rendered `main::1::x@2` as `main_3a_3a1_3a_3ax_402` in dumps; since STP needs no escaping at all, passing the name through is both simpler and better for debugging. `dump()` now shows `main::1::x@2` as written.

### Test

`symbol_name_punctuation_distinct` pins seven names differing only in punctuation (`n@x`, `n!x`, `n&x`, `n#x`, `n$x`, `n:x`, `n_x`) to seven different 4-bit values, which is satisfiable exactly when all seven are independent, then reads each back to confirm the names map to the right terms. Registered in `tests()`, so it runs on every backend — it failed on STP alone, which stopped at 9 assertions before reaching the rest of its suite.

Verified failing before the fix and passing after. Full suite 241/241, clean build, no warnings.

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp6BKyd2TaLMghESwZNaKQ