### PR TITLE
Make model queries, scope depth and round-to-away follow the failure model

### DIFF
--- a/regression/ackarray.test.h
+++ b/regression/ackarray.test.h
@@ -9,6 +9,7 @@
 // select/store/const/ite semantics and model queries.
 
 #include "camada.h"
+#include "modelhelpers.test.h"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -143,12 +144,12 @@ inline void ack_model_query_stability(const camada::SMTSolverRef &solver) {
 
   // Constrained index: exact value. Unconstrained index: some stable
   // value, the same on a repeated query against the same model.
-  auto at1 = solver->getArrayElement(a, solver->mkBVFromDec(1, 8));
+  auto at1 = arrayElement(solver, a, solver->mkBVFromDec(1, 8));
   auto at1val = solver->getBVInBin(at1);
   REQUIRE(at1val);
   REQUIRE(at1val.value() == "00001001");
-  auto at5a = solver->getArrayElement(a, solver->mkBVFromDec(5, 8));
-  auto at5b = solver->getArrayElement(a, solver->mkBVFromDec(5, 8));
+  auto at5a = arrayElement(solver, a, solver->mkBVFromDec(5, 8));
+  auto at5b = arrayElement(solver, a, solver->mkBVFromDec(5, 8));
   auto at5aval = solver->getBVInBin(at5a);
   auto at5bval = solver->getBVInBin(at5b);
   REQUIRE(at5aval);
@@ -257,12 +258,12 @@ inline void ack_fp_element_semantics(const camada::SMTSolverRef &solver) {
 
   solver->addConstraint(solver->mkEqual(solver->mkArraySelect(a, i), v));
   REQUIRE(solver->check() == camada::CheckResult::SAT);
-  auto at3 = solver->getArrayElement(a, solver->mkBVFromDec(3, 8));
+  auto at3 = arrayElement(solver, a, solver->mkBVFromDec(3, 8));
   auto fpval = solver->getFP32(at3);
   REQUIRE(fpval);
   REQUIRE(fpval.value() == 1.5f);
   // Unconstrained index: the synthesized default must evaluate too.
-  auto at9 = solver->getArrayElement(a, solver->mkBVFromDec(9, 8));
+  auto at9 = arrayElement(solver, a, solver->mkBVFromDec(9, 8));
   REQUIRE(solver->getFP32(at9));
 }
 

--- a/regression/array.test.h
+++ b/regression/array.test.h
@@ -1,5 +1,6 @@
 
 #include "camada.h"
+#include "modelhelpers.test.h"
 
 #include <bitset>
 #include <catch2/catch_test_macros.hpp>
