### PR TITLE
Report why a check returned UNKNOWN

### DIFF
--- a/regression/simple.test.h
+++ b/regression/simple.test.h
@@ -81,6 +81,22 @@ inline void implies_true_implies_false(const camada::SMTSolverRef &solver) {
   REQUIRE(solver->check() == camada::CheckResult::UNSAT);
 }
 
+inline void unknown_reason_semantics(const camada::SMTSolverRef &solver) {
+  // Nothing has answered UNKNOWN yet.
+  REQUIRE(solver->reasonUnknown() == camada::UnknownReason::NotApplicable);
+
+  auto x = solver->mkSymbol("ur_x", solver->mkBVSort(8));
+  solver->addConstraint(solver->mkEqual(x, solver->mkBVFromDec(3, 8)));
+  REQUIRE(solver->check() == camada::CheckResult::SAT);
+  // A decided check clears any earlier reason rather than leaving it to
+  // be misread as belonging to this one.
+  REQUIRE(solver->reasonUnknown() == camada::UnknownReason::NotApplicable);
+
+  solver->addConstraint(solver->mkEqual(x, solver->mkBVFromDec(4, 8)));
+  REQUIRE(solver->check() == camada::CheckResult::UNSAT);
+  REQUIRE(solver->reasonUnknown() == camada::UnknownReason::NotApplicable);
+}
+
 inline void solver_timeout_semantics(const camada::SMTSolverRef &solver) {
   if (!solver->setTimeout(150)) {
     // Backends without enforceable limits must report so and stay usable.
@@ -114,6 +130,8 @@ inline void solver_timeout_semantics(const camada::SMTSolverRef &solver) {
   };
   assertSemiprimeFactoring();
   REQUIRE(solver->check() == camada::CheckResult::UNKNOWN);
+  // The UNKNOWN is the limit firing, not the solver giving up.
+  REQUIRE(solver->reasonUnknown() == camada::UnknownReason::Timeout);
 
   // The limit applies to assumption-based checks too. Rebuild the problem
   // from scratch first: an incremental solver resumes the interrupted
@@ -123,6 +141,7 @@ inline void solver_timeout_semantics(const camada::SMTSolverRef &solver) {
   assertSemiprimeFactoring();
   auto t = solver->mkSymbol("t", solver->mkBoolSort());
   REQUIRE(solver->checkSatAssuming({t}) == camada::CheckResult::UNKNOWN);
+  REQUIRE(solver->reasonUnknown() == camada::UnknownReason::Timeout);
 
   // Clearing the limit must work from the just-timed-out state.
   REQUIRE(solver->setTimeout(0));

--- a/regression/smtlib.test.cpp
+++ b/regression/smtlib.test.cpp
@@ -87,7 +87,11 @@ TEST_CASE("SMTLIB write-only emits a minimal script", "[SMTLIB]") {
     auto X = Solver->mkSymbol("x", BV8);
     auto Five = Solver->mkBVFromBin("00000101", BV8);
     Solver->addConstraint(Solver->mkEqual(X, Five));
-    Solver->check();
+    // Write-only mode emits the script but nothing solves it, so the
+    // UNKNOWN is the absence of an answer rather than a solver declining
+    // to give one.
+    REQUIRE(Solver->check() == camada::CheckResult::UNKNOWN);
+    REQUIRE(Solver->reasonUnknown() == camada::UnknownReason::ProtocolError);
   } // Solver dtor flushes via FileEmitter dtor.
 
   const std::string Expected = "(set-option :print-success false)\n"

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -141,6 +141,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDARGTEST(fp_conformance_semantics, NativeFP);
   RESETANDARGTEST(fp_conformance_semantics, BVFP);
   RESETANDTEST(bv_overflow_semantics);
+  RESETANDTEST(unknown_reason_semantics);
   RESETANDTEST(solver_timeout_semantics);
 
   RESETANDTEST(check_sat_assuming_semantics);

--- a/src/camada.h
+++ b/src/camada.h
@@ -1034,6 +1034,20 @@ public:
   /// Check if the constraints are satisfiable
   virtual CheckResult check() = 0;
 
+  /// Why the last check returned CheckResult::UNKNOWN.
+  ///
+  /// Valid right after check() or checkSatAssuming() answered UNKNOWN;
+  /// any other time it reports UnknownReason::NotApplicable. The
+  /// distinction matters because UNKNOWN covers both "no answer for this
+  /// formula" and "the query never ran" -- a consumer that retries with a
+  /// longer limit wants Timeout, and one that should stop wants
+  /// BackendError or ProtocolError.
+  ///
+  /// Backends differ in how much they can tell apart: a timeout Camada
+  /// imposed itself is always known, while a solver that reports only
+  /// "unknown" is reported as Incomplete.
+  virtual UnknownReason reasonUnknown() const = 0;
+
   /// Set a wall-clock time limit, in milliseconds, applied to each
   /// subsequent check() or checkSatAssuming() individually; 0 removes the
   /// limit. A check that hits the limit returns CheckResult::UNKNOWN and

--- a/src/camadatypes.h
+++ b/src/camadatypes.h
@@ -177,6 +177,27 @@ enum class RM : std::uint8_t {
 
 enum class CheckResult : std::uint8_t { SAT, UNSAT, UNKNOWN };
 
+/// Why a check returned CheckResult::UNKNOWN. Query through
+/// SMTSolver::reasonUnknown(); meaningful only for the check that just
+/// answered UNKNOWN.
+enum class UnknownReason : std::uint8_t {
+  /// The check hit the limit set by setTimeout().
+  Timeout,
+  /// The solver terminated the search without deciding: an incomplete
+  /// fragment (quantifiers, non-linear arithmetic), a resource limit of
+  /// its own, or a deliberate give-up.
+  Incomplete,
+  /// The backend reported an error rather than a result. The formula's
+  /// satisfiability is unknown because the query did not run.
+  BackendError,
+  /// The SMT-LIB child answered with something other than a result --
+  /// an `(error ...)` reply, a malformed line, or end-of-stream because
+  /// it died. Also reported in write-only mode, where no solver ran.
+  ProtocolError,
+  /// No check has answered UNKNOWN yet, or the state has moved on.
+  NotApplicable,
+};
+
 /// Capabilities a backend may or may not implement, queryable through
 /// SMTSolver::supports() instead of discovering them through aborts or
 /// UnsupportedOperation errors.

--- a/src/core/camadaimpl.cpp
+++ b/src/core/camadaimpl.cpp
@@ -2208,7 +2208,22 @@ SMTExprRef SMTSolverImpl::mkIEEEFPToBV(const SMTExprRef &Exp) {
 
 CheckResult SMTSolverImpl::check() {
   invalidateUnsatAssumptions();
-  return checkImpl();
+  LastUnknownReason = UnknownReason::NotApplicable;
+  return finishCheck(checkImpl());
+}
+
+CheckResult SMTSolverImpl::finishCheck(CheckResult Result) {
+  if (Result != CheckResult::UNKNOWN) {
+    LastUnknownReason = UnknownReason::NotApplicable;
+    return Result;
+  }
+  // A backend that recognised the cause already recorded it. Otherwise
+  // attribute the UNKNOWN to the limit Camada set, if there was one:
+  // several backends report a deadline stop as a bare "unknown".
+  if (LastUnknownReason == UnknownReason::NotApplicable)
+    LastUnknownReason =
+        TimeoutMs ? UnknownReason::Timeout : UnknownReason::Incomplete;
+  return Result;
 }
 
 CheckResult
@@ -2219,8 +2234,9 @@ SMTSolverImpl::checkSatAssuming(const std::vector<SMTExprRef> &Assumptions) {
   // addConstraint/push/pop (the default fallback and the activation-literal
   // lowerings do), all of which invalidate the unsat-assumption state, so
   // record it only after the check completes.
-  const CheckResult Result =
-      Assumptions.empty() ? checkImpl() : checkSatAssumingImpl(Assumptions);
+  LastUnknownReason = UnknownReason::NotApplicable;
+  const CheckResult Result = finishCheck(
+      Assumptions.empty() ? checkImpl() : checkSatAssumingImpl(Assumptions));
   UnsatAssumptionsValid = Result == CheckResult::UNSAT;
   LastAssumptions =
       UnsatAssumptionsValid ? Assumptions : std::vector<SMTExprRef>{};

--- a/src/core/camadaimpl.h
+++ b/src/core/camadaimpl.h
@@ -391,6 +391,10 @@ protected:
   /// read the current value.
   uint64_t TimeoutMs = 0;
 
+  /// Set by the backend's checkImpl when it answers UNKNOWN; cleared by
+  /// any check that decides, so a stale reason cannot be read back.
+  UnknownReason LastUnknownReason = UnknownReason::NotApplicable;
+
   // --- Assumption-based solving ---
   // The assumptions of the most recent checkSatAssuming() call, kept so
   // backends can map the solver's native unsat core back to the caller's
@@ -781,6 +785,22 @@ public:
                           const SMTSortRef &To) override final;
   SMTExprRef mkIEEEFPToBV(const SMTExprRef &Exp) override final;
   CheckResult check() override final;
+
+  UnknownReason reasonUnknown() const override final {
+    return LastUnknownReason;
+  }
+
+protected:
+  /// Called by a backend's checkImpl when it can tell why the search did
+  /// not decide. Leaving it unset means Camada attributes the UNKNOWN to
+  /// its own timeout, if one was configured, and to Incomplete otherwise.
+  void noteUnknownReason(UnknownReason Reason) { LastUnknownReason = Reason; }
+
+private:
+  /// Settles LastUnknownReason once the backend has answered.
+  CheckResult finishCheck(CheckResult Result);
+
+public:
   bool setTimeout(uint64_t Milliseconds) override final;
 
   CheckResult

--- a/src/solvers/smtlibsolver.cpp
+++ b/src/solvers/smtlibsolver.cpp
@@ -856,10 +856,15 @@ CheckResult SMTLIBSolver::runOneShotCommand() {
   // wrapper tearing the job down) cannot be trusted: a truncated run must
   // not become a verification verdict. Non-zero *exit codes* stay
   // accepted — SAT-competition-style solvers exit 10/20.
-  if (Verdict && WIFSIGNALED(Status))
+  if (Verdict && WIFSIGNALED(Status)) {
+    noteUnknownReason(UnknownReason::ProtocolError);
     return CheckResult::UNKNOWN;
-  if (!Verdict)
+  }
+  if (!Verdict) {
+    // The run produced no line we could read as a verdict.
+    noteUnknownReason(UnknownReason::ProtocolError);
     return CheckResult::UNKNOWN;
+  }
   return *Verdict;
 }
 
@@ -2505,12 +2510,22 @@ CheckResult SMTLIBSolver::emitCheckCommand(const std::string &Cmd) {
     Proc->emitRaw(Cmd);
     Proc->flush();
     const std::string Resp = Proc->readResponse();
-    return Resp == "sat"     ? CheckResult::SAT
-           : Resp == "unsat" ? CheckResult::UNSAT
-                             : CheckResult::UNKNOWN;
+    if (Resp == "sat")
+      return CheckResult::SAT;
+    if (Resp == "unsat")
+      return CheckResult::UNSAT;
+    // Only a literal `unknown` is the solver declining to decide.
+    // Anything else means the exchange broke: an `(error ...)` reply, a
+    // line we cannot parse, or an empty string for end-of-stream because
+    // the child is gone.
+    if (Resp != "unknown")
+      noteUnknownReason(UnknownReason::ProtocolError);
+    return CheckResult::UNKNOWN;
   }
+  // Write-only mode: the script was emitted but nothing solved it.
   if (File)
     File->flush();
+  noteUnknownReason(UnknownReason::ProtocolError);
   return CheckResult::UNKNOWN;
 }
 

--- a/src/solvers/stpsolver.cpp
+++ b/src/solvers/stpsolver.cpp
@@ -639,7 +639,9 @@ CheckResult STPSolver::checkImpl() {
   if (res == 1)
     return CheckResult::UNSAT;
 
-  // 2 is an error, 3 a timeout.
+  // 2 is an error, 3 the search abandoned when the budget expired.
+  noteUnknownReason(res == 2 ? UnknownReason::BackendError
+                             : UnknownReason::Timeout);
   return CheckResult::UNKNOWN;
 }
 

--- a/src/solvers/yicessolver.cpp
+++ b/src/solvers/yicessolver.cpp
@@ -1058,6 +1058,12 @@ CheckResult YicesSolver::checkImpl() {
   if (res == YICES_STATUS_UNSAT)
     return CheckResult::UNSAT;
 
+  // The timeout is delivered by interrupting the search (see
+  // yicesAlarmHandler), so INTERRUPTED means the deadline fired.
+  if (res == YICES_STATUS_INTERRUPTED)
+    noteUnknownReason(UnknownReason::Timeout);
+  else if (res == YICES_STATUS_ERROR)
+    noteUnknownReason(UnknownReason::BackendError);
   return CheckResult::UNKNOWN;
 }
 

--- a/src/solvers/z3solver.cpp
+++ b/src/solvers/z3solver.cpp
@@ -1117,6 +1117,15 @@ CheckResult Z3Solver::checkImpl() {
   if (res == z3::check_result::unsat)
     return CheckResult::UNSAT;
 
+  // Z3 explains itself through reason_unknown(); it answers "timeout"
+  // when a limit stopped the search and something else (often nothing at
+  // all) when the search was genuinely incomplete. Only the timeout
+  // string is stable enough to key on -- the common layer already infers
+  // a configured timeout, so anything else stays Incomplete.
+  if (Solver.reason_unknown() == "timeout")
+    noteUnknownReason(UnknownReason::Timeout);
+  else
+    noteUnknownReason(UnknownReason::Incomplete);
   return CheckResult::UNKNOWN;
 }
 


### PR DESCRIPTION
Every backend folded three different outcomes into `CheckResult::UNKNOWN`: the configured limit firing, the solver declining to decide, and the query never running at all. Each backend knew the difference and discarded it — STP's comment named the codes right above the line that threw them away:

```cpp
// 2 is an error, 3 a timeout.
return CheckResult::UNKNOWN;
```

The distinction is what a consumer needs to act on: a timeout means retry with a longer budget, an incomplete search means the fragment is out of reach, and a backend or protocol failure means stop and fix something.

### Shape

`UnknownReason { Timeout, Incomplete, BackendError, ProtocolError, NotApplicable }` plus `SMTSolver::reasonUnknown()`, valid right after a check answered UNKNOWN. Non-breaking — `CheckResult` is untouched, and it follows the `produceUnsatAssumptions()`/`getUnsatAssumptions()` pattern already in the API.

The common layer does the bookkeeping: it clears the reason at the start of every check (so a stale one can never be misread as belonging to the current query) and attributes an otherwise-unexplained UNKNOWN to the limit Camada set, if there was one. Backends therefore only have to report what they can genuinely distinguish:

| Backend | What it can tell apart |
|---|---|
| STP | return code 2 (error) vs 3 (budget expired) |
| Yices | `YICES_STATUS_INTERRUPTED` (how its timeout fires) vs `YICES_STATUS_ERROR` |
| Z3 | `reason_unknown() == "timeout"`; verified it answers exactly that string on a limit and empty on a genuinely incomplete search |
| SMT-LIB | a literal `unknown` vs an `(error ...)` reply, an unparseable line, an empty read (dead child), a signal-killed one-shot solver, and write-only mode |
| Bitwuzla, cvc5, MathSAT | no distinction exposed; the common layer's timeout inference covers them |

Write-only mode is worth calling out: it reported UNKNOWN because *no solver ran*, which is now `ProtocolError` rather than looking like a solver that gave up.

### Tests

`solver_timeout_semantics` already produced a real timeout on every backend that enforces limits, so it now asserts `reasonUnknown() == Timeout` on both the `check()` and `checkSatAssuming()` paths. `unknown_reason_semantics` pins the transitions — `NotApplicable` before any check, and cleared again after a check decides SAT or UNSAT. The write-only SMT-LIB test asserts `ProtocolError`.

Suite 246/246, clean build, no warnings.

One note in case it saves someone the same detour: while spot-checking this by hand I got a wrong reading from `printf("%d %s", (int)s->check(), name(s->reasonUnknown()))`. Argument evaluation order is unspecified, so `reasonUnknown()` can be evaluated before `check()` runs. Sequence the two calls.

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp6BKyd2TaLMghESwZNaKQ