### PR TITLE
Document that FPNegBehavior is only observable under the BV encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ Camada is based on the backend written for [ESBMC](https://github.com/esbmc/esbm
 - `mkFPNeg` now accepts `FPNegBehavior`.
 - The default, `FPNegBehavior::FlipSignBit`, preserves the full IEEE payload and only toggles the sign bit, including on `NaN`s.
 - `FPNegBehavior::PreserveNaNPayload` follows the SMT floating-point standard and leaves `NaN`s unchanged.
-- `FlipSignBit` is fully honored under BV encoding and via the SMTLIB pipeline. On native FP backends (Bitwuzla, CVC5, Z3) it is best-effort: these solvers treat all `NaN`s as a single equivalence class, so when the operand is a `NaN` the resulting `NaN`'s bit pattern is not guaranteed to match a literal sign-bit flip of the input bits.
+- The distinction is only observable under `FPEncoding::BV`, where an FP value is its bit pattern. On a native FP sort both behaviors give that solver's canonical `NaN`, losing the operand's payload and sign; use `FPEncoding::BV` when the `NaN` bit pattern matters.
 
 Camada's own FP-over-BV encoding also follows IEEE-754's recommended `NaN` handling rather than SMT-LIB's, which matters when a formula reads the bits of a `NaN` result:
 - An operation with a `NaN` operand returns *that operand's* payload, with the significand's leading bit forced to 1: propagated per IEEE-754 6.2, quieted per 6.2.3. With two `NaN` operands the first one wins. This is what every hardware FPU does; SMT-LIB has a single abstract `NaN` and says nothing about payloads.

--- a/regression/fp.test.h
+++ b/regression/fp.test.h
@@ -51,6 +51,46 @@ inline void fp_native_bv_predicate_parity(const camada::SMTSolverRef &solver) {
   });
 }
 
