### PR TITLE
Fix the typed model getters' domains

### DIFF
--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -863,3 +863,48 @@ inline void fp_wide_format_semantics(const camada::SMTSolverRef &solver) {
     REQUIRE(solver->check() == camada::CheckResult::UNSAT);
   }
 }
+
+inline void fp_typed_getter_format(const camada::SMTSolverRef &solver,
+                                   camada::FPEncoding Encoding) {
+  // getFP32 and getFP64 name a specific IEEE format. Handed a term of a
+  // different one they used to parse whatever bitstring came back, so a
+  // binary64 1.5 read through getFP32 answered 0 instead of reporting.
+  auto f32 = solver->mkFPSort(8, 23, Encoding);
+  auto f64 = solver->mkFPSort(11, 52, Encoding);
+
+  auto d = solver->mkSymbol("tg_d", f64);
+  solver->addConstraint(solver->mkEqual(d, solver->mkFP64(1.5, Encoding)));
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
+  auto asDouble = solver->getFP64(d);
+  REQUIRE(asDouble);
+  REQUIRE(asDouble.value() == 1.5);
+  auto asFloat = solver->getFP32(d);
+  REQUIRE_FALSE(asFloat);
+  REQUIRE(asFloat.error().Code == camada::SMTErrorCode::InvalidUsage);
+
+  solver->reset();
+  f32 = solver->mkFPSort(8, 23, Encoding);
+  auto f = solver->mkSymbol("tg_f", f32);
+  solver->addConstraint(solver->mkEqual(f, solver->mkFP32(1.5f, Encoding)));
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
+  auto backAsFloat = solver->getFP32(f);
+  REQUIRE(backAsFloat);
+  REQUIRE(backAsFloat.value() == 1.5f);
+  REQUIRE_FALSE(solver->getFP64(f));
+
+  // A format that is neither binary32 nor binary64 matches neither
+  // getter. Uses the BV encoding explicitly: cvc5 rejects non-standard
+  // native FP formats without --fp-exp, and the getters' format check is
+  // encoding-independent anyway.
+  solver->reset();
+  auto f16 = solver->mkFPSort(5, 10, camada::FPEncoding::BV);
+  auto h = solver->mkSymbol("tg_h", f16);
+  solver->addConstraint(solver->mkEqual(
+      h, solver->mkFPFromBin("0011110000000000", 5, camada::FPEncoding::BV)));
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
+  REQUIRE_FALSE(solver->getFP32(h));
+  REQUIRE_FALSE(solver->getFP64(h));
+  auto bits = solver->getFPInBin(h);
+  REQUIRE(bits);
+  REQUIRE(bits.value() == "0011110000000000");
+}

--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -570,6 +570,73 @@ inline void int_arithmetic_semantics(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::CheckResult::SAT);
 }
 
