### PR TITLE
Give getFPSignificandWidth() one meaning on every backend

### DIFF
--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -910,3 +910,36 @@ inline void fp_typed_getter_format(const camada::SMTSolverRef &solver,
   REQUIRE(bits);
   REQUIRE(bits.value() == "0011110000000000");
 }
+
+inline void fp_sort_width_accessors(const camada::SMTSolverRef &solver) {
+  // getFPSignificandWidth() is the inverse of what mkFPSort was given, so
+  // both encodings must answer the same for the same arguments. The BV
+  // encoding used to report one more (the hidden bit), which made the
+  // accessor's meaning depend on the encoding.
+  // The BV encoding takes any format, so check the accessors there for a
+  // spread including binary16 and bfloat16.
+  const unsigned Formats[][2] = {{8, 23}, {11, 52}, {5, 10}, {8, 7}};
+  for (const auto &F : Formats) {
+    auto BV = solver->mkFPSort(F[0], F[1], camada::FPEncoding::BV);
+    REQUIRE(BV->getFPExponentWidth() == F[0]);
+    REQUIRE(BV->getFPSignificandWidth() == F[1]);
+    REQUIRE(BV->getFPSignificandBits() == F[1] + 1);
+    REQUIRE(BV->getWidth() == 1 + F[0] + F[1]);
+  }
+
+  // Native parity only for binary32 and binary64: every backend with
+  // native FP takes those, while the wider formats are gated per backend
+  // (see the format table in the README and issue #186).
+  if (!solver->supports(camada::SolverFeature::NativeFloatingPoint))
+    return;
+  const unsigned Standard[][2] = {{8, 23}, {11, 52}};
+  for (const auto &F : Standard) {
+    auto Native = solver->mkFPSort(F[0], F[1], camada::FPEncoding::Native);
+    auto BV = solver->mkFPSort(F[0], F[1], camada::FPEncoding::BV);
+    REQUIRE(Native->getFPExponentWidth() == BV->getFPExponentWidth());
+    REQUIRE(Native->getFPSignificandWidth() == BV->getFPSignificandWidth());
+    REQUIRE(Native->getFPSignificandBits() == BV->getFPSignificandBits());
+    REQUIRE(Native->getWidth() == BV->getWidth());
+    REQUIRE(Native->getFPSignificandWidth() == F[1]);
+  }
+}

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -189,6 +189,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);
   RESETANDTEST(fp_neg_nan_native_bv_parity);
+  RESETANDTEST(fp_sort_width_accessors);
   RESETANDARGTEST(fp_typed_getter_format, NativeFP);
   RESETANDARGTEST(fp_typed_getter_format, BVFP);
   RESETANDARGTEST(fp_equal, NativeFP);

--- a/src/camadasort.h
+++ b/src/camadasort.h
@@ -206,9 +206,19 @@ public:
   /// Returns the sort width from the Solver.
   virtual unsigned getWidthFromSolver() const;
 
-  /// Returns the floating-point significand width, fails if the sort is not a
-  /// floating-point.
+  /// Returns the number of *stored* significand bits, the same value
+  /// mkFPSort was given: binary32 answers 23, binary64 answers 52. The
+  /// hidden leading bit is not counted, so this is the inverse of the
+  /// constructor on every backend and under either encoding. Encodings
+  /// that need the significand including the hidden bit use
+  /// getFPSignificandBits().
   unsigned getFPSignificandWidth() const;
+
+  /// Returns the significand width including the hidden leading bit --
+  /// getFPSignificandWidth() + 1, `sbits` in the bit-blasting literature.
+  /// This is what the FP-over-BV encoding and the native backend APIs
+  /// take.
+  unsigned getFPSignificandBits() const;
 
   /// Returns the floating-point exponent width, fails if the sort is not a
   /// floating-point.

--- a/src/core/camadasort.cpp
+++ b/src/core/camadasort.cpp
@@ -157,6 +157,10 @@ unsigned SMTSort::getFPSignificandWidth() const {
   return std::get<FPSortData>(Data).SigWidth;
 }
 