+// The FPNegBehavior distinction is observable under the BV encoding and
+// not on a native FP sort, where both modes yield the backend's canonical
+// NaN. fp_neg_nan_native_bv_parity below compares with FP equality, under
+// which every NaN is equal to every other, so it cannot see this; the
+// comparison here is on IEEE bits.
+inline void fp_neg_nan_payload_bits(const camada::SMTSolverRef &solver) {
+  // A qNaN with a payload and the sign bit clear.
+  const std::string Nan = "01111111110101010101010101010101";
+  const std::string Flipped = "11111111110101010101010101010101";
+
+  const auto bits_of = [&](camada::FPEncoding Enc,
+                           camada::FPNegBehavior Behavior) {
+    solver->reset();
+    auto x = solver->mkFPFromBin(Nan, 8, Enc);
+    auto neg = solver->mkFPNeg(x, Behavior);
+    auto rb = solver->mkSymbol("neg_bits", solver->mkBVSort(32));
+    solver->addConstraint(solver->mkEqual(rb, solver->mkIEEEFPToBV(neg)));
+    REQUIRE(solver->check() == camada::CheckResult::SAT);
+    auto v = solver->getBVInBin(rb);
+    REQUIRE(v);
+    return v.value();
+  };
+
+  // Under BV the two modes differ, and each does what it says.
+  REQUIRE(bits_of(camada::FPEncoding::BV, camada::FPNegBehavior::FlipSignBit) ==
+          Flipped);
+  REQUIRE(bits_of(camada::FPEncoding::BV,
+                  camada::FPNegBehavior::PreserveNaNPayload) == Nan);
+
+  if (!solver->supports(camada::SolverFeature::NativeFloatingPoint))
+    return;
+
+  // On a native sort the two agree, which is the documented limitation:
+  // the payload is the backend's, not the operand's.
+  REQUIRE(
+      bits_of(camada::FPEncoding::Native, camada::FPNegBehavior::FlipSignBit) ==
+      bits_of(camada::FPEncoding::Native,
+              camada::FPNegBehavior::PreserveNaNPayload));
+}
+
 inline void fp_neg_nan_native_bv_parity(const camada::SMTSolverRef &solver) {
   const auto backend = solver->mkBool(true)->getBackendKind();
   if (backend != camada::SMTBackendKind::Bitwuzla &&

--- a/regression/tests.h
+++ b/regression/tests.h
@@ -199,6 +199,7 @@ inline void tests(const camada::SMTSolverRef &solver) {
   RESETANDTEST(dump_string_semantics);
   RESETANDTEST(fp_native_bv_predicate_parity);
   RESETANDTEST(fp_neg_nan_native_bv_parity);
+  RESETANDTEST(fp_neg_nan_payload_bits);
   RESETANDTEST(fp_nan_payload_propagation);
   RESETANDTEST(fp_sort_width_accessors);
   RESETANDARGTEST(rm_model_value, NativeFP);

--- a/src/camada.h
+++ b/src/camada.h
@@ -356,11 +356,16 @@ public:
   /// bit. `PreserveNaNPayload` follows the SMT floating-point standard and
   /// leaves NaNs unchanged.
   ///
-  /// `FlipSignBit` is fully honored under BV encoding and via the SMTLIB
-  /// pipeline. On native FP backends (Bitwuzla, CVC5, Z3) it is best-effort:
-  /// these solvers treat all NaNs as a single equivalence class, so when the
-  /// operand is a NaN the resulting NaN's bit pattern is not guaranteed to
-  /// match a literal sign-bit flip of the input bits.
+  /// Both behaviors are honored under FPEncoding::BV, where an FP value is
+  /// its bit pattern. On a native FP sort the two are indistinguishable: the
+  /// backends treat NaNs as one equivalence class, so a NaN operand yields
+  /// that solver's canonical NaN under either behavior, with the operand's
+  /// payload and sign lost. Measured on Bitwuzla, CVC5, MathSAT and Z3.
+  ///
+  /// Use FPEncoding::BV when the NaN bit pattern matters. Routing a native
+  /// operand through mkIEEEFPToBV does not help: that only returns exact
+  /// bits for terms whose provenance Camada tracks, so the guarantee is
+  /// lost again as soon as the result reaches a symbol or a model query.
   virtual SMTExprRef
   mkFPNeg(const SMTExprRef &Exp,
           FPNegBehavior Behavior = FPNegBehavior::FlipSignBit) = 0;

--- a/src/camadatypes.h
+++ b/src/camadatypes.h
@@ -78,18 +78,17 @@ enum class FPEncoding : bool { Native, BV };
 /// indexes).
 enum class ConstArrayLowering : std::uint8_t { Auto, Native, Lazy };
 
-/// Selects how Camada lowers `mkFPNeg` for backends whose native FP
-/// implementation diverges from the IEEE-754 sign-bit-flip semantics
-/// some users expect.
+/// Which negation semantics `mkFPNeg` encodes: the IEEE-754 sign-bit flip
+/// most users expect, or the SMT-LIB definition.
 ///
 /// - FlipSignBit: always flip the IEEE-754 sign bit, including on NaN
 ///   inputs. Matches the behavior of CPU FP units and most language
-///   runtimes. Backed by an explicit bit-blast on solvers whose native
-///   `fp.neg` preserves the NaN payload — see PR #59 for the per-
-///   backend status.
+///   runtimes.
 /// - PreserveNaNPayload: follow the SMT-LIB `fp.neg` definition, which
-///   leaves NaN payloads (including the sign bit) unchanged. Cheaper to
-///   emit on backends that natively implement this semantics.
+///   leaves NaN payloads (including the sign bit) unchanged.
+///
+/// The distinction is only observable under FPEncoding::BV. A native FP
+/// sort gives the same canonical NaN either way; see mkFPNeg.
 enum class FPNegBehavior : bool {
   FlipSignBit,
   PreserveNaNPayload,


### PR DESCRIPTION
The docs called `FlipSignBit` "best-effort" on native FP backends, saying the resulting NaN "is not guaranteed to match a literal sign-bit flip". Measuring it shows that undersells it: the parameter has **no effect at all** on a native FP sort.

Input `01111111110101010101010101010101` (binary32 qNaN with payload), expecting `11111111...` for a sign flip:

| backend | `FlipSignBit` | `PreserveNaNPayload` |
|---|---|---|
| Z3 BV | `1111111111010101...` | `0111111111010101...` |
| Z3 native | `0111111110000000...01` | same |
| CVC5 native | `0111111111000000...` | same |
| Bitwuzla native | `0111111111000000...` | same |
| MathSAT native | `1111111110000000...01` | same |

Both modes give the solver's canonical NaN, and the operand's payload and sign are lost either way. MathSAT even sets the sign bit when asked to *preserve*.

### Why not fix it instead

Worth recording, since the obvious repair looks like it works. Routing the native operand through its IEEE bits (`mkIEEEFPToBV` -> flip -> `mkBVToIEEEFP`, the way MathSAT already reaches `fp.rem` and `fp.fma`) does produce the correct payload-preserving result, and I had it working on all four backends.

It does not survive contact with real use. `mkIEEEFPToBV` returns exact bits only for terms whose provenance Camada tracks, and the header already warns that anything else "falls back to the underspecified backend operation SILENTLY". The chain holds when you read the negation result directly and breaks as soon as the value passes through a symbol or a model query, which is how consumers actually use results. That would make the parameter appear to work in small cases and fail silently in realistic ones, which is worse than an honest no-op. It also costs two conversions on every negation, including the common non-NaN case where native `fp.neg` is already correct.

A capability bit was considered and rejected: it would be constant-false on every native backend, so it carries no information. Removing the parameter was also rejected, since it works as specified under `FPEncoding::BV` and lets a caller select genuine SMT-LIB semantics.

### Changes

Documentation only, in three places that all made the same overstatement: `mkFPNeg` in `camada.h`, the `FPNegBehavior` enum in `camadatypes.h` (which claimed the flip was "backed by an explicit bit-blast on solvers whose native `fp.neg` preserves the NaN payload"), and the README bullet. Each now says the distinction is observable under `FPEncoding::BV` and points there when the NaN bit pattern matters.

### Test

`fp_neg_nan_payload_bits` pins all of it: under BV the two modes differ and each does what it claims; on a native sort they agree. It compares **IEEE bits**, which is the point. The existing `fp_neg_nan_native_bv_parity` fixture compares with `mkEqual` on FP terms, i.e. abstract FP equality under which every NaN equals every other, so it passes regardless of payload and could not see any of this.

Verified the new test fails if the documented claim is wrong: inverting one assertion produces the expected mismatch.

Suite 246/246, clean build, no warnings.

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp6BKyd2TaLMghESwZNaKQ