@@ -31,7 +32,7 @@ array(const camada::SMTSolverRef &solver,
   // Add the constraint to the solver, And check for satisfiability
   solver->addConstraint(eq);
   REQUIRE(solver->check() == camada::CheckResult::SAT);
-  auto selected = solver->getArrayElement(arr11, solver->mkBVFromDec(1, 2));
+  auto selected = arrayElement(solver, arr11, solver->mkBVFromDec(1, 2));
   REQUIRE(selected->Sort == elemsort);
   auto selected_res = solver->getBVInBin(selected);
   REQUIRE(selected_res);
@@ -59,8 +60,8 @@ inline void array_const_store_semantics(
 
   REQUIRE(solver->check() == camada::CheckResult::SAT);
 
-  auto read_written = solver->getArrayElement(updated, idx_written);
-  auto read_other = solver->getArrayElement(updated, idx_other);
+  auto read_written = arrayElement(solver, updated, idx_written);
+  auto read_other = arrayElement(solver, updated, idx_other);
 
   REQUIRE(read_written->Sort == elemsort);
   REQUIRE(read_other->Sort == elemsort);
@@ -98,8 +99,8 @@ inline void bool_array_const_store_semantics(
 
   REQUIRE(solver->check() == camada::CheckResult::SAT);
 
-  auto read_written = solver->getArrayElement(updated, idx_written);
-  auto read_other = solver->getArrayElement(updated, idx_other);
+  auto read_written = arrayElement(solver, updated, idx_written);
+  auto read_other = arrayElement(solver, updated, idx_other);
 
   REQUIRE(read_written->Sort == boolsort);
   REQUIRE(read_other->Sort == boolsort);
@@ -206,8 +207,8 @@ inline void wide_index_const_array_semantics(
 
     // The model query at an index the formula never touched must still
     // report the default, resolved from the tracked derivation chain.
-    auto read_written = solver->getArrayElement(updated, idx_written);
-    auto read_untouched = solver->getArrayElement(updated, idx_untouched);
+    auto read_written = arrayElement(solver, updated, idx_written);
+    auto read_untouched = arrayElement(solver, updated, idx_untouched);
     auto read_written_res = solver->getBVInBin(read_written);
     auto read_untouched_res = solver->getBVInBin(read_untouched);
     REQUIRE(read_written_res);
@@ -307,7 +308,7 @@ inline void const_array_model_values(
   // through the base or an explicit entry.
   REQUIRE(array_model_value_at(solver, Model.value(), 200) == 7);
   // The sparse model must agree with the per-index query API.
-  auto Probe = solver->getBV(solver->getArrayElement(arr, idx(200)));
+  auto Probe = solver->getBV(arrayElement(solver, arr, idx(200)));
   REQUIRE(Probe);
   REQUIRE(Probe.value() == 7);
 }
@@ -626,9 +627,9 @@ inline void nested_const_array_semantics(
       solver->mkArraySelect(solver->mkArraySelect(outer, idx(0)), idx(0)),
       idx(7)));
   REQUIRE(solver->check() == camada::CheckResult::SAT);
-  auto innerModel = solver->getArrayElement(outer, idx(1));
+  auto innerModel = arrayElement(solver, outer, idx(1));
   REQUIRE(innerModel->Sort == solver->mkArraySort(bv8, bv8));
-  auto cell = solver->getBV(solver->getArrayElement(innerModel, idx(3)));
+  auto cell = solver->getBV(arrayElement(solver, innerModel, idx(3)));
   REQUIRE(cell);
   REQUIRE(cell.value() == 7);
 

--- a/regression/bitwuzla.test.cpp
+++ b/regression/bitwuzla.test.cpp
@@ -194,6 +194,7 @@ TEST_CASE("Bitwuzla feature capabilities", "[Bitwuzla]") {
   REQUIRE(solver->supports(SolverFeature::Quantifiers));
   REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE(solver->supports(SolverFeature::NativeRoundToAway));
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeConstantArrays));
   // The capability is present either way; core extraction is opt-in at

--- a/regression/cvc5.test.cpp
+++ b/regression/cvc5.test.cpp
@@ -203,6 +203,7 @@ TEST_CASE("CVC5 feature capabilities", "[CVC5]") {
   REQUIRE(solver->supports(SolverFeature::Quantifiers));
   REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE(solver->supports(SolverFeature::NativeRoundToAway));
   REQUIRE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
   // The capability is present either way; core extraction is opt-in at

--- a/regression/mathsat.test.cpp
+++ b/regression/mathsat.test.cpp
@@ -272,6 +272,9 @@ TEST_CASE("MathSAT feature capabilities", "[MathSAT]") {
   REQUIRE_FALSE(solver->supports(SolverFeature::Quantifiers));
   REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
+  // Native FP without a native round-to-away term: mkRM aborts for that
+  // mode, so callers need the separate bit to know before they build it.
+  REQUIRE_FALSE(solver->supports(SolverFeature::NativeRoundToAway));
   REQUIRE_FALSE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
   REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));

--- a/regression/modelhelpers.test.h
+++ b/regression/modelhelpers.test.h
@@ -1,0 +1,17 @@
+
+#pragma once
+#include "camada.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+/// Unwrap a model getter that reports failure through SMTResult, failing the
+/// test rather than aborting when the backend could not answer. Tests that
+/// care about the error path check the SMTResult directly instead.
+inline camada::SMTExprRef arrayElement(const camada::SMTSolverRef &solver,
+                                       const camada::SMTExprRef &Array,
+                                       const camada::SMTExprRef &Index) {
+  camada::SMTResult<camada::SMTExprRef> Element =
+      solver->getArrayElement(Array, Index);
+  REQUIRE(Element);
+  return Element.value();
+}

--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -570,6 +570,16 @@ inline void int_arithmetic_semantics(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
+inline void pop_underflow_rejected(const camada::SMTSolverRef &solver) {
+  // Popping past the root would take the backend below its own scope
+  // floor while the common layer's journals stop at theirs, leaving the
+  // two permanently out of step (Z3 threw "index out of bounds").
+  solver->push(1);
+  solver->pop(1);
+  solver->push(2);
+  solver->pop(2);
+}
+
 inline void null_sort_handle_equality(const camada::SMTSolverRef &solver) {
   // Sort handles are nullable, so comparison has to answer instead of
   // aborting inside the dereference.

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -101,6 +101,18 @@ inline void foreign_handle_rejected(const camada::SMTSolverRef &solver,
 #endif
 }
 
+inline void pop_past_root_rejected(const camada::SMTSolverRef &solver) {
+  // Each check runs in a forked child, so the abort does not take the
+  // test process with it and the parent's scope depth is untouched.
+  require_abort([&]() { solver->pop(1); });
+  solver->push(1);
+  require_abort([&]() { solver->pop(2); });
+  solver->pop(1);
+  auto x = solver->mkSymbol("pop_x", solver->mkBVSort(4));
+  solver->addConstraint(solver->mkEqual(x, solver->mkBVFromDec(1, 4)));
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
+}
+
 inline void fp_degenerate_format_rejected(const camada::SMTSolverRef &solver) {
   require_abort(
       [&]() { (void)solver->mkFPSort(2, 10, camada::FPEncoding::BV); });
@@ -116,6 +128,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(equal_ten);
   RESETANDTEST(symbol_name_punctuation_distinct);
   RESETANDTEST(null_sort_handle_equality);
+  RESETANDTEST(pop_underflow_rejected);
+  RESETANDTEST(pop_past_root_rejected);
   RESETANDTEST(implies_semantics);
   RESETANDTEST(implies_true_implies_false);
   RESETANDTEST(bv_lshr_semantics);

--- a/regression/tuple.test.h
+++ b/regression/tuple.test.h
@@ -474,7 +474,7 @@ inline void tuple_array_model_values(
   // Exact single-index recovery: getArrayElement at a written and an
   // untouched index, read each tuple field back.
   auto fieldsAt = [&](int64_t Index, bool &Flag, int64_t &Num) {
-    auto e = solver->getArrayElement(arr, idx(Index));
+    auto e = arrayElement(solver, arr, idx(Index));
     REQUIRE(e->Sort->isTupleSort());
     auto b = solver->getBool(solver->mkTupleSelect(e, 0));
     auto n = solver->getBV(solver->mkTupleSelect(e, 1));
@@ -546,7 +546,7 @@ inline void tuple_array_model_values(
   auto stored = solver->mkTuple({solver->mkBool(true), idx(33)});
   auto sym1 = solver->mkArrayStore(sym, idx(4), stored);
   REQUIRE(solver->check() == camada::CheckResult::SAT);
-  auto e = solver->getArrayElement(sym1, idx(4));
+  auto e = arrayElement(solver, sym1, idx(4));
   auto eb = solver->getBool(solver->mkTupleSelect(e, 0));
   auto en = solver->getBV(solver->mkTupleSelect(e, 1));
   REQUIRE(eb);

--- a/regression/z3.test.cpp
+++ b/regression/z3.test.cpp
@@ -269,6 +269,7 @@ TEST_CASE("Z3 feature capabilities", "[Z3]") {
   REQUIRE(solver->supports(SolverFeature::Quantifiers));
   REQUIRE(solver->supports(SolverFeature::UninterpretedFunctions));
   REQUIRE(solver->supports(SolverFeature::NativeFloatingPoint));
+  REQUIRE(solver->supports(SolverFeature::NativeRoundToAway));
   REQUIRE(solver->supports(SolverFeature::NativeTuples));
   REQUIRE(solver->supports(SolverFeature::NativeConstantArrays));
   REQUIRE(solver->supports(SolverFeature::UnsatAssumptions));

--- a/src/camada.h
+++ b/src/camada.h
@@ -880,9 +880,11 @@ public:
   /// expression.
   virtual SMTResult<FXPValue> getFXP(const SMTExprRef &Exp) = 0;
 
-  /// If a model is available, returns the Expr in position Index of Array
-  virtual SMTExprRef getArrayElement(const SMTExprRef &Array,
-                                     const SMTExprRef &Index) = 0;
+  /// If a model is available, returns the Expr in position Index of Array.
+  /// Reports SMTError when the backend cannot answer the underlying model
+  /// query, like the other model getters.
+  virtual SMTResult<SMTExprRef> getArrayElement(const SMTExprRef &Array,
+                                                const SMTExprRef &Index) = 0;
 
   /// If a model is available, returns the model's sparse representation of
   /// an array expression: the finite set of (index, element) entries the

--- a/src/camadatypes.h
+++ b/src/camadatypes.h
@@ -196,6 +196,11 @@ enum class SolverFeature : std::uint8_t {
   /// FPEncoding::Native sorts and operations; FPEncoding::BV works on
   /// every backend regardless.
   NativeFloatingPoint,
+  /// RM::ROUND_TO_AWAY as a native rounding mode. Separate from
+  /// NativeFloatingPoint because MathSAT implements native FP but has no
+  /// term for this mode, and mkRM() has nothing to return in that case.
+  /// FPEncoding::BV supplies all five modes on every backend.
+  NativeRoundToAway,
   /// Backend-native tuple/datatype sorts; other backends route tuples
   /// through the Camada per-field lowering. Like every bit here this is a
   /// property of the backend, not of this instance: it stays true on a

--- a/src/core/camadaimpl.cpp
+++ b/src/core/camadaimpl.cpp
@@ -1774,8 +1774,8 @@ CAMADA_DEFINE_MODEL_GETTER(double, getFP64,
                                          "Expected floating-point expression"),
                            getFP64Impl)
 
-SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
-                                          const SMTExprRef &Index) {
+SMTResult<SMTExprRef> SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
+                                                     const SMTExprRef &Index) {
   fatalErrorIf(!Array->isArraySort(), "Expected array expression");
   fatalErrorIf(Array->Sort->getIndexSort() != Index->Sort,
                "Expected array index with matching sort");
@@ -1799,8 +1799,8 @@ SMTExprRef SMTSolverImpl::getArrayElement(const SMTExprRef &Array,
     explicit ModelQueryGuard(bool &F) : Flag(F), Saved(F) { F = true; }
     ~ModelQueryGuard() { Flag = Saved; }
   } Guard(InLazyModelQuery);
-  SMTExprRef theExp = getArrayElementImpl(Array, Index);
-  assert(theExp->Sort == Array->Sort->getElementSort());
+  SMTResult<SMTExprRef> theExp = getArrayElementImpl(Array, Index);
+  assert(!theExp || theExp.value()->Sort == Array->Sort->getElementSort());
   return theExp;
 }
 
@@ -2281,6 +2281,8 @@ bool SMTSolverImpl::supports(SolverFeature Feature) const {
     return uninterpretedFunctionSupport();
   case SolverFeature::NativeFloatingPoint:
     return nativeFloatingPointSupport();
+  case SolverFeature::NativeRoundToAway:
+    return nativeRoundToAwaySupport();
   case SolverFeature::NativeTuples:
     return nativeDatatypeSupport();
   case SolverFeature::NativeConstantArrays:
@@ -2322,6 +2324,15 @@ void SMTSolverImpl::push(unsigned nscopes) {
 }
 
 void SMTSolverImpl::pop(unsigned nscopes) {
+  // LazyConstraintLevels always holds the root scope plus one entry per
+  // push, so its size minus one is the number of scopes that can be
+  // popped. Reject an over-pop here: the journal loops below stop at the
+  // root either way, but popImpl() would still be handed the unclamped
+  // count and take the backend below its own root -- Z3 throws
+  // "index out of bounds" and the process dies -- leaving the common and
+  // backend scope states permanently out of step.
+  fatalErrorIf(nscopes > LazyConstraintLevels.size() - 1,
+               "Cannot pop more scopes than were pushed");
   invalidateUnsatAssumptions();
   // Lazy default axioms and extensionality lemmas asserted inside the
   // popped scopes are scope-independent facts about expressions that

--- a/src/core/camadaimpl.h
+++ b/src/core/camadaimpl.h
@@ -739,8 +739,8 @@ public:
   SMTResult<float> getFP32(const SMTExprRef &Exp) override final;
   SMTResult<double> getFP64(const SMTExprRef &Exp) override final;
   SMTResult<FXPValue> getFXP(const SMTExprRef &Exp) override final;
-  SMTExprRef getArrayElement(const SMTExprRef &Array,
-                             const SMTExprRef &Index) override final;
+  SMTResult<SMTExprRef> getArrayElement(const SMTExprRef &Array,
+                                        const SMTExprRef &Index) override final;
   SMTResult<ArrayModel> getArrayValues(const SMTExprRef &Array) override final;
   SMTExprRef mkBool(const bool b) override final;
   SMTExprRef mkInt(int64_t v) override final;
@@ -893,6 +893,9 @@ protected:
 
   /// Uninterpreted functions (mkFunctionSort, mkApply).
   virtual bool uninterpretedFunctionSupport() const { return true; }
+
+  /// RM::ROUND_TO_AWAY as a native rounding mode.
+  virtual bool nativeRoundToAwaySupport() const { return true; }
 
   /// FPEncoding::Native sorts and operations. FPEncoding::BV works on
   /// every backend regardless, through the common layer's bit-blast.
@@ -1182,8 +1185,8 @@ protected:
 
   SMTResult<double> getFP64Impl(const SMTExprRef &Exp);
 
-  virtual SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
-                                         const SMTExprRef &Index) = 0;
+  virtual SMTResult<SMTExprRef>
+  getArrayElementImpl(const SMTExprRef &Array, const SMTExprRef &Index) = 0;
 
   /// Walk the backend model's representation of Array (store chains over a
   /// constant array, function interpretations, ...) into an ArrayModel.

--- a/src/solvers/bitwuzlasolver.cpp
+++ b/src/solvers/bitwuzlasolver.cpp
@@ -802,8 +802,9 @@ SMTResult<std::string> BitwuzlaSolver::getFPInBinImpl(const SMTExprRef &Exp) {
   return result ? std::string(result) : std::string();
 }
 
-SMTExprRef BitwuzlaSolver::getArrayElementImpl(const SMTExprRef &Array,
-                                               const SMTExprRef &Index) {
+SMTResult<SMTExprRef>
+BitwuzlaSolver::getArrayElementImpl(const SMTExprRef &Array,
+                                    const SMTExprRef &Index) {
   const SMTExprRef &select = mkArraySelect(Array, Index);
   return makeExprRef<BitwExpr>(
       select->getKind(), Context, select->Sort,
@@ -824,7 +825,9 @@ BitwuzlaSolver::getArrayValuesImpl(const SMTExprRef &Array) {
   while (bitwuzla_term_get_kind(Val) == BITWUZLA_KIND_ARRAY_STORE) {
     size_t Size = 0;
     BitwuzlaTerm *Children = bitwuzla_term_get_children(Val, &Size);
-    fatalErrorIf(Size != 3, "Malformed bitwuzla array store in model");
+    if (Size != 3)
+      return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Bitwuzla,
+                      "Malformed array store in model"};
     Result.Entries.emplace_back(wrap(Children[1], IndexSort),
                                 wrap(Children[2], ElemSort));
     Val = Children[0];
@@ -832,7 +835,9 @@ BitwuzlaSolver::getArrayValuesImpl(const SMTExprRef &Array) {
   if (bitwuzla_term_get_kind(Val) == BITWUZLA_KIND_CONST_ARRAY) {
     size_t Size = 0;
     BitwuzlaTerm *Children = bitwuzla_term_get_children(Val, &Size);
-    fatalErrorIf(Size != 1, "Malformed bitwuzla constant array in model");
+    if (Size != 1)
+      return SMTError{SMTErrorCode::BackendError, SMTBackendKind::Bitwuzla,
+                      "Malformed constant array in model"};
     Result.Base = wrap(Children[0], ElemSort);
   }
   return Result;

--- a/src/solvers/bitwuzlasolver.h
+++ b/src/solvers/bitwuzlasolver.h
@@ -218,8 +218,8 @@ protected:
   SMTResult<bool> getBoolImpl(const SMTExprRef &Exp) override;
   SMTResult<std::string> getBVInBinImpl(const SMTExprRef &Exp) override;
   SMTResult<std::string> getFPInBinImpl(const SMTExprRef &Exp) override;
-  SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
-                                 const SMTExprRef &Index) override;
+  SMTResult<SMTExprRef> getArrayElementImpl(const SMTExprRef &Array,
+                                            const SMTExprRef &Index) override;
 
   SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
 

--- a/src/solvers/cvc5solver.cpp
+++ b/src/solvers/cvc5solver.cpp
@@ -1047,8 +1047,8 @@ SMTResult<std::string> CVC5Solver::getFPInBinImpl(const SMTExprRef &Exp) {
   return std::get<2>(fp).getBitVectorValue();
 }
 
-SMTExprRef CVC5Solver::getArrayElementImpl(const SMTExprRef &Array,
-                                           const SMTExprRef &Index) {
+SMTResult<SMTExprRef> CVC5Solver::getArrayElementImpl(const SMTExprRef &Array,
+                                                      const SMTExprRef &Index) {
   const SMTExprRef &sel = mkArraySelect(Array, Index);
   return makeExprRef<CVC5Expr>(
       sel->getKind(), &Context, sel->Sort,

--- a/src/solvers/cvc5solver.h
+++ b/src/solvers/cvc5solver.h
@@ -327,8 +327,8 @@ protected:
 
   SMTResult<std::string> getFPInBinImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
-                                 const SMTExprRef &Index) override;
+  SMTResult<SMTExprRef> getArrayElementImpl(const SMTExprRef &Array,
+                                            const SMTExprRef &Index) override;
 
   SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
 

--- a/src/solvers/mathsatsolver.cpp
+++ b/src/solvers/mathsatsolver.cpp
@@ -971,8 +971,9 @@ SMTResult<std::string> MathSATSolver::getFPInBinImpl(const SMTExprRef &Exp) {
   return getGMPVal(t);
 }
 
-SMTExprRef MathSATSolver::getArrayElementImpl(const SMTExprRef &Array,
-                                              const SMTExprRef &Index) {
+SMTResult<SMTExprRef>
+MathSATSolver::getArrayElementImpl(const SMTExprRef &Array,
+                                   const SMTExprRef &Index) {
   const SMTExprRef &sel = mkArraySelect(Array, Index);
   return makeExprRef<MathSATExpr>(
       sel->getKind(), &Context, sel->Sort,
@@ -1103,7 +1104,9 @@ SMTExprRef MathSATSolver::mkRMImpl(const RM &R) {
     e = msat_make_fp_roundingmode_nearest_even(Context);
     break;
   case RM::ROUND_TO_AWAY:
-    fatalError("MathSAT Error ROUND_TO_AWAY is not supported.");
+    fatalError("MathSAT has no native round-to-away rounding mode; check "
+               "supports(SolverFeature::NativeRoundToAway) first, or build "
+               "the mode with FPEncoding::BV");
   case RM::ROUND_TO_PLUS_INF:
     e = msat_make_fp_roundingmode_plus_inf(Context);
     break;

--- a/src/solvers/mathsatsolver.h
+++ b/src/solvers/mathsatsolver.h
@@ -300,8 +300,8 @@ protected:
 
   SMTResult<std::string> getFPInBinImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
-                                 const SMTExprRef &Index) override;
+  SMTResult<SMTExprRef> getArrayElementImpl(const SMTExprRef &Array,
+                                            const SMTExprRef &Index) override;
 
   SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
 
@@ -357,6 +357,8 @@ protected:
   bool quantifierSupport() const override { return false; }
   // Tracked natively, no creation-time opt-in.
   bool unsatAssumptionSupport() const override { return true; }
+  // No msat_make_fp_roundingmode_* for round-to-away; FPEncoding::BV has it.
+  bool nativeRoundToAwaySupport() const override { return false; }
 
   void resetImpl() override;
   void pushImpl(unsigned nscopes) override;

--- a/src/solvers/smtlibsolver.cpp
+++ b/src/solvers/smtlibsolver.cpp
@@ -2483,8 +2483,9 @@ SMTLIBSolver::getRationalImpl(const SMTExprRef &Exp) {
   return std::make_pair(Num, Den);
 }
 
-SMTExprRef SMTLIBSolver::getArrayElementImpl(const SMTExprRef &Array,
-                                             const SMTExprRef &Index) {
+SMTResult<SMTExprRef>
+SMTLIBSolver::getArrayElementImpl(const SMTExprRef &Array,
+                                  const SMTExprRef &Index) {
   // The native backends evaluate (select Array Index) against their cached
   // model. Over the SMT-LIB pipe we don't have a cached model — but the
   // child solver does, so building a (select ...) expression and letting the

--- a/src/solvers/smtlibsolver.h
+++ b/src/solvers/smtlibsolver.h
@@ -480,8 +480,8 @@ protected:
   SMTResult<std::string> getIntImpl(const SMTExprRef &Exp) override;
   SMTResult<std::pair<std::string, std::string>>
   getRationalImpl(const SMTExprRef &Exp) override;
-  SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
-                                 const SMTExprRef &Index) override;
+  SMTResult<SMTExprRef> getArrayElementImpl(const SMTExprRef &Array,
+                                            const SMTExprRef &Index) override;
 
   // --- check / push / pop / reset ---
   CheckResult checkImpl() override;

--- a/src/solvers/stpsolver.cpp
+++ b/src/solvers/stpsolver.cpp
@@ -544,26 +544,29 @@ SMTResult<std::string> STPSolver::getBVInBinImpl(const SMTExprRef &Exp) {
   return bv;
 }
 
-SMTExprRef STPSolver::getArrayElementImpl(const SMTExprRef &Array,
-                                          const SMTExprRef &Index) {
+SMTResult<SMTExprRef> STPSolver::getArrayElementImpl(const SMTExprRef &Array,
+                                                     const SMTExprRef &Index) {
   const SMTExprRef &sel = mkArraySelect(Array, Index);
 
   const SMTSortRef &elementSort = Array->Sort->getElementSort();
   if (elementSort->isBoolSort()) {
     SMTResult<bool> result = getBool(sel);
-    fatalErrorIf(!result, "Failed to get STP boolean array element");
+    if (!result)
+      return result.error();
     return mkBool(result.value());
   }
 
   if (elementSort->isBVSort()) {
     SMTResult<std::string> result = getBVInBin(sel);
-    fatalErrorIf(!result, "Failed to get STP bit-vector array element");
+    if (!result)
+      return result.error();
     return SMTSolverImpl::mkBVFromBin(result.value());
   }
 
   fatalErrorIf(!elementSort->isFPSort(), "Unknown STP array element type");
   SMTResult<std::string> result = getFPInBin(sel);
-  fatalErrorIf(!result, "Failed to get STP FP array element");
+  if (!result)
+    return result.error();
   return SMTSolverImpl::mkFPFromBin(
       result.value(), elementSort->getFPExponentWidth(), FPEncoding::BV);
 }

--- a/src/solvers/stpsolver.h
+++ b/src/solvers/stpsolver.h
@@ -200,8 +200,8 @@ protected:
 
   SMTResult<std::string> getBVInBinImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
-                                 const SMTExprRef &Index) override;
+  SMTResult<SMTExprRef> getArrayElementImpl(const SMTExprRef &Array,
+                                            const SMTExprRef &Index) override;
 
   SMTExprRef mkBoolImpl(const bool b) override;
   SMTExprRef mkBVFromDecImpl(const int64_t Int,

--- a/src/solvers/yicessolver.cpp
+++ b/src/solvers/yicessolver.cpp
@@ -814,26 +814,30 @@ YicesSolver::getRationalImpl(const SMTExprRef &Exp) {
   return std::make_pair(Num, Den);
 }
 
-SMTExprRef YicesSolver::getArrayElementImpl(const SMTExprRef &Array,
-                                            const SMTExprRef &Index) {
+SMTResult<SMTExprRef>
+YicesSolver::getArrayElementImpl(const SMTExprRef &Array,
+                                 const SMTExprRef &Index) {
   const SMTExprRef &sel = mkArraySelect(Array, Index);
 
   const SMTSortRef &elementSort = Array->Sort->getElementSort();
   if (elementSort->isBoolSort()) {
     SMTResult<bool> result = getBool(sel);
-    fatalErrorIf(!result, "Failed to get Yices boolean array element");
+    if (!result)
+      return result.error();
     return mkBool(result.value());
   }
 
   if (elementSort->isBVSort()) {
     SMTResult<std::string> result = getBVInBin(sel);
-    fatalErrorIf(!result, "Failed to get Yices bit-vector array element");
+    if (!result)
+      return result.error();
     return SMTSolverImpl::mkBVFromBin(result.value());
   }
 
   fatalErrorIf(!elementSort->isFPSort(), "Unknown Yices array element type");
   SMTResult<std::string> result = getFPInBin(sel);
-  fatalErrorIf(!result, "Failed to get Yices FP array element");
+  if (!result)
+    return result.error();
   return SMTSolverImpl::mkFPFromBin(
       result.value(), elementSort->getFPExponentWidth(), FPEncoding::BV);
 }

--- a/src/solvers/yicessolver.h
+++ b/src/solvers/yicessolver.h
@@ -243,8 +243,8 @@ protected:
   SMTResult<std::pair<std::string, std::string>>
   getRationalImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
-                                 const SMTExprRef &Index) override;
+  SMTResult<SMTExprRef> getArrayElementImpl(const SMTExprRef &Array,
+                                            const SMTExprRef &Index) override;
 
   SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
 

--- a/src/solvers/z3solver.cpp
+++ b/src/solvers/z3solver.cpp
@@ -897,8 +897,8 @@ SMTResult<std::string> Z3Solver::getFPInBinImpl(const SMTExprRef &Exp) {
   return bv;
 }
 
-SMTExprRef Z3Solver::getArrayElementImpl(const SMTExprRef &Array,
-                                         const SMTExprRef &Index) {
+SMTResult<SMTExprRef> Z3Solver::getArrayElementImpl(const SMTExprRef &Array,
+                                                    const SMTExprRef &Index) {
   const SMTExprRef &sel = mkArraySelect(Array, Index);
   return makeExprRef<Z3Expr>(sel->getKind(), &Context, sel->Sort,
                              Solver.get_model().eval(toZ3Expr(sel), true));

--- a/src/solvers/z3solver.h
+++ b/src/solvers/z3solver.h
@@ -341,8 +341,8 @@ protected:
 
   SMTResult<std::string> getFPInBinImpl(const SMTExprRef &Exp) override;
 
-  SMTExprRef getArrayElementImpl(const SMTExprRef &Array,
-                                 const SMTExprRef &Index) override;
+  SMTResult<SMTExprRef> getArrayElementImpl(const SMTExprRef &Array,
+                                            const SMTExprRef &Index) override;
 
   SMTResult<ArrayModel> getArrayValuesImpl(const SMTExprRef &Array) override;
 

--- a/src/theories/camadatuple.cpp
+++ b/src/theories/camadatuple.cpp
@@ -546,16 +546,20 @@ SMTExprRef mkCamadaTupleArrayIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
       SMTExprKind::Ite, T->getBackendKind(), T->Sort, std::move(Leaves));
 }
 
-SMTExprRef getCamadaTupleArrayElement(SMTSolverImpl &Solver,
-                                      const SMTExprRef &Array,
-                                      const SMTExprRef &Index) {
+SMTResult<SMTExprRef> getCamadaTupleArrayElement(SMTSolverImpl &Solver,
+                                                 const SMTExprRef &Array,
+                                                 const SMTExprRef &Index) {
   const CamadaTupleArrayExpr *AE = toCamadaTupleArrayExpr(Array);
   fatalErrorIf(AE == nullptr,
                "getCamadaTupleArrayElement on a non-bundle expression");
   std::vector<SMTExprRef> ElementLeaves;
   ElementLeaves.reserve(AE->LeafArrays.size());
-  for (const auto &Leaf : AE->LeafArrays)
-    ElementLeaves.push_back(Solver.getArrayElement(Leaf, Index));
+  for (const auto &Leaf : AE->LeafArrays) {
+    SMTResult<SMTExprRef> LeafValue = Solver.getArrayElement(Leaf, Index);
+    if (!LeafValue)
+      return LeafValue.error();
+    ElementLeaves.push_back(LeafValue.value());
+  }
   std::size_t Pos = 0;
   SMTExprRef Element = assembleFromLeaves(Solver, Array->Sort->getElementSort(),
                                           ElementLeaves, Pos);

--- a/src/theories/camadatuple.h
+++ b/src/theories/camadatuple.h
@@ -107,9 +107,9 @@ SMTExprRef mkCamadaTupleArrayIte(SMTSolverImpl &Solver, const SMTExprRef &Cond,
 /// into one tuple-valued ArrayModel: indexes are unioned by model value,
 /// and the Base is a tuple of the per-leaf bases only when every leaf
 /// reports one (otherwise null — no fabricated partial default).
-SMTExprRef getCamadaTupleArrayElement(SMTSolverImpl &Solver,
-                                      const SMTExprRef &Array,
-                                      const SMTExprRef &Index);
+SMTResult<SMTExprRef> getCamadaTupleArrayElement(SMTSolverImpl &Solver,
+                                                 const SMTExprRef &Array,
+                                                 const SMTExprRef &Index);
 
 SMTResult<ArrayModel> getCamadaTupleArrayValues(SMTSolverImpl &Solver,
                                                 const SMTExprRef &Array);


### PR DESCRIPTION
Four paths that broke the documented contract — caller error aborts, recoverable failures return `SMTError`. Part of #154; the policy itself was settled in that issue's discussion.

### 1. `getArrayElement` discarded recoverable errors

It returned a bare `SMTExprRef` while aborting on failures that `getBool`/`getBVInBin` had *already* reported as `SMTError`:

```cpp
SMTResult<bool> result = getBool(sel);
fatalErrorIf(!result, "Failed to get STP boolean array element");
```

Now `SMTResult<SMTExprRef>`, matching every other model query on the class. STP and Yices propagate the underlying error; `camadatuple.cpp` propagates a failing leaf read.

I argued against this signature change when it was first raised, on the grounds that `getArrayElement` returns an expression rather than a model value. Reading the implementations changed my mind — the abort was throwing away an error the layer below had gone to the trouble of reporting.

Tests use a new `arrayElement()` helper (`regression/modelhelpers.test.h`) so the 17 call sites stay readable; it `REQUIRE`s success, so a regression surfaces as a test failure rather than an abort.

### 2. Bitwuzla malformed-model checks

`getArrayValues` already returned `SMTResult<ArrayModel>`, so the two `fatalErrorIf`s on unexpected child counts became `BackendError` with no signature change.

### 3. `pop(n)` scope underflow

`pop` clamped its own journals at the root (`LazyConstraintLevels.size() > 1`) but still passed the unclamped count to `popImpl`. Confirmed in a release build:

```
popping 5 scopes from depth 1...
terminate called after throwing an instance of 'z3::exception'
  what():  index out of bounds
```

Beyond the crash, the common and backend scope states end up permanently out of step. `LazyConstraintLevels` already tracks depth exactly — it holds the root plus one entry per push — so the guard needs no new state.

### 4. MathSAT round-to-away is now queryable

MathSAT implements native FP but has no `msat_make_fp_roundingmode_*` for round-to-away, so `mkRM(RM::ROUND_TO_AWAY)` aborted with **nothing a caller could check first** — `supports(NativeFloatingPoint)` returns true. Adding `SolverFeature::NativeRoundToAway` (backed by a `nativeRoundToAwaySupport()` hook, default true, MathSAT overrides false) makes it checkable, and the abort message now names both the bit and the `FPEncoding::BV` path that supplies all five modes on every backend.

Asserted false on MathSAT and true on Z3, cvc5 and Bitwuzla.

### Deliberately not in this PR

The remaining SMT-LIB environment aborts — `fork()`, `fdopen()`, file open — sit inside the `FileEmitter`/`ProcessEmitter` **constructors**, which cannot return a result without converting the emitter layer to factory functions. That is a design change rather than mechanical work, so #154 stays open for it.

### Verification

`ctest -j16`: 246/246. Clean build, no warnings, clang-format applied. Both `pop` fixes verified against standalone release-build reproducers before and after.

Refs #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp6BKyd2TaLMghESwZNaKQ