+unsigned SMTSort::getFPSignificandBits() const {
+  return getFPSignificandWidth() + 1;
+}
+
 unsigned SMTSort::getFPExponentWidth() const {
   fatalErrorIf(!isFPSort(), "Exponent width is only defined for FP sorts");
   return std::get<FPSortData>(Data).ExpWidth;

--- a/src/solvers/bitwuzlasolver.cpp
+++ b/src/solvers/bitwuzlasolver.cpp
@@ -203,7 +203,7 @@ SMTSortRef BitwuzlaSolver::mkBVFPSortImpl(const unsigned ExpWidth,
   return makeSortRef<BitwSort>(BitwSort(
       SMTSortKind::BVFP, Context,
       bitwuzla_mk_bv_sort(TermManager, ExpWidth + SigWidth + 1),
-      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth + 1}));
+      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth}));
 }
 
 SMTSortRef BitwuzlaSolver::mkFXPSortImpl(unsigned Width, unsigned FracBits,

--- a/src/solvers/cvc5solver.cpp
+++ b/src/solvers/cvc5solver.cpp
@@ -175,7 +175,7 @@ SMTSortRef CVC5Solver::mkBVFPSortImpl(const unsigned ExpWidth,
   return makeSortRef<CVC5Sort>(CVC5Sort(
       SMTSortKind::BVFP, &Context,
       Terms.mkBitVectorSort(ExpWidth + SigWidth + 1),
-      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth + 1}));
+      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth}));
 }
 
 SMTSortRef CVC5Solver::mkFXPSortImpl(unsigned Width, unsigned FracBits,

--- a/src/solvers/mathsatsolver.cpp
+++ b/src/solvers/mathsatsolver.cpp
@@ -259,7 +259,7 @@ SMTSortRef MathSATSolver::mkBVFPSortImpl(const unsigned ExpWidth,
   return makeSortRef<MathSATSort>(MathSATSort(
       SMTSortKind::BVFP, &Context,
       msat_get_bv_type(Context, ExpWidth + SigWidth + 1),
-      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth + 1}));
+      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth}));
 }
 
 SMTSortRef MathSATSolver::mkFXPSortImpl(unsigned Width, unsigned FracBits,

--- a/src/solvers/smtlibsolver.cpp
+++ b/src/solvers/smtlibsolver.cpp
@@ -1128,7 +1128,7 @@ SMTSortRef SMTLIBSolver::mkBVFPSortImpl(unsigned ExpWidth, unsigned SigWidth) {
   unsigned Width = ExpWidth + SigWidth + 1;
   return makeSortRef<SMTLIBSort>(
       SMTLIBSort(SMTSortKind::BVFP, this, "(_ BitVec " + utoa(Width) + ")",
-                 SMTSort::FPSortData{Width, ExpWidth, SigWidth + 1}));
+                 SMTSort::FPSortData{Width, ExpWidth, SigWidth}));
 }
 
 SMTSortRef SMTLIBSolver::mkFXPSortImpl(unsigned Width, unsigned FracBits,

--- a/src/solvers/stpsolver.cpp
+++ b/src/solvers/stpsolver.cpp
@@ -124,7 +124,7 @@ SMTSortRef STPSolver::mkBVFPSortImpl(const unsigned ExpWidth,
   return makeSortRef<STPSort>(STPSort(
       SMTSortKind::BVFP, &Context,
       STP::vc_bvType(Context, ExpWidth + SigWidth + 1),
-      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth + 1}));
+      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth}));
 }
 
 SMTSortRef STPSolver::mkFXPSortImpl(unsigned Width, unsigned FracBits,

--- a/src/solvers/yicessolver.cpp
+++ b/src/solvers/yicessolver.cpp
@@ -283,7 +283,7 @@ SMTSortRef YicesSolver::mkBVFPSortImpl(const unsigned ExpWidth,
                                        const unsigned SigWidth) {
   return makeSortRef<YicesSort>(YicesSort(
       SMTSortKind::BVFP, Context, yices_bv_type(ExpWidth + SigWidth + 1),
-      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth + 1}));
+      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth}));
 }
 
 SMTSortRef YicesSolver::mkFXPSortImpl(unsigned Width, unsigned FracBits,

--- a/src/solvers/z3solver.cpp
+++ b/src/solvers/z3solver.cpp
@@ -174,7 +174,7 @@ SMTSortRef Z3Solver::mkBVFPSortImpl(const unsigned ExpWidth,
                                     const unsigned SigWidth) {
   return makeSortRef<Z3Sort>(Z3Sort(
       SMTSortKind::BVFP, &Context, Context.bv_sort(ExpWidth + SigWidth + 1),
-      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth + 1}));
+      SMTSort::FPSortData{ExpWidth + SigWidth + 1, ExpWidth, SigWidth}));
 }
 
 SMTSortRef Z3Solver::mkFXPSortImpl(unsigned Width, unsigned FracBits,

--- a/src/theories/camadafp.cpp
+++ b/src/theories/camadafp.cpp
@@ -111,12 +111,12 @@ static inline SMTExprRef extractSgn(SMTSolver &S, const SMTExprRef &Exp) {
 
 static inline SMTExprRef extractExp(SMTSolver &S, const SMTExprRef &Exp) {
   unsigned int expTop = Exp->getWidth() - 2;
-  unsigned int expBot = Exp->Sort->getFPSignificandWidth() - 2;
+  unsigned int expBot = Exp->Sort->getFPSignificandBits() - 2;
   return S.mkBVExtract(expTop, expBot + 1, Exp);
 }
 
 static inline SMTExprRef extractSig(SMTSolver &S, const SMTExprRef &Exp) {
-  return S.mkBVExtract(Exp->Sort->getFPSignificandWidth() - 2, 0, Exp);
+  return S.mkBVExtract(Exp->Sort->getFPSignificandBits() - 2, 0, Exp);
 }
 
 static inline SMTExprRef extractExpSig(SMTSolver &S, const SMTExprRef &Exp) {
@@ -402,7 +402,7 @@ mkRoundingDecision(SMTSolver &S, const SMTExprRef &R, const SMTExprRef &RMNeg,
 static inline void unpack(SMTSolver &S, const SMTExprRef &Src, SMTExprRef &Sgn,
                           SMTExprRef &Sig, SMTExprRef &Exp, SMTExprRef &LZ,
                           bool Normalize) {
-  unsigned SWidth = Src->Sort->getFPSignificandWidth();
+  unsigned SWidth = Src->Sort->getFPSignificandBits();
   unsigned EWidth = Src->Sort->getFPExponentWidth();
 
   // Extract parts
@@ -511,7 +511,7 @@ SMTExprRef SMTSolverImpl::mkFPNegImpl(const SMTExprRef &Exp,
 
 SMTExprRef SMTSolverImpl::mkFPIsInfiniteImpl(const SMTExprRef &Exp) {
   unsigned eWidth = Exp->Sort->getFPExponentWidth();
-  unsigned sWidth = Exp->Sort->getFPSignificandWidth();
+  unsigned sWidth = Exp->Sort->getFPSignificandBits();
   SMTExprRef pInf = mkFPInf(*this, eWidth, sWidth, false);
   SMTExprRef nInf = mkFPInf(*this, eWidth, sWidth, true);
   SMTExprRef result = mkOr(mkEqual(Exp, pInf), mkEqual(Exp, nInf));
@@ -581,7 +581,7 @@ SMTExprRef SMTSolverImpl::mkFPMulImpl(const SMTExprRef &LHS,
   assert(LHS->Sort->getFPExponentWidth() == RHS->Sort->getFPExponentWidth());
 
   std::size_t ebits = LHS->Sort->getFPExponentWidth();
-  std::size_t sbits = LHS->Sort->getFPSignificandWidth();
+  std::size_t sbits = LHS->Sort->getFPSignificandBits();
 
   SMTExprRef nan = mkFPNaN(*this, static_cast<unsigned>(ebits),
                            static_cast<unsigned>(sbits), false);
@@ -690,7 +690,7 @@ SMTExprRef SMTSolverImpl::mkFPDivImpl(const SMTExprRef &LHS,
   assert(LHS->Sort->getFPExponentWidth() == RHS->Sort->getFPExponentWidth());
 
   unsigned ebits = LHS->Sort->getFPExponentWidth();
-  unsigned sbits = LHS->Sort->getFPSignificandWidth();
+  unsigned sbits = LHS->Sort->getFPSignificandBits();
 
   SMTExprRef nan = mkFPNaN(*this, ebits, sbits, false);
   SMTExprRef nzero = mkFPZero(*this, ebits, sbits, true);
@@ -811,7 +811,7 @@ SMTExprRef SMTSolverImpl::mkFPDivImpl(const SMTExprRef &LHS,
 SMTExprRef SMTSolverImpl::mkFPRemImpl(const SMTExprRef &LHS,
                                       const SMTExprRef &RHS) {
   unsigned ebits = LHS->Sort->getFPExponentWidth();
-  unsigned sbits = LHS->Sort->getFPSignificandWidth();
+  unsigned sbits = LHS->Sort->getFPSignificandBits();
 
   SMTExprRef nan = mkFPNaN(*this, ebits, sbits, false);
   SMTExprRef nzero = mkFPZero(*this, ebits, sbits, true);
@@ -1077,7 +1077,7 @@ SMTExprRef SMTSolverImpl::mkFPAddImpl(const SMTExprRef &LHS,
   assert(LHS->Sort->getFPExponentWidth() == RHS->Sort->getFPExponentWidth());
 
   std::size_t ebits = LHS->Sort->getFPExponentWidth();
-  std::size_t sbits = LHS->Sort->getFPSignificandWidth();
+  std::size_t sbits = LHS->Sort->getFPSignificandBits();
 
   SMTExprRef nan = mkFPNaN(*this, static_cast<unsigned>(ebits),
                            static_cast<unsigned>(sbits), false);
@@ -1173,7 +1173,7 @@ SMTExprRef SMTSolverImpl::mkFPSubImpl(const SMTExprRef &LHS,
 SMTExprRef SMTSolverImpl::mkFPSqrtImpl(const SMTExprRef &Exp,
                                        const SMTExprRef &RM) {
   unsigned ebits = Exp->Sort->getFPExponentWidth();
-  unsigned sbits = Exp->Sort->getFPSignificandWidth();
+  unsigned sbits = Exp->Sort->getFPSignificandBits();
 
   SMTExprRef nan = mkFPNaN(*this, ebits, sbits, false);
 
@@ -1279,7 +1279,7 @@ SMTExprRef SMTSolverImpl::mkFPFMAImpl(const SMTExprRef &X, const SMTExprRef &Y,
   assert(X->Sort->getFPExponentWidth() == Y->Sort->getFPExponentWidth());
 
   unsigned ebits = X->Sort->getFPExponentWidth();
-  unsigned sbits = X->Sort->getFPSignificandWidth();
+  unsigned sbits = X->Sort->getFPSignificandBits();
 
   SMTExprRef nan = mkFPNaN(*this, ebits, sbits, false);
   SMTExprRef nzero = mkFPZero(*this, ebits, sbits, true);
@@ -1620,9 +1620,9 @@ SMTExprRef SMTSolverImpl::mkFPEqualImpl(const SMTExprRef &LHS,
 SMTExprRef SMTSolverImpl::mkFPToFPImpl(const SMTExprRef &From,
                                        const SMTSortRef &To,
                                        const SMTExprRef &R) {
-  unsigned from_sbits = From->Sort->getFPSignificandWidth();
+  unsigned from_sbits = From->Sort->getFPSignificandBits();
   unsigned from_ebits = From->Sort->getFPExponentWidth();
-  unsigned to_sbits = To->getFPSignificandWidth();
+  unsigned to_sbits = To->getFPSignificandBits();
   unsigned to_ebits = To->getFPExponentWidth();
 
   if (from_sbits == to_sbits && from_ebits == to_ebits)
@@ -1765,7 +1765,7 @@ SMTExprRef SMTSolverImpl::mkSBVToFPImpl(const SMTExprRef &From,
   //    mode r.
 
   unsigned ebits = To->getFPExponentWidth();
-  unsigned sbits = To->getFPSignificandWidth();
+  unsigned sbits = To->getFPSignificandBits();
   unsigned bv_sz = From->getWidth();
 
   SMTExprRef bv1_1 = mkBVOne1(*this);
@@ -1869,7 +1869,7 @@ SMTExprRef SMTSolverImpl::mkUBVToFPImpl(const SMTExprRef &From,
   //    mode r.
 
   unsigned ebits = To->getFPExponentWidth();
-  unsigned sbits = To->getFPSignificandWidth();
+  unsigned sbits = To->getFPSignificandBits();
   unsigned bv_sz = From->getWidth();
 
   SMTExprRef bv0_1 = mkBVZero1(*this);
@@ -1959,7 +1959,7 @@ SMTExprRef SMTSolverImpl::mkToBV(const SMTExprRef &Exp, bool isSigned,
   SMTSortRef xs = Exp->Sort;
 
   unsigned ebits = xs->getFPExponentWidth();
-  unsigned sbits = xs->getFPSignificandWidth();
+  unsigned sbits = xs->getFPSignificandBits();
   unsigned bv_sz = ToWidth;
 
   SMTExprRef bv0 = mkBVZero1(*this);
@@ -2089,7 +2089,7 @@ SMTExprRef SMTSolverImpl::mkFPToUBVImpl(const SMTExprRef &From,
 SMTExprRef SMTSolverImpl::mkFPToIntegralImpl(const SMTExprRef &From,
                                              const SMTExprRef &R) {
   unsigned ebits = From->Sort->getFPExponentWidth();
-  unsigned sbits = From->Sort->getFPSignificandWidth();
+  unsigned sbits = From->Sort->getFPSignificandBits();
   SMTExprRef rm_is_rta = mkIsRM(*this, R, RM::ROUND_TO_AWAY);
   SMTExprRef rm_is_rte = mkIsRM(*this, R, RM::ROUND_TO_EVEN);
   SMTExprRef rm_is_rtp = mkIsRM(*this, R, RM::ROUND_TO_PLUS_INF);
@@ -2545,10 +2545,8 @@ SMTResult<uint64_t> SMTSolverImpl::getBVUnsignedImpl(const SMTExprRef &Exp) {
 }
 
 SMTResult<float> SMTSolverImpl::getFP32Impl(const SMTExprRef &Exp) {
-  // Match on exponent width plus total width: getFPSignificandWidth()
-  // counts the hidden bit under the BV encoding but not the native one
-  // (see issue #184), while the total is 32 either way.
-  if (Exp->Sort->getFPExponentWidth() != 8 || Exp->getWidth() != 32)
+  if (Exp->Sort->getFPExponentWidth() != 8 ||
+      Exp->Sort->getFPSignificandWidth() != 23)
     return SMTError{SMTErrorCode::InvalidUsage, Exp->getBackendKind(),
                     "Expected an IEEE-754 binary32 expression; use "
                     "getFPInBin for other formats"};
@@ -2560,8 +2558,8 @@ SMTResult<float> SMTSolverImpl::getFP32Impl(const SMTExprRef &Exp) {
 }
 
 SMTResult<double> SMTSolverImpl::getFP64Impl(const SMTExprRef &Exp) {
-  // See getFP32Impl: the total width is the encoding-independent check.
-  if (Exp->Sort->getFPExponentWidth() != 11 || Exp->getWidth() != 64)
+  if (Exp->Sort->getFPExponentWidth() != 11 ||
+      Exp->Sort->getFPSignificandWidth() != 52)
     return SMTError{SMTErrorCode::InvalidUsage, Exp->getBackendKind(),
                     "Expected an IEEE-754 binary64 expression; use "
                     "getFPInBin for other formats"};


### PR DESCRIPTION
`getFPSignificandWidth()` answered differently depending on which encoding built the sort, for identical `mkFPSort` arguments:

```
mkFPSort(e,s)     Native sig   BV sig   total (N/BV)
mkFPSort( 8,23)   23           24       32/32
mkFPSort(11,52)   52           53       64/64
mkFPSort( 5,10)   10           11       16/16
```

A caller could not use the accessor without knowing which `FPEncoding` produced the sort — the detail the wrapper exists to hide.

### Where it came from

Both consumers were internally consistent; the ambiguity was in the public name serving two conventions:

- The FP-over-BV bit-blast wants the significand **including** the hidden bit (`sbits` in the literature). `extractSig` takes bits `[SigWidth - 2 : 0]`, which is only the stored significand if `SigWidth` counts the hidden bit.
- Native backends want it **excluded**, which is why 13 of their call sites read `getFPSignificandWidth() + 1` before handing widths to `fpa_sort`, `mkFloatingPointSort`, and friends.

So the seven `BVFP` sort constructions stored `SigWidth + 1` while every native construction stored `SigWidth`.

### The fix

Settle on the **stored** count, making the accessor the inverse of the constructor: `mkFPSort(11, 52)` reports 52 everywhere, matching IEEE-754's "stored significand" wording. Adds `getFPSignificandBits()` (= stored + 1) for the encoding's own use, so the bit-blast keeps the number it actually needs under a name that says so.

- Seven `BVFP` constructions drop their `+ 1`.
- The 17 uses in `camadafp.cpp` move to `getFPSignificandBits()` — all of them meant `sbits`.
- The 19 backend uses are unchanged: the 13 with an explicit `+ 1` are now correct by construction, and the six without (MathSAT's `msat_make_fp_cast` and friends, which take "mantissa width" meaning stored bits, plus one in `smtlibsolver.cpp` already commented "excludes hidden bit") already wanted the stored count.

It also lets the `getFP32`/`getFP64` guards from #185 say what they mean. They matched on *total* width because no significand check could be written that held under both encodings; they now read `getFPSignificandWidth() != 23` and `!= 52`.

### Test

`fp_sort_width_accessors` checks both accessors across binary32, binary64, binary16 and bfloat16 under the BV encoding, then asserts native/BV parity for binary32 and binary64. Native parity is limited to those two deliberately: the wider formats are gated per backend (#186), and my first version asserted bfloat16 natively and aborted on Bitwuzla — the restriction documented in #187.

Verified failing before the fix (`24 == 23`) and passing after. Full suite 246/246, clean build, no warnings.

Unblocks #188, which cannot define `FPValue`'s width field until this convention is fixed.

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp6BKyd2TaLMghESwZNaKQ