+inline void bv_typed_getter_domain(const camada::SMTSolverRef &solver) {
+  // getBV interprets the top bit as a sign, so its domain is exactly
+  // int64_t: widths up to 64 signed, and anything wider (or an unsigned
+  // value that does not fit) has to be reported rather than truncated.
+  auto pin = [&](unsigned Width, const std::string &Bits) {
+    auto x = solver->mkSymbol("g" + std::to_string(Width) + Bits,
+                              solver->mkBVSort(Width));
+    solver->addConstraint(solver->mkEqual(x, solver->mkBVFromBin(Bits)));
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
+    return x;
+  };
+
+  // Width 64 with the top bit set: every such value used to come back as
+  // -1, because the sign-extension mask shifted by the full width.
+  {
+    auto x = pin(64, "1" + std::string(63, '0'));
+    auto v = solver->getBV(x);
+    REQUIRE(v);
+    REQUIRE(v.value() == INT64_MIN);
+    auto u = solver->getBVUnsigned(x);
+    REQUIRE(u);
+    REQUIRE(u.value() == (1ULL << 63));
+  }
+  solver->reset();
+  {
+    auto x = pin(64, std::string(64, '1'));
+    auto v = solver->getBV(x);
+    REQUIRE(v);
+    REQUIRE(v.value() == -1);
+    auto u = solver->getBVUnsigned(x);
+    REQUIRE(u);
+    REQUIRE(u.value() == UINT64_MAX);
+  }
+  solver->reset();
+  // A positive 64-bit value is unaffected, signed or unsigned.
+  {
+    auto x = pin(64, "0" + std::string(63, '1'));
+    auto v = solver->getBV(x);
+    REQUIRE(v);
+    REQUIRE(v.value() == INT64_MAX);
+    auto u = solver->getBVUnsigned(x);
+    REQUIRE(u);
+    REQUIRE(u.value() == static_cast<uint64_t>(INT64_MAX));
+  }
+  solver->reset();
+  // Narrow widths keep working, both signs.
+  {
+    auto x = pin(8, "11111111");
+    REQUIRE(solver->getBV(x).value() == -1);
+    REQUIRE(solver->getBVUnsigned(x).value() == 255u);
+  }
+  solver->reset();
+  // Wider than 64 bits fits in neither getter: report, do not truncate.
+  {
+    auto x = pin(72, std::string(72, '1'));
+    auto v = solver->getBV(x);
+    REQUIRE_FALSE(v);
+    REQUIRE(v.error().Code == camada::SMTErrorCode::InvalidUsage);
+    auto u = solver->getBVUnsigned(x);
+    REQUIRE_FALSE(u);
+    // getBVInBin stays the exact path for any width.
+    auto bits = solver->getBVInBin(x);
+    REQUIRE(bits);
+    REQUIRE(bits.value() == std::string(72, '1'));
+  }
+}
+
 inline void pop_underflow_rejected(const camada::SMTSolverRef &solver) {
   // Popping past the root would take the backend below its own scope
   // floor while the common layer's journals stop at theirs, leaving the

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -128,6 +128,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(equal_ten);
   RESETANDTEST(symbol_name_punctuation_distinct);
   RESETANDTEST(null_sort_handle_equality);
+  RESETANDTEST(bv_typed_getter_domain);
   RESETANDTEST(pop_underflow_rejected);
   RESETANDTEST(pop_past_root_rejected);
   RESETANDTEST(implies_semantics);
@@ -188,6 +189,8 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);
   RESETANDTEST(fp_neg_nan_native_bv_parity);
+  RESETANDARGTEST(fp_typed_getter_format, NativeFP);
+  RESETANDARGTEST(fp_typed_getter_format, BVFP);
   RESETANDARGTEST(fp_equal, NativeFP);
   RESETANDARGTEST(fp_equal, BVFP);
   RESETANDARGTEST(fp_infinity_model_value, NativeFP);

--- a/src/camada.h
+++ b/src/camada.h
@@ -837,8 +837,16 @@ public:
   virtual SMTResult<bool> getBool(const SMTExprRef &Exp) = 0;
 
   /// If a model is available, returns the value of a given bitvector
-  /// symbol as a 64-bits int.
+  /// symbol as a signed 64-bit int, interpreting the top bit as the sign.
+  /// Widths above 64 do not fit and report InvalidUsage; getBVInBin is the
+  /// exact path for any width.
   virtual SMTResult<int64_t> getBV(const SMTExprRef &Exp) = 0;
+
+  /// If a model is available, returns the value of a given bitvector
+  /// symbol as an unsigned 64-bit int. The counterpart to getBV for
+  /// values whose top bit is set but which are not meant as negative;
+  /// widths above 64 report InvalidUsage.
+  virtual SMTResult<uint64_t> getBVUnsigned(const SMTExprRef &Exp) = 0;
 
   /// If a model is available, returns the value of a given bitvector
   /// symbol as a 2-complement form binary string.
@@ -865,15 +873,17 @@ public:
   virtual SMTResult<std::string> getFPInBin(const SMTExprRef &Exp) = 0;
 
   /// If a model is available, returns the value of a given floating-point
-  /// symbol as float. We assume the floating-point is using the IEEE-754
-  /// format: 1 bit for the sign + 8 bits for the exponent + 23 bits for the
-  /// significand and 1 hidden bit in the significand
+  /// symbol as float. Requires the IEEE-754 binary32 format: 1 sign bit +
+  /// 8 exponent bits + 23 stored significand bits. Any other format
+  /// reports InvalidUsage rather than reinterpreting the bits; use
+  /// getFPInBin for arbitrary formats.
   virtual SMTResult<float> getFP32(const SMTExprRef &Exp) = 0;
 
   /// If a model is available, returns the value of a given floating-point
