### PR TITLE
Answer instead of aborting when comparing null sort handles

### DIFF
--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -570,6 +570,24 @@ inline void int_arithmetic_semantics(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
+inline void null_sort_handle_equality(const camada::SMTSolverRef &solver) {
+  // Sort handles are nullable, so comparison has to answer instead of
+  // aborting inside the dereference.
+  camada::SMTSortRef null_a, null_b;
+  REQUIRE(null_a == null_b);
+  REQUIRE_FALSE(null_a != null_b);
+
+  auto live = solver->mkBVSort(8);
+  REQUIRE(live != null_a);
+  REQUIRE(null_a != live);
+  REQUIRE_FALSE(live == null_a);
+
+  // Two handles to the same sort still compare equal, and a different sort
+  // still compares unequal -- the null check must not short-circuit those.
+  REQUIRE(live == solver->mkBVSort(8));
+  REQUIRE(live != solver->mkBVSort(16));
+}
+
 inline void
 symbol_name_punctuation_distinct(const camada::SMTSolverRef &solver) {
   // Names differing only in punctuation are different symbols. A backend

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -73,6 +73,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
 
   RESETANDTEST(equal_ten);
   RESETANDTEST(symbol_name_punctuation_distinct);
+  RESETANDTEST(null_sort_handle_equality);
   RESETANDTEST(implies_semantics);
   RESETANDTEST(implies_true_implies_false);
   RESETANDTEST(bv_lshr_semantics);

--- a/src/camadasort.h
+++ b/src/camadasort.h
@@ -264,6 +264,13 @@ protected:
 };
 
 inline bool operator==(SMTSortRef const &LHS, SMTSortRef const &RHS) {
+  // Handles are nullable, so comparing one that is null (or stale) must
+  // answer rather than abort in the dereference: two absent sorts are
+  // equal, and an absent one differs from any live sort.
+  const bool LHSValid = static_cast<bool>(LHS),
+             RHSValid = static_cast<bool>(RHS);
+  if (!LHSValid || !RHSValid)
+    return LHSValid == RHSValid;
   return (*LHS == *RHS);
 }
 


### PR DESCRIPTION
`SMTSortRef` is documented as nullable (`camada.h` threading contract, `camadaexpr.h` handle docs), but `operator==` dereferenced both operands:

```cpp
inline bool operator==(SMTSortRef const &LHS, SMTSortRef const &RHS) {
  return (*LHS == *RHS);
}
```

Comparing two default-constructed handles — or a default and a live one — aborted instead of answering. Confirmed in a release build:

```
comparing two null sorts...
Dereferencing null sort handle
Aborted (core dumped)
```

### Fix

Treat an absent handle as absent: two absent sorts are equal, and an absent one differs from any live sort. A *stale* handle (owning solver reset or destroyed) counts as absent too, on the same reasoning — comparing one should not abort either, and `isValid()` already covers both cases.

`SMTExprRef` has no `operator==`, so sorts are the only affected type.

### Test

`null_sort_handle_equality` covers null==null, null vs live in both orders, and — importantly — that the new early return does not break the normal cases: two handles to the same sort still compare equal, and different sorts still compare unequal.

Without the fix the test aborts with `SIGABRT` rather than failing an assertion, which is the reproduced bug. Registered in `tests()` so every backend runs it. Full suite 241/241, clean build, no warnings.

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp6BKyd2TaLMghESwZNaKQ