-  /// symbol as double. We assume the floating-point is using the IEEE-754
-  /// format: 1 bit for the sign + 11 bits for the exponent + 52 bits for the
-  /// significand and 1 hidden bit in the significand
+  /// symbol as double. Requires the IEEE-754 binary64 format: 1 sign bit +
+  /// 11 exponent bits + 52 stored significand bits. Any other format
+  /// reports InvalidUsage rather than reinterpreting the bits; use
+  /// getFPInBin for arbitrary formats.
   virtual SMTResult<double> getFP64(const SMTExprRef &Exp) = 0;
 
   /// If a model is available, returns the exact value of a given fixed-point

--- a/src/core/camadaimpl.cpp
+++ b/src/core/camadaimpl.cpp
@@ -1711,6 +1711,10 @@ CAMADA_DEFINE_MODEL_GETTER(int64_t, getBV,
                            requireBVSort(Exp, "Expected bit-vector expression"),
                            getBVImpl)
 
+CAMADA_DEFINE_MODEL_GETTER(uint64_t, getBVUnsigned,
+                           requireBVSort(Exp, "Expected bit-vector expression"),
+                           getBVUnsignedImpl)
+
 SMTResult<std::string> SMTSolverImpl::getBVInBin(const SMTExprRef &Exp) {
   requireBVSort(Exp, "Expected bit-vector expression");
   SMTResult<std::string> result = getBVInBinImpl(Exp);

--- a/src/core/camadaimpl.h
+++ b/src/core/camadaimpl.h
@@ -728,6 +728,7 @@ public:
                       const SMTExprRef &Body) override final;
   SMTResult<bool> getBool(const SMTExprRef &Exp) override final;
   SMTResult<int64_t> getBV(const SMTExprRef &Exp) override final;
+  SMTResult<uint64_t> getBVUnsigned(const SMTExprRef &Exp) override final;
   SMTResult<std::string> getBVInBin(const SMTExprRef &Exp) override final;
   SMTResult<std::string> getInt(const SMTExprRef &Exp) override final;
   SMTResult<std::pair<std::string, std::string>>
@@ -1171,6 +1172,7 @@ protected:
   virtual SMTResult<bool> getBoolImpl(const SMTExprRef &Exp) = 0;
 
   SMTResult<int64_t> getBVImpl(const SMTExprRef &Exp);
+  SMTResult<uint64_t> getBVUnsignedImpl(const SMTExprRef &Exp);
 
   virtual SMTResult<std::string> getBVInBinImpl(const SMTExprRef &Exp) = 0;
 

--- a/src/theories/camadafp.cpp
+++ b/src/theories/camadafp.cpp
@@ -2518,17 +2518,40 @@ SMTExprRef SMTSolverImpl::round(const SMTExprRef &R, const SMTExprRef &Sgn,
 }
 
 SMTResult<int64_t> SMTSolverImpl::getBVImpl(const SMTExprRef &Exp) {
+  const unsigned Width = Exp->getWidth();
+  if (Width > 64)
+    return SMTError{SMTErrorCode::InvalidUsage, Exp->getBackendKind(),
+                    "Bit-vector is wider than 64 bits; use getBVInBin"};
   SMTResult<std::string> result = getBVInBin(Exp);
   if (!result)
     return result.error();
-  const std::string &bv = result.value();
-  uint64_t res = std::strtoull(bv.c_str(), nullptr, 2);
-  if (res & (1ULL << (Exp->getWidth() - 1)))
-    res |= ~((1ULL << Exp->getWidth()) - 1);
-  return res;
+  uint64_t res = std::strtoull(result.value().c_str(), nullptr, 2);
+  // Sign-extend from the top bit. Both shifts are undefined at width 64
+  // (1ULL << 64), which used to collapse every negative 64-bit value to
+  // -1, so a full-width value is already in its final form.
+  if (Width < 64 && (res & (1ULL << (Width - 1))))
+    res |= ~((1ULL << Width) - 1);
+  return static_cast<int64_t>(res);
+}
+
+SMTResult<uint64_t> SMTSolverImpl::getBVUnsignedImpl(const SMTExprRef &Exp) {
+  if (Exp->getWidth() > 64)
+    return SMTError{SMTErrorCode::InvalidUsage, Exp->getBackendKind(),
+                    "Bit-vector is wider than 64 bits; use getBVInBin"};
+  SMTResult<std::string> result = getBVInBin(Exp);
+  if (!result)
+    return result.error();
+  return std::strtoull(result.value().c_str(), nullptr, 2);
 }
 
 SMTResult<float> SMTSolverImpl::getFP32Impl(const SMTExprRef &Exp) {
+  // Match on exponent width plus total width: getFPSignificandWidth()
+  // counts the hidden bit under the BV encoding but not the native one
+  // (see issue #184), while the total is 32 either way.
+  if (Exp->Sort->getFPExponentWidth() != 8 || Exp->getWidth() != 32)
+    return SMTError{SMTErrorCode::InvalidUsage, Exp->getBackendKind(),
+                    "Expected an IEEE-754 binary32 expression; use "
+                    "getFPInBin for other formats"};
   SMTResult<std::string> result = getFPInBin(Exp);
   if (!result)
     return result.error();
@@ -2537,6 +2560,11 @@ SMTResult<float> SMTSolverImpl::getFP32Impl(const SMTExprRef &Exp) {
 }
 
 SMTResult<double> SMTSolverImpl::getFP64Impl(const SMTExprRef &Exp) {
+  // See getFP32Impl: the total width is the encoding-independent check.
+  if (Exp->Sort->getFPExponentWidth() != 11 || Exp->getWidth() != 64)
+    return SMTError{SMTErrorCode::InvalidUsage, Exp->getBackendKind(),
+                    "Expected an IEEE-754 binary64 expression; use "
+                    "getFPInBin for other formats"};
   SMTResult<std::string> result = getFPInBin(Exp);
   if (!result)
     return result.error();


### PR DESCRIPTION
`getBV`, `getFP32` and `getFP64` all silently answered wrong for inputs outside their real domain. Confirmed in release builds before and after each fix.

### `getBV` was a wrong-answer bug at width 64, not just a domain limit

The sign extension shifted `1ULL` left by the bit-vector width, which is undefined at 64. The issue described this as an unrepresentable-value problem; measuring it showed worse — **every** 64-bit value with the top bit set collapsed to `-1`:

```
before                          after
2^63          -> -1             -> -9223372036854775808
2^63 + 1      -> -1             -> -9223372036854775807
2^63 + 2^62   -> -1             -> -4611686018427387904
all ones      -> -1             -> -1
2^63 - 1      -> correct        -> correct
```

Four distinct values were indistinguishable. Positive values were always fine, which is why no existing test caught it.

Widths above 64 now report `InvalidUsage` instead of truncating.

### `getBVUnsigned` added

`getBV` interprets the top bit as a sign, so a genuine unsigned 64-bit value had nowhere to go. `getBVUnsigned` is the counterpart; `getBVInBin` remains the exact path for any width, the same division `FXPValue` already uses for fixed-point.

### `getFP32`/`getFP64` now check the format

Both name a specific IEEE format — the doc comments said "we assume" — but accepted any FP sort and parsed whatever bitstring came back. A binary64 `1.5` read through `getFP32` returned `0`. Both now report `InvalidUsage` for a mismatched format, and the docs state the requirement instead of assuming it.

### One thing this surfaced: #184

The natural check (`getFPSignificandWidth() != 52` for binary64) rejects every valid term, because **the two encodings disagree on that accessor**: for identical `mkFPSort` arguments, BV counts the hidden bit and native does not (`52` vs `53`), while the total width agrees. That is a public API inconsistency in its own right, so it is filed separately as #184 and these guards match on exponent plus total width, with a comment pointing there.

### Tests

- `bv_typed_getter_domain` — width-64 with the top bit set (signed and unsigned), `INT64_MIN`, `INT64_MAX`, all-ones, narrow widths both signs, and a 72-bit value that fits neither getter but round-trips exactly through `getBVInBin`.
- `fp_typed_getter_format` — binary64 read through both getters, binary32 through both, and a binary16 term that matches neither. Runs under both encodings; the binary16 case pins `FPEncoding::BV` because cvc5 rejects non-standard native formats without `--fp-exp`.

Both verified failing before the fix. Full suite 246/246, clean build, no warnings.

Fixes #156
Fixes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp6BKyd2TaLMghESwZNaKQ